### PR TITLE
Define environment variables for provider attributes

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -3,16 +3,16 @@ id: 9d20c53e-7836-4ea8-88b8-a75fb7dce3a2
 management:
   docChecksum: 57b43fc5cc7955d7204213f59e8a4111
   docVersion: 2.0.0
-  speakeasyVersion: 1.287.0
-  generationVersion: 2.331.0
-  releaseVersion: 0.2.3
-  configChecksum: 95ea855704e3ee774597a2125ab2260c
+  speakeasyVersion: 1.299.4
+  generationVersion: 2.338.7
+  releaseVersion: 0.2.4
+  configChecksum: 0d4108667c33961683e0a696aa82c808
 features:
   terraform:
     additionalDependencies: 0.1.0
     additionalProperties: 0.1.2
     constsAndDefaults: 0.1.4
-    core: 3.21.0
+    core: 3.21.1
     deprecations: 2.81.1
     globalSecurity: 2.81.6
     globalServerURLs: 2.82.1
@@ -21,7 +21,7 @@ features:
     nullables: 0.0.0
     retries: 2.81.1
     typeOverrides: 2.81.1
-    unions: 2.81.13
+    unions: 2.81.14
 generatedFiles:
   - internal/sdk/mesh.go
   - internal/sdk/apiproducts.go

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,13 @@
 # Changelog
 
-# Changelog
+## 0.2.4
+> Released on 2024/05/31
+
+### Features
+* Allow users to set provider attributes via environment variables
+  * `personal_access_token` = `KONNECT_TOKEN`
+  * `system_account_access_token` = `KONNECT_SPAT`
+  * `server_url` = `KONNECT_SERVER_URL`
 
 ## 0.2.3
 > Released on 2024/05/14

--- a/README.md
+++ b/README.md
@@ -115,6 +115,14 @@ provider "konnect" {
 }
 ```
 
+You may also configure the `provider` block using environment variables:
+
+- `personal_access_token` = `KONNECT_TOKEN`
+- `system_account_access_token` = `KONNECT_SPAT`
+- `server_url` = `KONNECT_SERVER_URL`
+
+e.g. `KONNECT_TOKEN=kpat_YOUR_PAT terraform apply`
+
 ## Examples
 
 The examples directory contains sample usage for all supported resources. For a full list of supported parameters for each resource, see the [Konnect API documentation](https://docs.konghq.com/api/).

--- a/gen.yaml
+++ b/gen.yaml
@@ -18,7 +18,13 @@ terraform:
   additionalDependencies: {}
   additionalResources: []
   author: kong
-  environmentVariables: []
+  environmentVariables:
+    - env: KONNECT_TOKEN
+      providerAttribute: personal_access_token
+    - env: KONNECT_SPAT
+      providerAttribute: system_account_access_token
+    - env: KONNECT_SERVER_URL
+      providerAttribute: server_url
   imports:
     option: openapi
     paths:

--- a/gen.yaml
+++ b/gen.yaml
@@ -17,6 +17,7 @@ terraform:
   additionalDataSources: []
   additionalDependencies: {}
   additionalResources: []
+  allowUnknownFieldsInWeakUnions: false
   author: kong
   environmentVariables: []
   imports:

--- a/gen.yaml
+++ b/gen.yaml
@@ -13,18 +13,12 @@ generation:
     oAuth2ClientCredentialsEnabled: false
   baseServerURL: ""
 terraform:
-  version: 0.2.3
+  version: 0.2.4
   additionalDataSources: []
   additionalDependencies: {}
   additionalResources: []
   author: kong
-  environmentVariables:
-    - env: KONNECT_TOKEN
-      providerAttribute: personal_access_token
-    - env: KONNECT_SPAT
-      providerAttribute: system_account_access_token
-    - env: KONNECT_SERVER_URL
-      providerAttribute: server_url
+  environmentVariables: []
   imports:
     option: openapi
     paths:

--- a/internal/provider/apiproductversion_data_source_sdk.go
+++ b/internal/provider/apiproductversion_data_source_sdk.go
@@ -23,12 +23,14 @@ func (r *APIProductVersionDataSourceModel) RefreshFromSharedAPIProductVersion(re
 		}
 		r.ID = types.StringValue(resp.ID)
 		r.Name = types.StringValue(resp.Name)
+		r.Portals = []tfTypes.APIProductVersionPortal{}
 		if len(r.Portals) > len(resp.Portals) {
 			r.Portals = r.Portals[:len(resp.Portals)]
 		}
 		for portalsCount, portalsItem := range resp.Portals {
 			var portals1 tfTypes.APIProductVersionPortal
 			portals1.ApplicationRegistrationEnabled = types.BoolValue(portalsItem.ApplicationRegistrationEnabled)
+			portals1.AuthStrategies = []tfTypes.APIProductVersionAuthStrategy{}
 			for authStrategiesCount, authStrategiesItem := range portalsItem.AuthStrategies {
 				var authStrategies1 tfTypes.APIProductVersionAuthStrategy
 				authStrategies1.ID = types.StringValue(authStrategiesItem.ID)

--- a/internal/provider/apiproductversion_resource_sdk.go
+++ b/internal/provider/apiproductversion_resource_sdk.go
@@ -48,12 +48,14 @@ func (r *APIProductVersionResourceModel) RefreshFromSharedAPIProductVersion(resp
 		}
 		r.ID = types.StringValue(resp.ID)
 		r.Name = types.StringValue(resp.Name)
+		r.Portals = []tfTypes.APIProductVersionPortal{}
 		if len(r.Portals) > len(resp.Portals) {
 			r.Portals = r.Portals[:len(resp.Portals)]
 		}
 		for portalsCount, portalsItem := range resp.Portals {
 			var portals1 tfTypes.APIProductVersionPortal
 			portals1.ApplicationRegistrationEnabled = types.BoolValue(portalsItem.ApplicationRegistrationEnabled)
+			portals1.AuthStrategies = []tfTypes.APIProductVersionAuthStrategy{}
 			for authStrategiesCount, authStrategiesItem := range portalsItem.AuthStrategies {
 				var authStrategies1 tfTypes.APIProductVersionAuthStrategy
 				authStrategies1.ID = types.StringValue(authStrategiesItem.ID)

--- a/internal/provider/cloudgatewayconfiguration_data_source_sdk.go
+++ b/internal/provider/cloudgatewayconfiguration_data_source_sdk.go
@@ -20,6 +20,7 @@ func (r *CloudGatewayConfigurationDataSourceModel) RefreshFromSharedConfiguratio
 		r.ControlPlaneGeo = types.StringValue(string(resp.ControlPlaneGeo))
 		r.ControlPlaneID = types.StringValue(resp.ControlPlaneID)
 		r.CreatedAt = types.StringValue(resp.CreatedAt.Format(time.RFC3339Nano))
+		r.DataplaneGroupConfig = []tfTypes.ConfigurationDataPlaneGroupConfig{}
 		if len(r.DataplaneGroupConfig) > len(resp.DataplaneGroupConfig) {
 			r.DataplaneGroupConfig = r.DataplaneGroupConfig[:len(resp.DataplaneGroupConfig)]
 		}
@@ -49,6 +50,7 @@ func (r *CloudGatewayConfigurationDataSourceModel) RefreshFromSharedConfiguratio
 				r.DataplaneGroupConfig[dataplaneGroupConfigCount].Region = dataplaneGroupConfig1.Region
 			}
 		}
+		r.DataplaneGroups = []tfTypes.ConfigurationDataPlaneGroup{}
 		if len(r.DataplaneGroups) > len(resp.DataplaneGroups) {
 			r.DataplaneGroups = r.DataplaneGroups[:len(resp.DataplaneGroups)]
 		}

--- a/internal/provider/cloudgatewayconfiguration_resource_sdk.go
+++ b/internal/provider/cloudgatewayconfiguration_resource_sdk.go
@@ -90,6 +90,7 @@ func (r *CloudGatewayConfigurationResourceModel) RefreshFromSharedConfigurationM
 		r.ControlPlaneGeo = types.StringValue(string(resp.ControlPlaneGeo))
 		r.ControlPlaneID = types.StringValue(resp.ControlPlaneID)
 		r.CreatedAt = types.StringValue(resp.CreatedAt.Format(time.RFC3339Nano))
+		r.DataplaneGroupConfig = []tfTypes.ConfigurationDataPlaneGroupConfig{}
 		if len(r.DataplaneGroupConfig) > len(resp.DataplaneGroupConfig) {
 			r.DataplaneGroupConfig = r.DataplaneGroupConfig[:len(resp.DataplaneGroupConfig)]
 		}
@@ -119,6 +120,7 @@ func (r *CloudGatewayConfigurationResourceModel) RefreshFromSharedConfigurationM
 				r.DataplaneGroupConfig[dataplaneGroupConfigCount].Region = dataplaneGroupConfig1.Region
 			}
 		}
+		r.DataplaneGroups = []tfTypes.ConfigurationDataPlaneGroup{}
 		if len(r.DataplaneGroups) > len(resp.DataplaneGroups) {
 			r.DataplaneGroups = r.DataplaneGroups[:len(resp.DataplaneGroups)]
 		}

--- a/internal/provider/cloudgatewayprovideraccountlist_data_source_sdk.go
+++ b/internal/provider/cloudgatewayprovideraccountlist_data_source_sdk.go
@@ -12,6 +12,7 @@ import (
 
 func (r *CloudGatewayProviderAccountListDataSourceModel) RefreshFromSharedListProviderAccountsResponse(resp *shared.ListProviderAccountsResponse) {
 	if resp != nil {
+		r.Data = []tfTypes.ProviderAccount{}
 		if len(r.Data) > len(resp.Data) {
 			r.Data = r.Data[:len(resp.Data)]
 		}

--- a/internal/provider/cloudgatewaytransitgateway_data_source_sdk.go
+++ b/internal/provider/cloudgatewaytransitgateway_data_source_sdk.go
@@ -16,6 +16,7 @@ func (r *CloudGatewayTransitGatewayDataSourceModel) RefreshFromSharedTransitGate
 			r.CidrBlocks = append(r.CidrBlocks, types.StringValue(v))
 		}
 		r.CreatedAt = types.StringValue(resp.CreatedAt.Format(time.RFC3339Nano))
+		r.DNSConfig = []tfTypes.TransitGatewayDNSConfig{}
 		if len(r.DNSConfig) > len(resp.DNSConfig) {
 			r.DNSConfig = r.DNSConfig[:len(resp.DNSConfig)]
 		}

--- a/internal/provider/cloudgatewaytransitgateway_resource_sdk.go
+++ b/internal/provider/cloudgatewaytransitgateway_resource_sdk.go
@@ -63,6 +63,7 @@ func (r *CloudGatewayTransitGatewayResourceModel) RefreshFromSharedTransitGatewa
 			r.CidrBlocks = append(r.CidrBlocks, types.StringValue(v))
 		}
 		r.CreatedAt = types.StringValue(resp.CreatedAt.Format(time.RFC3339Nano))
+		r.DNSConfig = []tfTypes.TransitGatewayDNSConfig{}
 		if len(r.DNSConfig) > len(resp.DNSConfig) {
 			r.DNSConfig = r.DNSConfig[:len(resp.DNSConfig)]
 		}

--- a/internal/provider/gatewaypluginaipromptdecorator_data_source_sdk.go
+++ b/internal/provider/gatewaypluginaipromptdecorator_data_source_sdk.go
@@ -14,6 +14,7 @@ func (r *GatewayPluginAIPromptDecoratorDataSourceModel) RefreshFromSharedAIPromp
 			r.Config.Prompts = nil
 		} else {
 			r.Config.Prompts = &tfTypes.CreateAIPromptDecoratorPluginPrompts{}
+			r.Config.Prompts.Append = []tfTypes.AIPromptDecoratorPluginAppend{}
 			if len(r.Config.Prompts.Append) > len(resp.Config.Prompts.Append) {
 				r.Config.Prompts.Append = r.Config.Prompts.Append[:len(resp.Config.Prompts.Append)]
 			}
@@ -32,6 +33,7 @@ func (r *GatewayPluginAIPromptDecoratorDataSourceModel) RefreshFromSharedAIPromp
 					r.Config.Prompts.Append[appendCount].Role = append2.Role
 				}
 			}
+			r.Config.Prompts.Prepend = []tfTypes.AIPromptDecoratorPluginAppend{}
 			if len(r.Config.Prompts.Prepend) > len(resp.Config.Prompts.Prepend) {
 				r.Config.Prompts.Prepend = r.Config.Prompts.Prepend[:len(resp.Config.Prompts.Prepend)]
 			}

--- a/internal/provider/gatewaypluginaipromptdecorator_resource_sdk.go
+++ b/internal/provider/gatewaypluginaipromptdecorator_resource_sdk.go
@@ -125,6 +125,7 @@ func (r *GatewayPluginAIPromptDecoratorResourceModel) RefreshFromSharedAIPromptD
 			r.Config.Prompts = nil
 		} else {
 			r.Config.Prompts = &tfTypes.CreateAIPromptDecoratorPluginPrompts{}
+			r.Config.Prompts.Append = []tfTypes.AIPromptDecoratorPluginAppend{}
 			if len(r.Config.Prompts.Append) > len(resp.Config.Prompts.Append) {
 				r.Config.Prompts.Append = r.Config.Prompts.Append[:len(resp.Config.Prompts.Append)]
 			}
@@ -143,6 +144,7 @@ func (r *GatewayPluginAIPromptDecoratorResourceModel) RefreshFromSharedAIPromptD
 					r.Config.Prompts.Append[appendCount].Role = append2.Role
 				}
 			}
+			r.Config.Prompts.Prepend = []tfTypes.AIPromptDecoratorPluginAppend{}
 			if len(r.Config.Prompts.Prepend) > len(resp.Config.Prompts.Prepend) {
 				r.Config.Prompts.Prepend = r.Config.Prompts.Prepend[:len(resp.Config.Prompts.Prepend)]
 			}

--- a/internal/provider/gatewaypluginaiprompttemplate_data_source_sdk.go
+++ b/internal/provider/gatewaypluginaiprompttemplate_data_source_sdk.go
@@ -12,6 +12,7 @@ func (r *GatewayPluginAIPromptTemplateDataSourceModel) RefreshFromSharedAIPrompt
 	if resp != nil {
 		r.Config.AllowUntemplatedRequests = types.BoolPointerValue(resp.Config.AllowUntemplatedRequests)
 		r.Config.LogOriginalRequest = types.BoolPointerValue(resp.Config.LogOriginalRequest)
+		r.Config.Templates = []tfTypes.Templates{}
 		if len(r.Config.Templates) > len(resp.Config.Templates) {
 			r.Config.Templates = r.Config.Templates[:len(resp.Config.Templates)]
 		}

--- a/internal/provider/gatewaypluginaiprompttemplate_resource_sdk.go
+++ b/internal/provider/gatewaypluginaiprompttemplate_resource_sdk.go
@@ -111,6 +111,7 @@ func (r *GatewayPluginAIPromptTemplateResourceModel) RefreshFromSharedAIPromptTe
 	if resp != nil {
 		r.Config.AllowUntemplatedRequests = types.BoolPointerValue(resp.Config.AllowUntemplatedRequests)
 		r.Config.LogOriginalRequest = types.BoolPointerValue(resp.Config.LogOriginalRequest)
+		r.Config.Templates = []tfTypes.Templates{}
 		if len(r.Config.Templates) > len(resp.Config.Templates) {
 			r.Config.Templates = r.Config.Templates[:len(resp.Config.Templates)]
 		}

--- a/internal/provider/gatewaypluginopenidconnect_data_source_sdk.go
+++ b/internal/provider/gatewaypluginopenidconnect_data_source_sdk.go
@@ -113,6 +113,7 @@ func (r *GatewayPluginOpenidConnectDataSourceModel) RefreshFromSharedOpenidConne
 		for _, v := range resp.Config.ClientID {
 			r.Config.ClientID = append(r.Config.ClientID, types.StringValue(v))
 		}
+		r.Config.ClientJwk = []tfTypes.ClientJwk{}
 		if len(r.Config.ClientJwk) > len(resp.Config.ClientJwk) {
 			r.Config.ClientJwk = r.Config.ClientJwk[:len(resp.Config.ClientJwk)]
 		}
@@ -471,6 +472,7 @@ func (r *GatewayPluginOpenidConnectDataSourceModel) RefreshFromSharedOpenidConne
 		r.Config.SessionMemcachedPrefix = types.StringPointerValue(resp.Config.SessionMemcachedPrefix)
 		r.Config.SessionMemcachedSocket = types.StringPointerValue(resp.Config.SessionMemcachedSocket)
 		r.Config.SessionRedisClusterMaxRedirections = types.Int64PointerValue(resp.Config.SessionRedisClusterMaxRedirections)
+		r.Config.SessionRedisClusterNodes = []tfTypes.SessionRedisClusterNodes{}
 		if len(r.Config.SessionRedisClusterNodes) > len(resp.Config.SessionRedisClusterNodes) {
 			r.Config.SessionRedisClusterNodes = r.Config.SessionRedisClusterNodes[:len(resp.Config.SessionRedisClusterNodes)]
 		}

--- a/internal/provider/gatewaypluginopenidconnect_resource_sdk.go
+++ b/internal/provider/gatewaypluginopenidconnect_resource_sdk.go
@@ -1803,6 +1803,7 @@ func (r *GatewayPluginOpenidConnectResourceModel) RefreshFromSharedOpenidConnect
 		for _, v := range resp.Config.ClientID {
 			r.Config.ClientID = append(r.Config.ClientID, types.StringValue(v))
 		}
+		r.Config.ClientJwk = []tfTypes.ClientJwk{}
 		if len(r.Config.ClientJwk) > len(resp.Config.ClientJwk) {
 			r.Config.ClientJwk = r.Config.ClientJwk[:len(resp.Config.ClientJwk)]
 		}
@@ -2161,6 +2162,7 @@ func (r *GatewayPluginOpenidConnectResourceModel) RefreshFromSharedOpenidConnect
 		r.Config.SessionMemcachedPrefix = types.StringPointerValue(resp.Config.SessionMemcachedPrefix)
 		r.Config.SessionMemcachedSocket = types.StringPointerValue(resp.Config.SessionMemcachedSocket)
 		r.Config.SessionRedisClusterMaxRedirections = types.Int64PointerValue(resp.Config.SessionRedisClusterMaxRedirections)
+		r.Config.SessionRedisClusterNodes = []tfTypes.SessionRedisClusterNodes{}
 		if len(r.Config.SessionRedisClusterNodes) > len(resp.Config.SessionRedisClusterNodes) {
 			r.Config.SessionRedisClusterNodes = r.Config.SessionRedisClusterNodes[:len(resp.Config.SessionRedisClusterNodes)]
 		}

--- a/internal/provider/gatewaypluginsaml_data_source_sdk.go
+++ b/internal/provider/gatewaypluginsaml_data_source_sdk.go
@@ -73,6 +73,7 @@ func (r *GatewayPluginSamlDataSourceModel) RefreshFromSharedSamlPlugin(resp *sha
 		r.Config.SessionMemcachedPrefix = types.StringPointerValue(resp.Config.SessionMemcachedPrefix)
 		r.Config.SessionMemcachedSocket = types.StringPointerValue(resp.Config.SessionMemcachedSocket)
 		r.Config.SessionRedisClusterMaxRedirections = types.Int64PointerValue(resp.Config.SessionRedisClusterMaxRedirections)
+		r.Config.SessionRedisClusterNodes = []tfTypes.SessionRedisClusterNodes{}
 		if len(r.Config.SessionRedisClusterNodes) > len(resp.Config.SessionRedisClusterNodes) {
 			r.Config.SessionRedisClusterNodes = r.Config.SessionRedisClusterNodes[:len(resp.Config.SessionRedisClusterNodes)]
 		}

--- a/internal/provider/gatewaypluginsaml_resource_sdk.go
+++ b/internal/provider/gatewaypluginsaml_resource_sdk.go
@@ -525,6 +525,7 @@ func (r *GatewayPluginSamlResourceModel) RefreshFromSharedSamlPlugin(resp *share
 		r.Config.SessionMemcachedPrefix = types.StringPointerValue(resp.Config.SessionMemcachedPrefix)
 		r.Config.SessionMemcachedSocket = types.StringPointerValue(resp.Config.SessionMemcachedSocket)
 		r.Config.SessionRedisClusterMaxRedirections = types.Int64PointerValue(resp.Config.SessionRedisClusterMaxRedirections)
+		r.Config.SessionRedisClusterNodes = []tfTypes.SessionRedisClusterNodes{}
 		if len(r.Config.SessionRedisClusterNodes) > len(resp.Config.SessionRedisClusterNodes) {
 			r.Config.SessionRedisClusterNodes = r.Config.SessionRedisClusterNodes[:len(resp.Config.SessionRedisClusterNodes)]
 		}

--- a/internal/provider/gatewayroute_data_source_sdk.go
+++ b/internal/provider/gatewayroute_data_source_sdk.go
@@ -12,6 +12,7 @@ import (
 func (r *GatewayRouteDataSourceModel) RefreshFromSharedRoute(resp *shared.Route) {
 	if resp != nil {
 		r.CreatedAt = types.Int64PointerValue(resp.CreatedAt)
+		r.Destinations = []tfTypes.SessionRedisClusterNodes{}
 		if len(r.Destinations) > len(resp.Destinations) {
 			r.Destinations = r.Destinations[:len(resp.Destinations)]
 		}
@@ -75,6 +76,7 @@ func (r *GatewayRouteDataSourceModel) RefreshFromSharedRoute(resp *shared.Route)
 		for _, v := range resp.Snis {
 			r.Snis = append(r.Snis, types.StringValue(v))
 		}
+		r.Sources = []tfTypes.SessionRedisClusterNodes{}
 		if len(r.Sources) > len(resp.Sources) {
 			r.Sources = r.Sources[:len(resp.Sources)]
 		}

--- a/internal/provider/gatewayroute_resource_sdk.go
+++ b/internal/provider/gatewayroute_resource_sdk.go
@@ -164,6 +164,7 @@ func (r *GatewayRouteResourceModel) ToSharedCreateRoute() *shared.CreateRoute {
 func (r *GatewayRouteResourceModel) RefreshFromSharedRoute(resp *shared.Route) {
 	if resp != nil {
 		r.CreatedAt = types.Int64PointerValue(resp.CreatedAt)
+		r.Destinations = []tfTypes.SessionRedisClusterNodes{}
 		if len(r.Destinations) > len(resp.Destinations) {
 			r.Destinations = r.Destinations[:len(resp.Destinations)]
 		}
@@ -227,6 +228,7 @@ func (r *GatewayRouteResourceModel) RefreshFromSharedRoute(resp *shared.Route) {
 		for _, v := range resp.Snis {
 			r.Snis = append(r.Snis, types.StringValue(v))
 		}
+		r.Sources = []tfTypes.SessionRedisClusterNodes{}
 		if len(r.Sources) > len(resp.Sources) {
 			r.Sources = r.Sources[:len(resp.Sources)]
 		}

--- a/internal/provider/portallist_data_source_sdk.go
+++ b/internal/provider/portallist_data_source_sdk.go
@@ -12,6 +12,7 @@ import (
 
 func (r *PortalListDataSourceModel) RefreshFromSharedListPortalsResponse(resp *shared.ListPortalsResponse) {
 	if resp != nil {
+		r.Data = []tfTypes.Portal{}
 		if len(r.Data) > len(resp.Data) {
 			r.Data = r.Data[:len(resp.Data)]
 		}

--- a/internal/provider/portalproductversion_data_source_sdk.go
+++ b/internal/provider/portalproductversion_data_source_sdk.go
@@ -12,6 +12,7 @@ import (
 func (r *PortalProductVersionDataSourceModel) RefreshFromSharedPortalProductVersion(resp *shared.PortalProductVersion) {
 	if resp != nil {
 		r.ApplicationRegistrationEnabled = types.BoolValue(resp.ApplicationRegistrationEnabled)
+		r.AuthStrategies = []tfTypes.AuthStrategy{}
 		if len(r.AuthStrategies) > len(resp.AuthStrategies) {
 			r.AuthStrategies = r.AuthStrategies[:len(resp.AuthStrategies)]
 		}

--- a/internal/provider/portalproductversion_resource_sdk.go
+++ b/internal/provider/portalproductversion_resource_sdk.go
@@ -38,6 +38,7 @@ func (r *PortalProductVersionResourceModel) ToSharedReplacePortalProductVersionP
 func (r *PortalProductVersionResourceModel) RefreshFromSharedPortalProductVersion(resp *shared.PortalProductVersion) {
 	if resp != nil {
 		r.ApplicationRegistrationEnabled = types.BoolValue(resp.ApplicationRegistrationEnabled)
+		r.AuthStrategies = []tfTypes.AuthStrategy{}
 		if len(r.AuthStrategies) > len(resp.AuthStrategies) {
 			r.AuthStrategies = r.AuthStrategies[:len(resp.AuthStrategies)]
 		}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -112,7 +112,8 @@ func (p *KonnectProvider) Configure(ctx context.Context, req provider.ConfigureR
 }
 
 func (p *KonnectProvider) Resources(ctx context.Context) []func() resource.Resource {
-	return []func() resource.Resource{NewAPIProductResource,
+	return []func() resource.Resource{
+		NewAPIProductResource,
 		NewAPIProductVersionResource,
 		NewApplicationAuthStrategyResource,
 		NewCloudGatewayConfigurationResource,
@@ -181,7 +182,8 @@ func (p *KonnectProvider) Resources(ctx context.Context) []func() resource.Resou
 }
 
 func (p *KonnectProvider) DataSources(ctx context.Context) []func() datasource.DataSource {
-	return []func() datasource.DataSource{NewAPIProductDataSource,
+	return []func() datasource.DataSource{
+		NewAPIProductDataSource,
 		NewAPIProductVersionDataSource,
 		NewApplicationAuthStrategyDataSource,
 		NewCloudGatewayConfigurationDataSource,

--- a/internal/sdk/acls.go
+++ b/internal/sdk/acls.go
@@ -118,6 +118,7 @@ func (s *ACLs) CreateACLWithConsumer(ctx context.Context, request operations.Cre
 	}
 
 	return res, nil
+
 }
 
 // DeleteACLWithConsumer - Delete a an ACL associated with a a Consumer
@@ -196,6 +197,7 @@ func (s *ACLs) DeleteACLWithConsumer(ctx context.Context, request operations.Del
 	}
 
 	return res, nil
+
 }
 
 // GetACLWithConsumer - Fetch an ACL associated with a Consumer
@@ -286,4 +288,5 @@ func (s *ACLs) GetACLWithConsumer(ctx context.Context, request operations.GetACL
 	}
 
 	return res, nil
+
 }

--- a/internal/sdk/apikeys.go
+++ b/internal/sdk/apikeys.go
@@ -118,6 +118,7 @@ func (s *APIKeys) CreateKeyAuthWithConsumer(ctx context.Context, request operati
 	}
 
 	return res, nil
+
 }
 
 // DeleteKeyAuthWithConsumer - Delete a an API-key associated with a a Consumer
@@ -196,6 +197,7 @@ func (s *APIKeys) DeleteKeyAuthWithConsumer(ctx context.Context, request operati
 	}
 
 	return res, nil
+
 }
 
 // GetKeyAuthWithConsumer - Fetch an API-key associated with a Consumer
@@ -286,4 +288,5 @@ func (s *APIKeys) GetKeyAuthWithConsumer(ctx context.Context, request operations
 	}
 
 	return res, nil
+
 }

--- a/internal/sdk/apiproducts.go
+++ b/internal/sdk/apiproducts.go
@@ -183,6 +183,7 @@ func (s *APIProducts) CreateAPIProduct(ctx context.Context, request shared.Creat
 	}
 
 	return res, nil
+
 }
 
 // GetAPIProduct - Fetch API product
@@ -323,6 +324,7 @@ func (s *APIProducts) GetAPIProduct(ctx context.Context, request operations.GetA
 	}
 
 	return res, nil
+
 }
 
 // UpdateAPIProduct - Update an individual API product
@@ -493,6 +495,7 @@ func (s *APIProducts) UpdateAPIProduct(ctx context.Context, request operations.U
 	}
 
 	return res, nil
+
 }
 
 // DeleteAPIProduct - Delete API Product
@@ -607,4 +610,5 @@ func (s *APIProducts) DeleteAPIProduct(ctx context.Context, request operations.D
 	}
 
 	return res, nil
+
 }

--- a/internal/sdk/apiproductversions.go
+++ b/internal/sdk/apiproductversions.go
@@ -193,6 +193,7 @@ func (s *APIProductVersions) CreateAPIProductVersion(ctx context.Context, reques
 	}
 
 	return res, nil
+
 }
 
 // GetAPIProductVersion - Fetch API Product Version
@@ -333,6 +334,7 @@ func (s *APIProductVersions) GetAPIProductVersion(ctx context.Context, request o
 	}
 
 	return res, nil
+
 }
 
 // UpdateAPIProductVersion - Update an API Product Version
@@ -503,6 +505,7 @@ func (s *APIProductVersions) UpdateAPIProductVersion(ctx context.Context, reques
 	}
 
 	return res, nil
+
 }
 
 // DeleteAPIProductVersion - Delete API Product Version
@@ -617,4 +620,5 @@ func (s *APIProductVersions) DeleteAPIProductVersion(ctx context.Context, reques
 	}
 
 	return res, nil
+
 }

--- a/internal/sdk/appauthstrategies.go
+++ b/internal/sdk/appauthstrategies.go
@@ -173,6 +173,7 @@ func (s *AppAuthStrategies) CreateAppAuthStrategy(ctx context.Context, request s
 	}
 
 	return res, nil
+
 }
 
 // GetAppAuthStrategy - Get App Auth Strategy
@@ -313,6 +314,7 @@ func (s *AppAuthStrategies) GetAppAuthStrategy(ctx context.Context, request oper
 	}
 
 	return res, nil
+
 }
 
 // UpdateAppAuthStrategy - Update App Auth Strategy
@@ -471,6 +473,7 @@ func (s *AppAuthStrategies) UpdateAppAuthStrategy(ctx context.Context, request o
 	}
 
 	return res, nil
+
 }
 
 // DeleteAppAuthStrategy - Delete App Auth Strategy
@@ -597,4 +600,5 @@ func (s *AppAuthStrategies) DeleteAppAuthStrategy(ctx context.Context, request o
 	}
 
 	return res, nil
+
 }

--- a/internal/sdk/basicauthcredentials.go
+++ b/internal/sdk/basicauthcredentials.go
@@ -118,6 +118,7 @@ func (s *BasicAuthCredentials) CreateBasicAuthWithConsumer(ctx context.Context, 
 	}
 
 	return res, nil
+
 }
 
 // DeleteBasicAuthWithConsumer - Delete a a Basic-auth credential associated with a a Consumer
@@ -196,6 +197,7 @@ func (s *BasicAuthCredentials) DeleteBasicAuthWithConsumer(ctx context.Context, 
 	}
 
 	return res, nil
+
 }
 
 // GetBasicAuthWithConsumer - Fetch a Basic-auth credential associated with a Consumer
@@ -286,4 +288,5 @@ func (s *BasicAuthCredentials) GetBasicAuthWithConsumer(ctx context.Context, req
 	}
 
 	return res, nil
+
 }

--- a/internal/sdk/cacertificates.go
+++ b/internal/sdk/cacertificates.go
@@ -132,6 +132,7 @@ func (s *CACertificates) CreateCaCertificate(ctx context.Context, request operat
 	}
 
 	return res, nil
+
 }
 
 // DeleteCaCertificate - Delete a CA Certificate
@@ -222,6 +223,7 @@ func (s *CACertificates) DeleteCaCertificate(ctx context.Context, request operat
 	}
 
 	return res, nil
+
 }
 
 // GetCaCertificate - Fetch a CA Certificate
@@ -324,4 +326,5 @@ func (s *CACertificates) GetCaCertificate(ctx context.Context, request operation
 	}
 
 	return res, nil
+
 }

--- a/internal/sdk/certificates.go
+++ b/internal/sdk/certificates.go
@@ -135,6 +135,7 @@ func (s *Certificates) CreateCertificate(ctx context.Context, request operations
 	}
 
 	return res, nil
+
 }
 
 // DeleteCertificate - Delete a Certificate
@@ -225,6 +226,7 @@ func (s *Certificates) DeleteCertificate(ctx context.Context, request operations
 	}
 
 	return res, nil
+
 }
 
 // GetCertificate - Fetch a Certificate
@@ -327,4 +329,5 @@ func (s *Certificates) GetCertificate(ctx context.Context, request operations.Ge
 	}
 
 	return res, nil
+
 }

--- a/internal/sdk/consumergroups.go
+++ b/internal/sdk/consumergroups.go
@@ -132,6 +132,7 @@ func (s *ConsumerGroups) CreateConsumerGroup(ctx context.Context, request operat
 	}
 
 	return res, nil
+
 }
 
 // DeleteConsumerGroup - Delete a Consumer Group
@@ -222,6 +223,7 @@ func (s *ConsumerGroups) DeleteConsumerGroup(ctx context.Context, request operat
 	}
 
 	return res, nil
+
 }
 
 // GetConsumerGroup - Fetch a Consumer Group
@@ -324,4 +326,5 @@ func (s *ConsumerGroups) GetConsumerGroup(ctx context.Context, request operation
 	}
 
 	return res, nil
+
 }

--- a/internal/sdk/consumers.go
+++ b/internal/sdk/consumers.go
@@ -132,6 +132,7 @@ func (s *Consumers) CreateConsumer(ctx context.Context, request operations.Creat
 	}
 
 	return res, nil
+
 }
 
 // DeleteConsumer - Delete a Consumer
@@ -222,6 +223,7 @@ func (s *Consumers) DeleteConsumer(ctx context.Context, request operations.Delet
 	}
 
 	return res, nil
+
 }
 
 // GetConsumer - Fetch a Consumer
@@ -324,4 +326,5 @@ func (s *Consumers) GetConsumer(ctx context.Context, request operations.GetConsu
 	}
 
 	return res, nil
+
 }

--- a/internal/sdk/controlplanegroups.go
+++ b/internal/sdk/controlplanegroups.go
@@ -167,6 +167,7 @@ func (s *ControlPlaneGroups) PostControlPlanesIDGroupMembershipsAdd(ctx context.
 	}
 
 	return res, nil
+
 }
 
 // PostControlPlanesIDGroupMembershipsRemove - Remove Control Plane Group Members
@@ -311,4 +312,5 @@ func (s *ControlPlaneGroups) PostControlPlanesIDGroupMembershipsRemove(ctx conte
 	}
 
 	return res, nil
+
 }

--- a/internal/sdk/controlplanes.go
+++ b/internal/sdk/controlplanes.go
@@ -206,6 +206,7 @@ func (s *ControlPlanes) CreateControlPlane(ctx context.Context, request shared.C
 	}
 
 	return res, nil
+
 }
 
 // GetControlPlane - Fetch Control Plane
@@ -370,6 +371,7 @@ func (s *ControlPlanes) GetControlPlane(ctx context.Context, request operations.
 	}
 
 	return res, nil
+
 }
 
 // UpdateControlPlane - Update Control Plane
@@ -552,6 +554,7 @@ func (s *ControlPlanes) UpdateControlPlane(ctx context.Context, request operatio
 	}
 
 	return res, nil
+
 }
 
 // DeleteControlPlane - Delete Control Plane
@@ -702,4 +705,5 @@ func (s *ControlPlanes) DeleteControlPlane(ctx context.Context, request operatio
 	}
 
 	return res, nil
+
 }

--- a/internal/sdk/customdomains.go
+++ b/internal/sdk/customdomains.go
@@ -196,6 +196,7 @@ func (s *CustomDomains) CreateCustomDomains(ctx context.Context, request shared.
 	}
 
 	return res, nil
+
 }
 
 // GetCustomDomain - Get Custom Domain
@@ -336,6 +337,7 @@ func (s *CustomDomains) GetCustomDomain(ctx context.Context, request operations.
 	}
 
 	return res, nil
+
 }
 
 // DeleteCustomDomain - Delete Custom Domain
@@ -502,4 +504,5 @@ func (s *CustomDomains) DeleteCustomDomain(ctx context.Context, request operatio
 	}
 
 	return res, nil
+
 }

--- a/internal/sdk/dataplanegroupconfigurations.go
+++ b/internal/sdk/dataplanegroupconfigurations.go
@@ -199,6 +199,7 @@ func (s *DataPlaneGroupConfigurations) CreateConfiguration(ctx context.Context, 
 	}
 
 	return res, nil
+
 }
 
 // GetConfiguration - Get Configuration
@@ -339,4 +340,5 @@ func (s *DataPlaneGroupConfigurations) GetConfiguration(ctx context.Context, req
 	}
 
 	return res, nil
+
 }

--- a/internal/sdk/dpcertificates.go
+++ b/internal/sdk/dpcertificates.go
@@ -119,6 +119,7 @@ func (s *DPCertificates) CreateDataplaneCertificate(ctx context.Context, request
 	}
 
 	return res, nil
+
 }
 
 // GetDataplaneCertificate - Fetch DP Client Certificate
@@ -208,6 +209,7 @@ func (s *DPCertificates) GetDataplaneCertificate(ctx context.Context, request op
 	}
 
 	return res, nil
+
 }
 
 // DeleteDataplaneCertificate - Delete DP Client Certificate
@@ -286,4 +288,5 @@ func (s *DPCertificates) DeleteDataplaneCertificate(ctx context.Context, request
 	}
 
 	return res, nil
+
 }

--- a/internal/sdk/hmacauthcredentials.go
+++ b/internal/sdk/hmacauthcredentials.go
@@ -118,6 +118,7 @@ func (s *HMACAuthCredentials) CreateHmacAuthWithConsumer(ctx context.Context, re
 	}
 
 	return res, nil
+
 }
 
 // DeleteHmacAuthWithConsumer - Delete a a HMAC-auth credential associated with a a Consumer
@@ -196,6 +197,7 @@ func (s *HMACAuthCredentials) DeleteHmacAuthWithConsumer(ctx context.Context, re
 	}
 
 	return res, nil
+
 }
 
 // GetHmacAuthWithConsumer - Fetch a HMAC-auth credential associated with a Consumer
@@ -286,4 +288,5 @@ func (s *HMACAuthCredentials) GetHmacAuthWithConsumer(ctx context.Context, reque
 	}
 
 	return res, nil
+
 }

--- a/internal/sdk/internal/utils/headers.go
+++ b/internal/sdk/internal/utils/headers.go
@@ -18,8 +18,7 @@ func PopulateHeaders(_ context.Context, req *http.Request, headers interface{}, 
 }
 
 func populateHeaders(headers interface{}, globals interface{}, reqHeaders http.Header, skipFields []string) []string {
-	headerParamsStructType := reflect.TypeOf(headers)
-	headerParamsValType := reflect.ValueOf(headers)
+	headerParamsStructType, headerParamsValType := dereferencePointers(reflect.TypeOf(headers), reflect.ValueOf(headers))
 
 	globalsAlreadyPopulated := []string{}
 

--- a/internal/sdk/internal/utils/pathparams.go
+++ b/internal/sdk/internal/utils/pathparams.go
@@ -38,8 +38,7 @@ func GenerateURL(_ context.Context, serverURL, path string, pathParams interface
 }
 
 func populateParsedParameters(pathParams interface{}, globals interface{}, parsedParameters map[string]string, skipFields []string) ([]string, error) {
-	pathParamsStructType := reflect.TypeOf(pathParams)
-	pathParamsValType := reflect.ValueOf(pathParams)
+	pathParamsStructType, pathParamsValType := dereferencePointers(reflect.TypeOf(pathParams), reflect.ValueOf(pathParams))
 
 	globalsAlreadyPopulated := []string{}
 

--- a/internal/sdk/internal/utils/queryparams.go
+++ b/internal/sdk/internal/utils/queryparams.go
@@ -32,8 +32,7 @@ func PopulateQueryParams(_ context.Context, req *http.Request, queryParams inter
 }
 
 func populateQueryParams(queryParams interface{}, globals interface{}, values url.Values, skipFields []string) ([]string, error) {
-	queryParamsStructType := reflect.TypeOf(queryParams)
-	queryParamsValType := reflect.ValueOf(queryParams)
+	queryParamsStructType, queryParamsValType := dereferencePointers(reflect.TypeOf(queryParams), reflect.ValueOf(queryParams))
 
 	globalsAlreadyPopulated := []string{}
 

--- a/internal/sdk/internal/utils/security.go
+++ b/internal/sdk/internal/utils/security.go
@@ -196,6 +196,10 @@ func handleBasicAuthScheme(headers map[string]string, scheme interface{}) {
 		fieldType := schemeStructType.Field(i)
 		valType := schemeValType.Field(i)
 
+		if fieldType.Type.Kind() == reflect.Ptr {
+			valType = valType.Elem()
+		}
+
 		secTag := parseSecurityTag(fieldType)
 		if secTag == nil || secTag.Name == "" {
 			continue

--- a/internal/sdk/internal/utils/utils.go
+++ b/internal/sdk/internal/utils/utils.go
@@ -3,6 +3,7 @@
 package utils
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"math/big"
@@ -85,6 +86,12 @@ func MatchStatusCodes(expectedCodes []string, statusCode int) bool {
 	}
 
 	return false
+}
+
+func AsSecuritySource(security interface{}) func(context.Context) (interface{}, error) {
+	return func(context.Context) (interface{}, error) {
+		return security, nil
+	}
 }
 
 func parseStructTag(tagKey string, field reflect.StructField) map[string]string {

--- a/internal/sdk/jwts.go
+++ b/internal/sdk/jwts.go
@@ -118,6 +118,7 @@ func (s *JWTs) CreateJwtWithConsumer(ctx context.Context, request operations.Cre
 	}
 
 	return res, nil
+
 }
 
 // DeleteJwtWithConsumer - Delete a a JWT associated with a a Consumer
@@ -196,6 +197,7 @@ func (s *JWTs) DeleteJwtWithConsumer(ctx context.Context, request operations.Del
 	}
 
 	return res, nil
+
 }
 
 // GetJwtWithConsumer - Fetch a JWT associated with a Consumer
@@ -286,4 +288,5 @@ func (s *JWTs) GetJwtWithConsumer(ctx context.Context, request operations.GetJwt
 	}
 
 	return res, nil
+
 }

--- a/internal/sdk/keys.go
+++ b/internal/sdk/keys.go
@@ -131,6 +131,7 @@ func (s *Keys) CreateKey(ctx context.Context, request operations.CreateKeyReques
 	}
 
 	return res, nil
+
 }
 
 // DeleteKey - Delete a Key
@@ -221,6 +222,7 @@ func (s *Keys) DeleteKey(ctx context.Context, request operations.DeleteKeyReques
 	}
 
 	return res, nil
+
 }
 
 // GetKey - Fetch a Key
@@ -323,4 +325,5 @@ func (s *Keys) GetKey(ctx context.Context, request operations.GetKeyRequest) (*o
 	}
 
 	return res, nil
+
 }

--- a/internal/sdk/keysets.go
+++ b/internal/sdk/keysets.go
@@ -131,6 +131,7 @@ func (s *KeySets) CreateKeySet(ctx context.Context, request operations.CreateKey
 	}
 
 	return res, nil
+
 }
 
 // DeleteKeySet - Delete a KeySet
@@ -221,6 +222,7 @@ func (s *KeySets) DeleteKeySet(ctx context.Context, request operations.DeleteKey
 	}
 
 	return res, nil
+
 }
 
 // GetKeySet - Fetch a KeySet
@@ -323,4 +325,5 @@ func (s *KeySets) GetKeySet(ctx context.Context, request operations.GetKeySetReq
 	}
 
 	return res, nil
+
 }

--- a/internal/sdk/konnect.go
+++ b/internal/sdk/konnect.go
@@ -238,16 +238,10 @@ func WithClient(client HTTPClient) SDKOption {
 	}
 }
 
-func withSecurity(security interface{}) func(context.Context) (interface{}, error) {
-	return func(context.Context) (interface{}, error) {
-		return security, nil
-	}
-}
-
 // WithSecurity configures the SDK to use the provided security details
 func WithSecurity(security shared.Security) SDKOption {
 	return func(sdk *Konnect) {
-		sdk.sdkConfiguration.Security = withSecurity(security)
+		sdk.sdkConfiguration.Security = utils.AsSecuritySource(security)
 	}
 }
 
@@ -273,8 +267,8 @@ func New(opts ...SDKOption) *Konnect {
 			Language:          "go",
 			OpenAPIDocVersion: "2.0.0",
 			SDKVersion:        "0.0.1",
-			GenVersion:        "2.331.0",
-			UserAgent:         "speakeasy-sdk/go 0.0.1 2.331.0 2.0.0 github.com/kong/terraform-provider-konnect/internal/sdk",
+			GenVersion:        "2.338.7",
+			UserAgent:         "speakeasy-sdk/go 0.0.1 2.338.7 2.0.0 github.com/kong/terraform-provider-konnect/internal/sdk",
 			Hooks:             hooks.New(),
 		},
 	}

--- a/internal/sdk/mesh.go
+++ b/internal/sdk/mesh.go
@@ -170,6 +170,7 @@ func (s *Mesh) CreateCp(ctx context.Context, request shared.CreateMeshControlPla
 	}
 
 	return res, nil
+
 }
 
 // GetMeshControlPlane - Get the control plane
@@ -310,6 +311,7 @@ func (s *Mesh) GetMeshControlPlane(ctx context.Context, request operations.GetMe
 	}
 
 	return res, nil
+
 }
 
 // DeleteMeshControlPlane - Delete the control plane
@@ -424,6 +426,7 @@ func (s *Mesh) DeleteMeshControlPlane(ctx context.Context, request operations.De
 	}
 
 	return res, nil
+
 }
 
 // UpdateMeshControlPlane - Update control plane
@@ -582,4 +585,5 @@ func (s *Mesh) UpdateMeshControlPlane(ctx context.Context, request operations.Up
 	}
 
 	return res, nil
+
 }

--- a/internal/sdk/models/shared/aclplugin.go
+++ b/internal/sdk/models/shared/aclplugin.go
@@ -26,7 +26,6 @@ const (
 func (e ACLPluginProtocols) ToPointer() *ACLPluginProtocols {
 	return &e
 }
-
 func (e *ACLPluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/aipromptdecoratorplugin.go
+++ b/internal/sdk/models/shared/aipromptdecoratorplugin.go
@@ -26,7 +26,6 @@ const (
 func (e AIPromptDecoratorPluginProtocols) ToPointer() *AIPromptDecoratorPluginProtocols {
 	return &e
 }
-
 func (e *AIPromptDecoratorPluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -106,7 +105,6 @@ const (
 func (e Role) ToPointer() *Role {
 	return &e
 }
-
 func (e *Role) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -166,7 +164,6 @@ const (
 func (e AIPromptDecoratorPluginRole) ToPointer() *AIPromptDecoratorPluginRole {
 	return &e
 }
-
 func (e *AIPromptDecoratorPluginRole) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/aipromptguardplugin.go
+++ b/internal/sdk/models/shared/aipromptguardplugin.go
@@ -26,7 +26,6 @@ const (
 func (e AIPromptGuardPluginProtocols) ToPointer() *AIPromptGuardPluginProtocols {
 	return &e
 }
-
 func (e *AIPromptGuardPluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/aiprompttemplateplugin.go
+++ b/internal/sdk/models/shared/aiprompttemplateplugin.go
@@ -26,7 +26,6 @@ const (
 func (e AIPromptTemplatePluginProtocols) ToPointer() *AIPromptTemplatePluginProtocols {
 	return &e
 }
-
 func (e *AIPromptTemplatePluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/aiproxyplugin.go
+++ b/internal/sdk/models/shared/aiproxyplugin.go
@@ -26,7 +26,6 @@ const (
 func (e AIProxyPluginProtocols) ToPointer() *AIProxyPluginProtocols {
 	return &e
 }
-
 func (e *AIProxyPluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -106,7 +105,6 @@ const (
 func (e ParamLocation) ToPointer() *ParamLocation {
 	return &e
 }
-
 func (e *ParamLocation) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -215,7 +213,6 @@ const (
 func (e Llama2Format) ToPointer() *Llama2Format {
 	return &e
 }
-
 func (e *Llama2Format) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -245,7 +242,6 @@ const (
 func (e MistralFormat) ToPointer() *MistralFormat {
 	return &e
 }
-
 func (e *MistralFormat) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -391,7 +387,6 @@ const (
 func (e Provider) ToPointer() *Provider {
 	return &e
 }
-
 func (e *Provider) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -457,7 +452,6 @@ const (
 func (e RouteType) ToPointer() *RouteType {
 	return &e
 }
-
 func (e *RouteType) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/apiaccess.go
+++ b/internal/sdk/models/shared/apiaccess.go
@@ -19,7 +19,6 @@ const (
 func (e APIAccess) ToPointer() *APIAccess {
 	return &e
 }
-
 func (e *APIAccess) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/apiproductversion.go
+++ b/internal/sdk/models/shared/apiproductversion.go
@@ -54,7 +54,6 @@ const (
 func (e APIProductVersionPublishStatus1) ToPointer() *APIProductVersionPublishStatus1 {
 	return &e
 }
-
 func (e *APIProductVersionPublishStatus1) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/apiproductversionpublishstatus.go
+++ b/internal/sdk/models/shared/apiproductversionpublishstatus.go
@@ -17,7 +17,6 @@ const (
 func (e APIProductVersionPublishStatus) ToPointer() *APIProductVersionPublishStatus {
 	return &e
 }
-
 func (e *APIProductVersionPublishStatus) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/assignedrole.go
+++ b/internal/sdk/models/shared/assignedrole.go
@@ -20,7 +20,6 @@ const (
 func (e AssignedRoleEntityRegion) ToPointer() *AssignedRoleEntityRegion {
 	return &e
 }
-
 func (e *AssignedRoleEntityRegion) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/assignrole.go
+++ b/internal/sdk/models/shared/assignrole.go
@@ -20,7 +20,6 @@ const (
 func (e EntityRegion) ToPointer() *EntityRegion {
 	return &e
 }
-
 func (e *EntityRegion) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/authstrategy.go
+++ b/internal/sdk/models/shared/authstrategy.go
@@ -74,8 +74,8 @@ func (u *AuthStrategy) UnmarshalJSON(data []byte) error {
 	switch dis.CredentialType {
 	case "key_auth":
 		authStrategyKeyAuth := new(AuthStrategyKeyAuth)
-		if err := utils.UnmarshalJSON(data, &authStrategyKeyAuth, "", true, true); err != nil {
-			return fmt.Errorf("could not unmarshal expected type: %w", err)
+		if err := utils.UnmarshalJSON(data, &authStrategyKeyAuth, "", true, false); err != nil {
+			return fmt.Errorf("could not unmarshal `%s` into expected (CredentialType == key_auth) type AuthStrategyKeyAuth within AuthStrategy: %w", string(data), err)
 		}
 
 		u.AuthStrategyKeyAuth = authStrategyKeyAuth
@@ -83,8 +83,8 @@ func (u *AuthStrategy) UnmarshalJSON(data []byte) error {
 		return nil
 	case "client_credentials":
 		authStrategyClientCredentials := new(AuthStrategyClientCredentials)
-		if err := utils.UnmarshalJSON(data, &authStrategyClientCredentials, "", true, true); err != nil {
-			return fmt.Errorf("could not unmarshal expected type: %w", err)
+		if err := utils.UnmarshalJSON(data, &authStrategyClientCredentials, "", true, false); err != nil {
+			return fmt.Errorf("could not unmarshal `%s` into expected (CredentialType == client_credentials) type AuthStrategyClientCredentials within AuthStrategy: %w", string(data), err)
 		}
 
 		u.AuthStrategyClientCredentials = authStrategyClientCredentials
@@ -92,8 +92,8 @@ func (u *AuthStrategy) UnmarshalJSON(data []byte) error {
 		return nil
 	case "self_managed_client_credentials":
 		authStrategyClientCredentials := new(AuthStrategyClientCredentials)
-		if err := utils.UnmarshalJSON(data, &authStrategyClientCredentials, "", true, true); err != nil {
-			return fmt.Errorf("could not unmarshal expected type: %w", err)
+		if err := utils.UnmarshalJSON(data, &authStrategyClientCredentials, "", true, false); err != nil {
+			return fmt.Errorf("could not unmarshal `%s` into expected (CredentialType == self_managed_client_credentials) type AuthStrategyClientCredentials within AuthStrategy: %w", string(data), err)
 		}
 
 		u.AuthStrategyClientCredentials = authStrategyClientCredentials
@@ -101,7 +101,7 @@ func (u *AuthStrategy) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
-	return errors.New("could not unmarshal into supported union types")
+	return fmt.Errorf("could not unmarshal `%s` into any supported union types for AuthStrategy", string(data))
 }
 
 func (u AuthStrategy) MarshalJSON() ([]byte, error) {
@@ -113,5 +113,5 @@ func (u AuthStrategy) MarshalJSON() ([]byte, error) {
 		return utils.MarshalJSON(u.AuthStrategyClientCredentials, "", true)
 	}
 
-	return nil, errors.New("could not marshal union type: all fields are null")
+	return nil, errors.New("could not marshal union type AuthStrategy: all fields are null")
 }

--- a/internal/sdk/models/shared/authstrategyclientcredentials.go
+++ b/internal/sdk/models/shared/authstrategyclientcredentials.go
@@ -18,7 +18,6 @@ const (
 func (e AuthStrategyClientCredentialsCredentialType) ToPointer() *AuthStrategyClientCredentialsCredentialType {
 	return &e
 }
-
 func (e *AuthStrategyClientCredentialsCredentialType) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/authstrategykeyauth.go
+++ b/internal/sdk/models/shared/authstrategykeyauth.go
@@ -17,7 +17,6 @@ const (
 func (e CredentialType) ToPointer() *CredentialType {
 	return &e
 }
-
 func (e *CredentialType) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/authstrategysyncerror.go
+++ b/internal/sdk/models/shared/authstrategysyncerror.go
@@ -20,7 +20,6 @@ const (
 func (e Value) ToPointer() *Value {
 	return &e
 }
-
 func (e *Value) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/awslambdaplugin.go
+++ b/internal/sdk/models/shared/awslambdaplugin.go
@@ -26,7 +26,6 @@ const (
 func (e AWSLambdaPluginProtocols) ToPointer() *AWSLambdaPluginProtocols {
 	return &e
 }
-
 func (e *AWSLambdaPluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -106,7 +105,6 @@ const (
 func (e AwsImdsProtocolVersion) ToPointer() *AwsImdsProtocolVersion {
 	return &e
 }
-
 func (e *AwsImdsProtocolVersion) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -135,7 +133,6 @@ const (
 func (e InvocationType) ToPointer() *InvocationType {
 	return &e
 }
-
 func (e *InvocationType) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -165,7 +162,6 @@ const (
 func (e LogType) ToPointer() *LogType {
 	return &e
 }
-
 func (e *LogType) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/awstransitgatewayattachmentconfig.go
+++ b/internal/sdk/models/shared/awstransitgatewayattachmentconfig.go
@@ -16,7 +16,6 @@ const (
 func (e AWSTransitGatewayAttachmentType) ToPointer() *AWSTransitGatewayAttachmentType {
 	return &e
 }
-
 func (e *AWSTransitGatewayAttachmentType) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/basicauthplugin.go
+++ b/internal/sdk/models/shared/basicauthplugin.go
@@ -26,7 +26,6 @@ const (
 func (e BasicAuthPluginProtocols) ToPointer() *BasicAuthPluginProtocols {
 	return &e
 }
-
 func (e *BasicAuthPluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/configurationdataplanegroup.go
+++ b/internal/sdk/models/shared/configurationdataplanegroup.go
@@ -23,7 +23,6 @@ const (
 func (e State) ToPointer() *State {
 	return &e
 }
-
 func (e *State) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/configurationdataplanegroupautoscale.go
+++ b/internal/sdk/models/shared/configurationdataplanegroupautoscale.go
@@ -4,6 +4,7 @@ package shared
 
 import (
 	"errors"
+	"fmt"
 	"github.com/kong/terraform-provider-konnect/internal/sdk/internal/utils"
 )
 
@@ -55,7 +56,7 @@ func (u *ConfigurationDataPlaneGroupAutoscale) UnmarshalJSON(data []byte) error 
 		return nil
 	}
 
-	return errors.New("could not unmarshal into supported union types")
+	return fmt.Errorf("could not unmarshal `%s` into any supported union types for ConfigurationDataPlaneGroupAutoscale", string(data))
 }
 
 func (u ConfigurationDataPlaneGroupAutoscale) MarshalJSON() ([]byte, error) {
@@ -67,5 +68,5 @@ func (u ConfigurationDataPlaneGroupAutoscale) MarshalJSON() ([]byte, error) {
 		return utils.MarshalJSON(u.ConfigurationDataPlaneGroupAutoscaleAutopilot, "", true)
 	}
 
-	return nil, errors.New("could not marshal union type: all fields are null")
+	return nil, errors.New("could not marshal union type ConfigurationDataPlaneGroupAutoscale: all fields are null")
 }

--- a/internal/sdk/models/shared/configurationdataplanegroupautoscaleautopilot.go
+++ b/internal/sdk/models/shared/configurationdataplanegroupautoscaleautopilot.go
@@ -16,7 +16,6 @@ const (
 func (e ConfigurationDataPlaneGroupAutoscaleAutopilotKind) ToPointer() *ConfigurationDataPlaneGroupAutoscaleAutopilotKind {
 	return &e
 }
-
 func (e *ConfigurationDataPlaneGroupAutoscaleAutopilotKind) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/configurationdataplanegroupautoscalestatic.go
+++ b/internal/sdk/models/shared/configurationdataplanegroupautoscalestatic.go
@@ -16,7 +16,6 @@ const (
 func (e Kind) ToPointer() *Kind {
 	return &e
 }
-
 func (e *Kind) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/controlplanegeo.go
+++ b/internal/sdk/models/shared/controlplanegeo.go
@@ -19,7 +19,6 @@ const (
 func (e ControlPlaneGeo) ToPointer() *ControlPlaneGeo {
 	return &e
 }
-
 func (e *ControlPlaneGeo) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/correlationidplugin.go
+++ b/internal/sdk/models/shared/correlationidplugin.go
@@ -26,7 +26,6 @@ const (
 func (e CorrelationIDPluginProtocols) ToPointer() *CorrelationIDPluginProtocols {
 	return &e
 }
-
 func (e *CorrelationIDPluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -107,7 +106,6 @@ const (
 func (e Generator) ToPointer() *Generator {
 	return &e
 }
-
 func (e *Generator) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/corsplugin.go
+++ b/internal/sdk/models/shared/corsplugin.go
@@ -26,7 +26,6 @@ const (
 func (e CORSPluginProtocols) ToPointer() *CORSPluginProtocols {
 	return &e
 }
-
 func (e *CORSPluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -112,7 +111,6 @@ const (
 func (e Methods) ToPointer() *Methods {
 	return &e
 }
-
 func (e *Methods) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/createaclplugin.go
+++ b/internal/sdk/models/shared/createaclplugin.go
@@ -26,7 +26,6 @@ const (
 func (e CreateACLPluginProtocols) ToPointer() *CreateACLPluginProtocols {
 	return &e
 }
-
 func (e *CreateACLPluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/createaipromptdecoratorplugin.go
+++ b/internal/sdk/models/shared/createaipromptdecoratorplugin.go
@@ -26,7 +26,6 @@ const (
 func (e CreateAIPromptDecoratorPluginProtocols) ToPointer() *CreateAIPromptDecoratorPluginProtocols {
 	return &e
 }
-
 func (e *CreateAIPromptDecoratorPluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -106,7 +105,6 @@ const (
 func (e CreateAIPromptDecoratorPluginRole) ToPointer() *CreateAIPromptDecoratorPluginRole {
 	return &e
 }
-
 func (e *CreateAIPromptDecoratorPluginRole) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -166,7 +164,6 @@ const (
 func (e CreateAIPromptDecoratorPluginConfigRole) ToPointer() *CreateAIPromptDecoratorPluginConfigRole {
 	return &e
 }
-
 func (e *CreateAIPromptDecoratorPluginConfigRole) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/createaipromptguardplugin.go
+++ b/internal/sdk/models/shared/createaipromptguardplugin.go
@@ -26,7 +26,6 @@ const (
 func (e CreateAIPromptGuardPluginProtocols) ToPointer() *CreateAIPromptGuardPluginProtocols {
 	return &e
 }
-
 func (e *CreateAIPromptGuardPluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/createaiprompttemplateplugin.go
+++ b/internal/sdk/models/shared/createaiprompttemplateplugin.go
@@ -26,7 +26,6 @@ const (
 func (e CreateAIPromptTemplatePluginProtocols) ToPointer() *CreateAIPromptTemplatePluginProtocols {
 	return &e
 }
-
 func (e *CreateAIPromptTemplatePluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/createaiproxyplugin.go
+++ b/internal/sdk/models/shared/createaiproxyplugin.go
@@ -26,7 +26,6 @@ const (
 func (e CreateAIProxyPluginProtocols) ToPointer() *CreateAIProxyPluginProtocols {
 	return &e
 }
-
 func (e *CreateAIProxyPluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -106,7 +105,6 @@ const (
 func (e CreateAIProxyPluginParamLocation) ToPointer() *CreateAIProxyPluginParamLocation {
 	return &e
 }
-
 func (e *CreateAIProxyPluginParamLocation) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -215,7 +213,6 @@ const (
 func (e CreateAIProxyPluginLlama2Format) ToPointer() *CreateAIProxyPluginLlama2Format {
 	return &e
 }
-
 func (e *CreateAIProxyPluginLlama2Format) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -245,7 +242,6 @@ const (
 func (e CreateAIProxyPluginMistralFormat) ToPointer() *CreateAIProxyPluginMistralFormat {
 	return &e
 }
-
 func (e *CreateAIProxyPluginMistralFormat) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -391,7 +387,6 @@ const (
 func (e CreateAIProxyPluginProvider) ToPointer() *CreateAIProxyPluginProvider {
 	return &e
 }
-
 func (e *CreateAIProxyPluginProvider) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -457,7 +452,6 @@ const (
 func (e CreateAIProxyPluginRouteType) ToPointer() *CreateAIProxyPluginRouteType {
 	return &e
 }
-
 func (e *CreateAIProxyPluginRouteType) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/createapiproductversiondto.go
+++ b/internal/sdk/models/shared/createapiproductversiondto.go
@@ -21,7 +21,6 @@ const (
 func (e PublishStatus) ToPointer() *PublishStatus {
 	return &e
 }
-
 func (e *PublishStatus) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/createappauthstrategyrequest.go
+++ b/internal/sdk/models/shared/createappauthstrategyrequest.go
@@ -18,7 +18,6 @@ const (
 func (e AppAuthStrategyOpenIDConnectRequestStrategyType) ToPointer() *AppAuthStrategyOpenIDConnectRequestStrategyType {
 	return &e
 }
-
 func (e *AppAuthStrategyOpenIDConnectRequestStrategyType) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -108,7 +107,6 @@ const (
 func (e StrategyType) ToPointer() *StrategyType {
 	return &e
 }
-
 func (e *StrategyType) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -233,8 +231,8 @@ func (u *CreateAppAuthStrategyRequest) UnmarshalJSON(data []byte) error {
 	switch dis.StrategyType {
 	case "key_auth":
 		appAuthStrategyKeyAuthRequest := new(AppAuthStrategyKeyAuthRequest)
-		if err := utils.UnmarshalJSON(data, &appAuthStrategyKeyAuthRequest, "", true, true); err != nil {
-			return fmt.Errorf("could not unmarshal expected type: %w", err)
+		if err := utils.UnmarshalJSON(data, &appAuthStrategyKeyAuthRequest, "", true, false); err != nil {
+			return fmt.Errorf("could not unmarshal `%s` into expected (StrategyType == key_auth) type AppAuthStrategyKeyAuthRequest within CreateAppAuthStrategyRequest: %w", string(data), err)
 		}
 
 		u.AppAuthStrategyKeyAuthRequest = appAuthStrategyKeyAuthRequest
@@ -242,8 +240,8 @@ func (u *CreateAppAuthStrategyRequest) UnmarshalJSON(data []byte) error {
 		return nil
 	case "openid_connect":
 		appAuthStrategyOpenIDConnectRequest := new(AppAuthStrategyOpenIDConnectRequest)
-		if err := utils.UnmarshalJSON(data, &appAuthStrategyOpenIDConnectRequest, "", true, true); err != nil {
-			return fmt.Errorf("could not unmarshal expected type: %w", err)
+		if err := utils.UnmarshalJSON(data, &appAuthStrategyOpenIDConnectRequest, "", true, false); err != nil {
+			return fmt.Errorf("could not unmarshal `%s` into expected (StrategyType == openid_connect) type AppAuthStrategyOpenIDConnectRequest within CreateAppAuthStrategyRequest: %w", string(data), err)
 		}
 
 		u.AppAuthStrategyOpenIDConnectRequest = appAuthStrategyOpenIDConnectRequest
@@ -251,7 +249,7 @@ func (u *CreateAppAuthStrategyRequest) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
-	return errors.New("could not unmarshal into supported union types")
+	return fmt.Errorf("could not unmarshal `%s` into any supported union types for CreateAppAuthStrategyRequest", string(data))
 }
 
 func (u CreateAppAuthStrategyRequest) MarshalJSON() ([]byte, error) {
@@ -263,5 +261,5 @@ func (u CreateAppAuthStrategyRequest) MarshalJSON() ([]byte, error) {
 		return utils.MarshalJSON(u.AppAuthStrategyOpenIDConnectRequest, "", true)
 	}
 
-	return nil, errors.New("could not marshal union type: all fields are null")
+	return nil, errors.New("could not marshal union type CreateAppAuthStrategyRequest: all fields are null")
 }

--- a/internal/sdk/models/shared/createappauthstrategyresponse.go
+++ b/internal/sdk/models/shared/createappauthstrategyresponse.go
@@ -19,7 +19,6 @@ const (
 func (e AppAuthStrategyOpenIDConnectResponseStrategyType) ToPointer() *AppAuthStrategyOpenIDConnectResponseStrategyType {
 	return &e
 }
-
 func (e *AppAuthStrategyOpenIDConnectResponseStrategyType) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -195,7 +194,6 @@ const (
 func (e AppAuthStrategyKeyAuthResponseStrategyType) ToPointer() *AppAuthStrategyKeyAuthResponseStrategyType {
 	return &e
 }
-
 func (e *AppAuthStrategyKeyAuthResponseStrategyType) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -414,8 +412,8 @@ func (u *CreateAppAuthStrategyResponse) UnmarshalJSON(data []byte) error {
 	switch dis.StrategyType {
 	case "key_auth":
 		appAuthStrategyKeyAuthResponse := new(AppAuthStrategyKeyAuthResponse)
-		if err := utils.UnmarshalJSON(data, &appAuthStrategyKeyAuthResponse, "", true, true); err != nil {
-			return fmt.Errorf("could not unmarshal expected type: %w", err)
+		if err := utils.UnmarshalJSON(data, &appAuthStrategyKeyAuthResponse, "", true, false); err != nil {
+			return fmt.Errorf("could not unmarshal `%s` into expected (StrategyType == key_auth) type AppAuthStrategyKeyAuthResponse within CreateAppAuthStrategyResponse: %w", string(data), err)
 		}
 
 		u.AppAuthStrategyKeyAuthResponse = appAuthStrategyKeyAuthResponse
@@ -423,8 +421,8 @@ func (u *CreateAppAuthStrategyResponse) UnmarshalJSON(data []byte) error {
 		return nil
 	case "openid_connect":
 		appAuthStrategyOpenIDConnectResponse := new(AppAuthStrategyOpenIDConnectResponse)
-		if err := utils.UnmarshalJSON(data, &appAuthStrategyOpenIDConnectResponse, "", true, true); err != nil {
-			return fmt.Errorf("could not unmarshal expected type: %w", err)
+		if err := utils.UnmarshalJSON(data, &appAuthStrategyOpenIDConnectResponse, "", true, false); err != nil {
+			return fmt.Errorf("could not unmarshal `%s` into expected (StrategyType == openid_connect) type AppAuthStrategyOpenIDConnectResponse within CreateAppAuthStrategyResponse: %w", string(data), err)
 		}
 
 		u.AppAuthStrategyOpenIDConnectResponse = appAuthStrategyOpenIDConnectResponse
@@ -432,7 +430,7 @@ func (u *CreateAppAuthStrategyResponse) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
-	return errors.New("could not unmarshal into supported union types")
+	return fmt.Errorf("could not unmarshal `%s` into any supported union types for CreateAppAuthStrategyResponse", string(data))
 }
 
 func (u CreateAppAuthStrategyResponse) MarshalJSON() ([]byte, error) {
@@ -444,5 +442,5 @@ func (u CreateAppAuthStrategyResponse) MarshalJSON() ([]byte, error) {
 		return utils.MarshalJSON(u.AppAuthStrategyOpenIDConnectResponse, "", true)
 	}
 
-	return nil, errors.New("could not marshal union type: all fields are null")
+	return nil, errors.New("could not marshal union type CreateAppAuthStrategyResponse: all fields are null")
 }

--- a/internal/sdk/models/shared/createawslambdaplugin.go
+++ b/internal/sdk/models/shared/createawslambdaplugin.go
@@ -26,7 +26,6 @@ const (
 func (e CreateAWSLambdaPluginProtocols) ToPointer() *CreateAWSLambdaPluginProtocols {
 	return &e
 }
-
 func (e *CreateAWSLambdaPluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -106,7 +105,6 @@ const (
 func (e CreateAWSLambdaPluginAWSImdsProtocolVersion) ToPointer() *CreateAWSLambdaPluginAWSImdsProtocolVersion {
 	return &e
 }
-
 func (e *CreateAWSLambdaPluginAWSImdsProtocolVersion) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -135,7 +133,6 @@ const (
 func (e CreateAWSLambdaPluginInvocationType) ToPointer() *CreateAWSLambdaPluginInvocationType {
 	return &e
 }
-
 func (e *CreateAWSLambdaPluginInvocationType) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -165,7 +162,6 @@ const (
 func (e CreateAWSLambdaPluginLogType) ToPointer() *CreateAWSLambdaPluginLogType {
 	return &e
 }
-
 func (e *CreateAWSLambdaPluginLogType) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/createbasicauthplugin.go
+++ b/internal/sdk/models/shared/createbasicauthplugin.go
@@ -26,7 +26,6 @@ const (
 func (e CreateBasicAuthPluginProtocols) ToPointer() *CreateBasicAuthPluginProtocols {
 	return &e
 }
-
 func (e *CreateBasicAuthPluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/createcontrolplanerequest.go
+++ b/internal/sdk/models/shared/createcontrolplanerequest.go
@@ -20,7 +20,6 @@ const (
 func (e ClusterType) ToPointer() *ClusterType {
 	return &e
 }
-
 func (e *ClusterType) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -52,7 +51,6 @@ const (
 func (e AuthType) ToPointer() *AuthType {
 	return &e
 }
-
 func (e *AuthType) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/createcorrelationidplugin.go
+++ b/internal/sdk/models/shared/createcorrelationidplugin.go
@@ -26,7 +26,6 @@ const (
 func (e CreateCorrelationIDPluginProtocols) ToPointer() *CreateCorrelationIDPluginProtocols {
 	return &e
 }
-
 func (e *CreateCorrelationIDPluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -107,7 +106,6 @@ const (
 func (e CreateCorrelationIDPluginGenerator) ToPointer() *CreateCorrelationIDPluginGenerator {
 	return &e
 }
-
 func (e *CreateCorrelationIDPluginGenerator) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/createcorsplugin.go
+++ b/internal/sdk/models/shared/createcorsplugin.go
@@ -26,7 +26,6 @@ const (
 func (e CreateCORSPluginProtocols) ToPointer() *CreateCORSPluginProtocols {
 	return &e
 }
-
 func (e *CreateCORSPluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -112,7 +111,6 @@ const (
 func (e CreateCORSPluginMethods) ToPointer() *CreateCORSPluginMethods {
 	return &e
 }
-
 func (e *CreateCORSPluginMethods) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/createfilelogplugin.go
+++ b/internal/sdk/models/shared/createfilelogplugin.go
@@ -26,7 +26,6 @@ const (
 func (e CreateFileLogPluginProtocols) ToPointer() *CreateFileLogPluginProtocols {
 	return &e
 }
-
 func (e *CreateFileLogPluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/createiprestrictionplugin.go
+++ b/internal/sdk/models/shared/createiprestrictionplugin.go
@@ -26,7 +26,6 @@ const (
 func (e CreateIPRestrictionPluginProtocols) ToPointer() *CreateIPRestrictionPluginProtocols {
 	return &e
 }
-
 func (e *CreateIPRestrictionPluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/createjqplugin.go
+++ b/internal/sdk/models/shared/createjqplugin.go
@@ -26,7 +26,6 @@ const (
 func (e CreateJQPluginProtocols) ToPointer() *CreateJQPluginProtocols {
 	return &e
 }
-
 func (e *CreateJQPluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/createjwtplugin.go
+++ b/internal/sdk/models/shared/createjwtplugin.go
@@ -26,7 +26,6 @@ const (
 func (e CreateJWTPluginProtocols) ToPointer() *CreateJWTPluginProtocols {
 	return &e
 }
-
 func (e *CreateJWTPluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -105,7 +104,6 @@ const (
 func (e CreateJWTPluginClaimsToVerify) ToPointer() *CreateJWTPluginClaimsToVerify {
 	return &e
 }
-
 func (e *CreateJWTPluginClaimsToVerify) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/createjwtsignerplugin.go
+++ b/internal/sdk/models/shared/createjwtsignerplugin.go
@@ -26,7 +26,6 @@ const (
 func (e CreateJWTSignerPluginProtocols) ToPointer() *CreateJWTSignerPluginProtocols {
 	return &e
 }
-
 func (e *CreateJWTSignerPluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -106,7 +105,6 @@ const (
 func (e CreateJWTSignerPluginAccessTokenConsumerBy) ToPointer() *CreateJWTSignerPluginAccessTokenConsumerBy {
 	return &e
 }
-
 func (e *CreateJWTSignerPluginAccessTokenConsumerBy) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -136,7 +134,6 @@ const (
 func (e CreateJWTSignerPluginAccessTokenIntrospectionConsumerBy) ToPointer() *CreateJWTSignerPluginAccessTokenIntrospectionConsumerBy {
 	return &e
 }
-
 func (e *CreateJWTSignerPluginAccessTokenIntrospectionConsumerBy) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -176,7 +173,6 @@ const (
 func (e CreateJWTSignerPluginAccessTokenSigningAlgorithm) ToPointer() *CreateJWTSignerPluginAccessTokenSigningAlgorithm {
 	return &e
 }
-
 func (e *CreateJWTSignerPluginAccessTokenSigningAlgorithm) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -224,7 +220,6 @@ const (
 func (e CreateJWTSignerPluginChannelTokenConsumerBy) ToPointer() *CreateJWTSignerPluginChannelTokenConsumerBy {
 	return &e
 }
-
 func (e *CreateJWTSignerPluginChannelTokenConsumerBy) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -254,7 +249,6 @@ const (
 func (e CreateJWTSignerPluginChannelTokenIntrospectionConsumerBy) ToPointer() *CreateJWTSignerPluginChannelTokenIntrospectionConsumerBy {
 	return &e
 }
-
 func (e *CreateJWTSignerPluginChannelTokenIntrospectionConsumerBy) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -294,7 +288,6 @@ const (
 func (e CreateJWTSignerPluginChannelTokenSigningAlgorithm) ToPointer() *CreateJWTSignerPluginChannelTokenSigningAlgorithm {
 	return &e
 }
-
 func (e *CreateJWTSignerPluginChannelTokenSigningAlgorithm) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/createjwtwithoutparents.go
+++ b/internal/sdk/models/shared/createjwtwithoutparents.go
@@ -24,7 +24,6 @@ const (
 func (e Algorithm) ToPointer() *Algorithm {
 	return &e
 }
-
 func (e *Algorithm) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/createkeyauthplugin.go
+++ b/internal/sdk/models/shared/createkeyauthplugin.go
@@ -26,7 +26,6 @@ const (
 func (e CreateKeyAuthPluginProtocols) ToPointer() *CreateKeyAuthPluginProtocols {
 	return &e
 }
-
 func (e *CreateKeyAuthPluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/createoauth2plugin.go
+++ b/internal/sdk/models/shared/createoauth2plugin.go
@@ -26,7 +26,6 @@ const (
 func (e CreateOauth2PluginProtocols) ToPointer() *CreateOauth2PluginProtocols {
 	return &e
 }
-
 func (e *CreateOauth2PluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -107,7 +106,6 @@ const (
 func (e CreateOauth2PluginPkce) ToPointer() *CreateOauth2PluginPkce {
 	return &e
 }
-
 func (e *CreateOauth2PluginPkce) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/createopenidconnectplugin.go
+++ b/internal/sdk/models/shared/createopenidconnectplugin.go
@@ -26,7 +26,6 @@ const (
 func (e CreateOpenidConnectPluginProtocols) ToPointer() *CreateOpenidConnectPluginProtocols {
 	return &e
 }
-
 func (e *CreateOpenidConnectPluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -112,7 +111,6 @@ const (
 func (e CreateOpenidConnectPluginAuthMethods) ToPointer() *CreateOpenidConnectPluginAuthMethods {
 	return &e
 }
-
 func (e *CreateOpenidConnectPluginAuthMethods) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -156,7 +154,6 @@ const (
 func (e CreateOpenidConnectPluginAuthorizationCookieSameSite) ToPointer() *CreateOpenidConnectPluginAuthorizationCookieSameSite {
 	return &e
 }
-
 func (e *CreateOpenidConnectPluginAuthorizationCookieSameSite) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -189,7 +186,6 @@ const (
 func (e CreateOpenidConnectPluginBearerTokenParamType) ToPointer() *CreateOpenidConnectPluginBearerTokenParamType {
 	return &e
 }
-
 func (e *CreateOpenidConnectPluginBearerTokenParamType) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -231,7 +227,6 @@ const (
 func (e CreateOpenidConnectPluginClientAlg) ToPointer() *CreateOpenidConnectPluginClientAlg {
 	return &e
 }
-
 func (e *CreateOpenidConnectPluginClientAlg) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -285,7 +280,6 @@ const (
 func (e CreateOpenidConnectPluginClientAuth) ToPointer() *CreateOpenidConnectPluginClientAuth {
 	return &e
 }
-
 func (e *CreateOpenidConnectPluginClientAuth) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -323,7 +317,6 @@ const (
 func (e CreateOpenidConnectPluginClientCredentialsParamType) ToPointer() *CreateOpenidConnectPluginClientCredentialsParamType {
 	return &e
 }
-
 func (e *CreateOpenidConnectPluginClientCredentialsParamType) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -556,7 +549,6 @@ const (
 func (e CreateOpenidConnectPluginConsumerBy) ToPointer() *CreateOpenidConnectPluginConsumerBy {
 	return &e
 }
-
 func (e *CreateOpenidConnectPluginConsumerBy) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -592,7 +584,6 @@ const (
 func (e CreateOpenidConnectPluginDisableSession) ToPointer() *CreateOpenidConnectPluginDisableSession {
 	return &e
 }
-
 func (e *CreateOpenidConnectPluginDisableSession) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -634,7 +625,6 @@ const (
 func (e CreateOpenidConnectPluginIDTokenParamType) ToPointer() *CreateOpenidConnectPluginIDTokenParamType {
 	return &e
 }
-
 func (e *CreateOpenidConnectPluginIDTokenParamType) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -668,7 +658,6 @@ const (
 func (e CreateOpenidConnectPluginIgnoreSignature) ToPointer() *CreateOpenidConnectPluginIgnoreSignature {
 	return &e
 }
-
 func (e *CreateOpenidConnectPluginIgnoreSignature) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -707,7 +696,6 @@ const (
 func (e CreateOpenidConnectPluginIntrospectionAccept) ToPointer() *CreateOpenidConnectPluginIntrospectionAccept {
 	return &e
 }
-
 func (e *CreateOpenidConnectPluginIntrospectionAccept) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -742,7 +730,6 @@ const (
 func (e CreateOpenidConnectPluginIntrospectionEndpointAuthMethod) ToPointer() *CreateOpenidConnectPluginIntrospectionEndpointAuthMethod {
 	return &e
 }
-
 func (e *CreateOpenidConnectPluginIntrospectionEndpointAuthMethod) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -781,7 +768,6 @@ const (
 func (e CreateOpenidConnectPluginLoginAction) ToPointer() *CreateOpenidConnectPluginLoginAction {
 	return &e
 }
-
 func (e *CreateOpenidConnectPluginLoginAction) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -817,7 +803,6 @@ const (
 func (e CreateOpenidConnectPluginLoginMethods) ToPointer() *CreateOpenidConnectPluginLoginMethods {
 	return &e
 }
-
 func (e *CreateOpenidConnectPluginLoginMethods) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -859,7 +844,6 @@ const (
 func (e CreateOpenidConnectPluginLoginRedirectMode) ToPointer() *CreateOpenidConnectPluginLoginRedirectMode {
 	return &e
 }
-
 func (e *CreateOpenidConnectPluginLoginRedirectMode) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -889,7 +873,6 @@ const (
 func (e CreateOpenidConnectPluginLoginTokens) ToPointer() *CreateOpenidConnectPluginLoginTokens {
 	return &e
 }
-
 func (e *CreateOpenidConnectPluginLoginTokens) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -923,7 +906,6 @@ const (
 func (e CreateOpenidConnectPluginLogoutMethods) ToPointer() *CreateOpenidConnectPluginLogoutMethods {
 	return &e
 }
-
 func (e *CreateOpenidConnectPluginLogoutMethods) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -953,7 +935,6 @@ const (
 func (e CreateOpenidConnectPluginPasswordParamType) ToPointer() *CreateOpenidConnectPluginPasswordParamType {
 	return &e
 }
-
 func (e *CreateOpenidConnectPluginPasswordParamType) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -984,7 +965,6 @@ const (
 func (e CreateOpenidConnectPluginProofOfPossessionMtls) ToPointer() *CreateOpenidConnectPluginProofOfPossessionMtls {
 	return &e
 }
-
 func (e *CreateOpenidConnectPluginProofOfPossessionMtls) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -1019,7 +999,6 @@ const (
 func (e CreateOpenidConnectPluginPushedAuthorizationRequestEndpointAuthMethod) ToPointer() *CreateOpenidConnectPluginPushedAuthorizationRequestEndpointAuthMethod {
 	return &e
 }
-
 func (e *CreateOpenidConnectPluginPushedAuthorizationRequestEndpointAuthMethod) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -1057,7 +1036,6 @@ const (
 func (e CreateOpenidConnectPluginRefreshTokenParamType) ToPointer() *CreateOpenidConnectPluginRefreshTokenParamType {
 	return &e
 }
-
 func (e *CreateOpenidConnectPluginRefreshTokenParamType) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -1088,7 +1066,6 @@ const (
 func (e CreateOpenidConnectPluginResponseMode) ToPointer() *CreateOpenidConnectPluginResponseMode {
 	return &e
 }
-
 func (e *CreateOpenidConnectPluginResponseMode) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -1123,7 +1100,6 @@ const (
 func (e CreateOpenidConnectPluginRevocationEndpointAuthMethod) ToPointer() *CreateOpenidConnectPluginRevocationEndpointAuthMethod {
 	return &e
 }
-
 func (e *CreateOpenidConnectPluginRevocationEndpointAuthMethod) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -1163,7 +1139,6 @@ const (
 func (e CreateOpenidConnectPluginSessionCookieSameSite) ToPointer() *CreateOpenidConnectPluginSessionCookieSameSite {
 	return &e
 }
-
 func (e *CreateOpenidConnectPluginSessionCookieSameSite) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -1231,7 +1206,6 @@ const (
 func (e CreateOpenidConnectPluginSessionRequestHeaders) ToPointer() *CreateOpenidConnectPluginSessionRequestHeaders {
 	return &e
 }
-
 func (e *CreateOpenidConnectPluginSessionRequestHeaders) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -1273,7 +1247,6 @@ const (
 func (e CreateOpenidConnectPluginSessionResponseHeaders) ToPointer() *CreateOpenidConnectPluginSessionResponseHeaders {
 	return &e
 }
-
 func (e *CreateOpenidConnectPluginSessionResponseHeaders) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -1313,7 +1286,6 @@ const (
 func (e CreateOpenidConnectPluginSessionStorage) ToPointer() *CreateOpenidConnectPluginSessionStorage {
 	return &e
 }
-
 func (e *CreateOpenidConnectPluginSessionStorage) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -1350,7 +1322,6 @@ const (
 func (e CreateOpenidConnectPluginTokenEndpointAuthMethod) ToPointer() *CreateOpenidConnectPluginTokenEndpointAuthMethod {
 	return &e
 }
-
 func (e *CreateOpenidConnectPluginTokenEndpointAuthMethod) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -1389,7 +1360,6 @@ const (
 func (e CreateOpenidConnectPluginTokenHeadersGrants) ToPointer() *CreateOpenidConnectPluginTokenHeadersGrants {
 	return &e
 }
-
 func (e *CreateOpenidConnectPluginTokenHeadersGrants) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -1421,7 +1391,6 @@ const (
 func (e CreateOpenidConnectPluginUserinfoAccept) ToPointer() *CreateOpenidConnectPluginUserinfoAccept {
 	return &e
 }
-
 func (e *CreateOpenidConnectPluginUserinfoAccept) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/createopentelemetryplugin.go
+++ b/internal/sdk/models/shared/createopentelemetryplugin.go
@@ -26,7 +26,6 @@ const (
 func (e CreateOpentelemetryPluginProtocols) ToPointer() *CreateOpentelemetryPluginProtocols {
 	return &e
 }
-
 func (e *CreateOpentelemetryPluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -113,7 +112,6 @@ const (
 func (e CreateOpentelemetryPluginHeaderType) ToPointer() *CreateOpentelemetryPluginHeaderType {
 	return &e
 }
-
 func (e *CreateOpentelemetryPluginHeaderType) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/createplugin.go
+++ b/internal/sdk/models/shared/createplugin.go
@@ -26,7 +26,6 @@ const (
 func (e Protocols) ToPointer() *Protocols {
 	return &e
 }
-
 func (e *Protocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/createprefunctionplugin.go
+++ b/internal/sdk/models/shared/createprefunctionplugin.go
@@ -26,7 +26,6 @@ const (
 func (e CreatePreFunctionPluginProtocols) ToPointer() *CreatePreFunctionPluginProtocols {
 	return &e
 }
-
 func (e *CreatePreFunctionPluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/createprometheusplugin.go
+++ b/internal/sdk/models/shared/createprometheusplugin.go
@@ -26,7 +26,6 @@ const (
 func (e CreatePrometheusPluginProtocols) ToPointer() *CreatePrometheusPluginProtocols {
 	return &e
 }
-
 func (e *CreatePrometheusPluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/createproxycacheplugin.go
+++ b/internal/sdk/models/shared/createproxycacheplugin.go
@@ -26,7 +26,6 @@ const (
 func (e CreateProxyCachePluginProtocols) ToPointer() *CreateProxyCachePluginProtocols {
 	return &e
 }
-
 func (e *CreateProxyCachePluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -131,7 +130,6 @@ const (
 func (e CreateProxyCachePluginRequestMethod) ToPointer() *CreateProxyCachePluginRequestMethod {
 	return &e
 }
-
 func (e *CreateProxyCachePluginRequestMethod) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -203,7 +201,6 @@ const (
 func (e CreateProxyCachePluginStrategy) ToPointer() *CreateProxyCachePluginStrategy {
 	return &e
 }
-
 func (e *CreateProxyCachePluginStrategy) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/createratelimitingadvancedplugin.go
+++ b/internal/sdk/models/shared/createratelimitingadvancedplugin.go
@@ -26,7 +26,6 @@ const (
 func (e CreateRateLimitingAdvancedPluginProtocols) ToPointer() *CreateRateLimitingAdvancedPluginProtocols {
 	return &e
 }
-
 func (e *CreateRateLimitingAdvancedPluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -111,7 +110,6 @@ const (
 func (e CreateRateLimitingAdvancedPluginIdentifier) ToPointer() *CreateRateLimitingAdvancedPluginIdentifier {
 	return &e
 }
-
 func (e *CreateRateLimitingAdvancedPluginIdentifier) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -150,7 +148,6 @@ const (
 func (e CreateRateLimitingAdvancedPluginSentinelRole) ToPointer() *CreateRateLimitingAdvancedPluginSentinelRole {
 	return &e
 }
-
 func (e *CreateRateLimitingAdvancedPluginSentinelRole) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -375,7 +372,6 @@ const (
 func (e CreateRateLimitingAdvancedPluginStrategy) ToPointer() *CreateRateLimitingAdvancedPluginStrategy {
 	return &e
 }
-
 func (e *CreateRateLimitingAdvancedPluginStrategy) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -405,7 +401,6 @@ const (
 func (e CreateRateLimitingAdvancedPluginWindowType) ToPointer() *CreateRateLimitingAdvancedPluginWindowType {
 	return &e
 }
-
 func (e *CreateRateLimitingAdvancedPluginWindowType) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/createratelimitingplugin.go
+++ b/internal/sdk/models/shared/createratelimitingplugin.go
@@ -26,7 +26,6 @@ const (
 func (e CreateRateLimitingPluginProtocols) ToPointer() *CreateRateLimitingPluginProtocols {
 	return &e
 }
-
 func (e *CreateRateLimitingPluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -111,7 +110,6 @@ const (
 func (e CreateRateLimitingPluginLimitBy) ToPointer() *CreateRateLimitingPluginLimitBy {
 	return &e
 }
-
 func (e *CreateRateLimitingPluginLimitBy) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -150,7 +148,6 @@ const (
 func (e CreateRateLimitingPluginPolicy) ToPointer() *CreateRateLimitingPluginPolicy {
 	return &e
 }
-
 func (e *CreateRateLimitingPluginPolicy) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/createrequestterminationplugin.go
+++ b/internal/sdk/models/shared/createrequestterminationplugin.go
@@ -26,7 +26,6 @@ const (
 func (e CreateRequestTerminationPluginProtocols) ToPointer() *CreateRequestTerminationPluginProtocols {
 	return &e
 }
-
 func (e *CreateRequestTerminationPluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/createrequesttransformeradvancedplugin.go
+++ b/internal/sdk/models/shared/createrequesttransformeradvancedplugin.go
@@ -26,7 +26,6 @@ const (
 func (e CreateRequestTransformerAdvancedPluginProtocols) ToPointer() *CreateRequestTransformerAdvancedPluginProtocols {
 	return &e
 }
-
 func (e *CreateRequestTransformerAdvancedPluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -106,7 +105,6 @@ const (
 func (e CreateRequestTransformerAdvancedPluginJSONTypes) ToPointer() *CreateRequestTransformerAdvancedPluginJSONTypes {
 	return &e
 }
-
 func (e *CreateRequestTransformerAdvancedPluginJSONTypes) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -182,7 +180,6 @@ const (
 func (e CreateRequestTransformerAdvancedPluginConfigJSONTypes) ToPointer() *CreateRequestTransformerAdvancedPluginConfigJSONTypes {
 	return &e
 }
-
 func (e *CreateRequestTransformerAdvancedPluginConfigJSONTypes) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -301,7 +298,6 @@ const (
 func (e CreateRequestTransformerAdvancedPluginConfigReplaceJSONTypes) ToPointer() *CreateRequestTransformerAdvancedPluginConfigReplaceJSONTypes {
 	return &e
 }
-
 func (e *CreateRequestTransformerAdvancedPluginConfigReplaceJSONTypes) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/createrequesttransformerplugin.go
+++ b/internal/sdk/models/shared/createrequesttransformerplugin.go
@@ -26,7 +26,6 @@ const (
 func (e CreateRequestTransformerPluginProtocols) ToPointer() *CreateRequestTransformerPluginProtocols {
 	return &e
 }
-
 func (e *CreateRequestTransformerPluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/createresponsetransformeradvancedplugin.go
+++ b/internal/sdk/models/shared/createresponsetransformeradvancedplugin.go
@@ -26,7 +26,6 @@ const (
 func (e CreateResponseTransformerAdvancedPluginProtocols) ToPointer() *CreateResponseTransformerAdvancedPluginProtocols {
 	return &e
 }
-
 func (e *CreateResponseTransformerAdvancedPluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -106,7 +105,6 @@ const (
 func (e CreateResponseTransformerAdvancedPluginJSONTypes) ToPointer() *CreateResponseTransformerAdvancedPluginJSONTypes {
 	return &e
 }
-
 func (e *CreateResponseTransformerAdvancedPluginJSONTypes) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -182,7 +180,6 @@ const (
 func (e CreateResponseTransformerAdvancedPluginConfigJSONTypes) ToPointer() *CreateResponseTransformerAdvancedPluginConfigJSONTypes {
 	return &e
 }
-
 func (e *CreateResponseTransformerAdvancedPluginConfigJSONTypes) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -293,7 +290,6 @@ const (
 func (e CreateResponseTransformerAdvancedPluginConfigReplaceJSONTypes) ToPointer() *CreateResponseTransformerAdvancedPluginConfigReplaceJSONTypes {
 	return &e
 }
-
 func (e *CreateResponseTransformerAdvancedPluginConfigReplaceJSONTypes) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/createresponsetransformerplugin.go
+++ b/internal/sdk/models/shared/createresponsetransformerplugin.go
@@ -26,7 +26,6 @@ const (
 func (e CreateResponseTransformerPluginProtocols) ToPointer() *CreateResponseTransformerPluginProtocols {
 	return &e
 }
-
 func (e *CreateResponseTransformerPluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -106,7 +105,6 @@ const (
 func (e CreateResponseTransformerPluginJSONTypes) ToPointer() *CreateResponseTransformerPluginJSONTypes {
 	return &e
 }
-
 func (e *CreateResponseTransformerPluginJSONTypes) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -165,7 +163,6 @@ const (
 func (e CreateResponseTransformerPluginConfigJSONTypes) ToPointer() *CreateResponseTransformerPluginConfigJSONTypes {
 	return &e
 }
-
 func (e *CreateResponseTransformerPluginConfigJSONTypes) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -254,7 +251,6 @@ const (
 func (e CreateResponseTransformerPluginConfigReplaceJSONTypes) ToPointer() *CreateResponseTransformerPluginConfigReplaceJSONTypes {
 	return &e
 }
-
 func (e *CreateResponseTransformerPluginConfigReplaceJSONTypes) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/createroute.go
+++ b/internal/sdk/models/shared/createroute.go
@@ -41,7 +41,6 @@ const (
 func (e HTTPSRedirectStatusCode) ToPointer() *HTTPSRedirectStatusCode {
 	return &e
 }
-
 func (e *HTTPSRedirectStatusCode) UnmarshalJSON(data []byte) error {
 	var v int64
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -75,7 +74,6 @@ const (
 func (e PathHandling) ToPointer() *PathHandling {
 	return &e
 }
-
 func (e *PathHandling) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -110,7 +108,6 @@ const (
 func (e CreateRouteProtocols) ToPointer() *CreateRouteProtocols {
 	return &e
 }
-
 func (e *CreateRouteProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/createsamlplugin.go
+++ b/internal/sdk/models/shared/createsamlplugin.go
@@ -26,7 +26,6 @@ const (
 func (e CreateSamlPluginProtocols) ToPointer() *CreateSamlPluginProtocols {
 	return &e
 }
-
 func (e *CreateSamlPluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -108,7 +107,6 @@ const (
 func (e CreateSamlPluginNameidFormat) ToPointer() *CreateSamlPluginNameidFormat {
 	return &e
 }
-
 func (e *CreateSamlPluginNameidFormat) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -140,7 +138,6 @@ const (
 func (e CreateSamlPluginRequestDigestAlgorithm) ToPointer() *CreateSamlPluginRequestDigestAlgorithm {
 	return &e
 }
-
 func (e *CreateSamlPluginRequestDigestAlgorithm) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -169,7 +166,6 @@ const (
 func (e CreateSamlPluginRequestSignatureAlgorithm) ToPointer() *CreateSamlPluginRequestSignatureAlgorithm {
 	return &e
 }
-
 func (e *CreateSamlPluginRequestSignatureAlgorithm) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -199,7 +195,6 @@ const (
 func (e CreateSamlPluginResponseDigestAlgorithm) ToPointer() *CreateSamlPluginResponseDigestAlgorithm {
 	return &e
 }
-
 func (e *CreateSamlPluginResponseDigestAlgorithm) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -228,7 +223,6 @@ const (
 func (e CreateSamlPluginResponseSignatureAlgorithm) ToPointer() *CreateSamlPluginResponseSignatureAlgorithm {
 	return &e
 }
-
 func (e *CreateSamlPluginResponseSignatureAlgorithm) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -260,7 +254,6 @@ const (
 func (e CreateSamlPluginSessionCookieSameSite) ToPointer() *CreateSamlPluginSessionCookieSameSite {
 	return &e
 }
-
 func (e *CreateSamlPluginSessionCookieSameSite) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -328,7 +321,6 @@ const (
 func (e CreateSamlPluginSessionRequestHeaders) ToPointer() *CreateSamlPluginSessionRequestHeaders {
 	return &e
 }
-
 func (e *CreateSamlPluginSessionRequestHeaders) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -370,7 +362,6 @@ const (
 func (e CreateSamlPluginSessionResponseHeaders) ToPointer() *CreateSamlPluginSessionResponseHeaders {
 	return &e
 }
-
 func (e *CreateSamlPluginSessionResponseHeaders) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -410,7 +401,6 @@ const (
 func (e CreateSamlPluginSessionStorage) ToPointer() *CreateSamlPluginSessionStorage {
 	return &e
 }
-
 func (e *CreateSamlPluginSessionStorage) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/createservice.go
+++ b/internal/sdk/models/shared/createservice.go
@@ -39,7 +39,6 @@ const (
 func (e Protocol) ToPointer() *Protocol {
 	return &e
 }
-
 func (e *Protocol) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/createupstream.go
+++ b/internal/sdk/models/shared/createupstream.go
@@ -20,7 +20,6 @@ const (
 func (e CreateUpstreamAlgorithm) ToPointer() *CreateUpstreamAlgorithm {
 	return &e
 }
-
 func (e *CreateUpstreamAlgorithm) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -68,7 +67,6 @@ const (
 func (e HashFallback) ToPointer() *HashFallback {
 	return &e
 }
-
 func (e *HashFallback) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -114,7 +112,6 @@ const (
 func (e HashOn) ToPointer() *HashOn {
 	return &e
 }
-
 func (e *HashOn) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -194,7 +191,6 @@ const (
 func (e Type) ToPointer() *Type {
 	return &e
 }
-
 func (e *Type) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -400,7 +396,6 @@ const (
 func (e CreateUpstreamType) ToPointer() *CreateUpstreamType {
 	return &e
 }
-
 func (e *CreateUpstreamType) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/customdomainstate.go
+++ b/internal/sdk/models/shared/customdomainstate.go
@@ -22,7 +22,6 @@ const (
 func (e CustomDomainState) ToPointer() *CustomDomainState {
 	return &e
 }
-
 func (e *CustomDomainState) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/dcrprovidertype.go
+++ b/internal/sdk/models/shared/dcrprovidertype.go
@@ -21,7 +21,6 @@ const (
 func (e DcrProviderType) ToPointer() *DcrProviderType {
 	return &e
 }
-
 func (e *DcrProviderType) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/filelogplugin.go
+++ b/internal/sdk/models/shared/filelogplugin.go
@@ -26,7 +26,6 @@ const (
 func (e FileLogPluginProtocols) ToPointer() *FileLogPluginProtocols {
 	return &e
 }
-
 func (e *FileLogPluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/getappauthstrategyresponse.go
+++ b/internal/sdk/models/shared/getappauthstrategyresponse.go
@@ -19,7 +19,6 @@ const (
 func (e AppAuthStrategyOpenIDConnectResponseGetAppAuthStrategyResponseStrategyType) ToPointer() *AppAuthStrategyOpenIDConnectResponseGetAppAuthStrategyResponseStrategyType {
 	return &e
 }
-
 func (e *AppAuthStrategyOpenIDConnectResponseGetAppAuthStrategyResponseStrategyType) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -195,7 +194,6 @@ const (
 func (e AppAuthStrategyKeyAuthResponseGetAppAuthStrategyResponseStrategyType) ToPointer() *AppAuthStrategyKeyAuthResponseGetAppAuthStrategyResponseStrategyType {
 	return &e
 }
-
 func (e *AppAuthStrategyKeyAuthResponseGetAppAuthStrategyResponseStrategyType) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -414,8 +412,8 @@ func (u *GetAppAuthStrategyResponse) UnmarshalJSON(data []byte) error {
 	switch dis.StrategyType {
 	case "key_auth":
 		appAuthStrategyKeyAuthResponseAppAuthStrategyKeyAuthResponse := new(AppAuthStrategyKeyAuthResponseAppAuthStrategyKeyAuthResponse)
-		if err := utils.UnmarshalJSON(data, &appAuthStrategyKeyAuthResponseAppAuthStrategyKeyAuthResponse, "", true, true); err != nil {
-			return fmt.Errorf("could not unmarshal expected type: %w", err)
+		if err := utils.UnmarshalJSON(data, &appAuthStrategyKeyAuthResponseAppAuthStrategyKeyAuthResponse, "", true, false); err != nil {
+			return fmt.Errorf("could not unmarshal `%s` into expected (StrategyType == key_auth) type AppAuthStrategyKeyAuthResponseAppAuthStrategyKeyAuthResponse within GetAppAuthStrategyResponse: %w", string(data), err)
 		}
 
 		u.AppAuthStrategyKeyAuthResponseAppAuthStrategyKeyAuthResponse = appAuthStrategyKeyAuthResponseAppAuthStrategyKeyAuthResponse
@@ -423,8 +421,8 @@ func (u *GetAppAuthStrategyResponse) UnmarshalJSON(data []byte) error {
 		return nil
 	case "openid_connect":
 		appAuthStrategyOpenIDConnectResponseAppAuthStrategyOpenIDConnectResponse := new(AppAuthStrategyOpenIDConnectResponseAppAuthStrategyOpenIDConnectResponse)
-		if err := utils.UnmarshalJSON(data, &appAuthStrategyOpenIDConnectResponseAppAuthStrategyOpenIDConnectResponse, "", true, true); err != nil {
-			return fmt.Errorf("could not unmarshal expected type: %w", err)
+		if err := utils.UnmarshalJSON(data, &appAuthStrategyOpenIDConnectResponseAppAuthStrategyOpenIDConnectResponse, "", true, false); err != nil {
+			return fmt.Errorf("could not unmarshal `%s` into expected (StrategyType == openid_connect) type AppAuthStrategyOpenIDConnectResponseAppAuthStrategyOpenIDConnectResponse within GetAppAuthStrategyResponse: %w", string(data), err)
 		}
 
 		u.AppAuthStrategyOpenIDConnectResponseAppAuthStrategyOpenIDConnectResponse = appAuthStrategyOpenIDConnectResponseAppAuthStrategyOpenIDConnectResponse
@@ -432,7 +430,7 @@ func (u *GetAppAuthStrategyResponse) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
-	return errors.New("could not unmarshal into supported union types")
+	return fmt.Errorf("could not unmarshal `%s` into any supported union types for GetAppAuthStrategyResponse", string(data))
 }
 
 func (u GetAppAuthStrategyResponse) MarshalJSON() ([]byte, error) {
@@ -444,5 +442,5 @@ func (u GetAppAuthStrategyResponse) MarshalJSON() ([]byte, error) {
 		return utils.MarshalJSON(u.AppAuthStrategyOpenIDConnectResponseAppAuthStrategyOpenIDConnectResponse, "", true)
 	}
 
-	return nil, errors.New("could not marshal union type: all fields are null")
+	return nil, errors.New("could not marshal union type GetAppAuthStrategyResponse: all fields are null")
 }

--- a/internal/sdk/models/shared/instancetypename.go
+++ b/internal/sdk/models/shared/instancetypename.go
@@ -19,7 +19,6 @@ const (
 func (e InstanceTypeName) ToPointer() *InstanceTypeName {
 	return &e
 }
-
 func (e *InstanceTypeName) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/internalservererror.go
+++ b/internal/sdk/models/shared/internalservererror.go
@@ -17,7 +17,6 @@ const (
 func (e Status) ToPointer() *Status {
 	return &e
 }
-
 func (e *Status) UnmarshalJSON(data []byte) error {
 	var v int64
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/invalidparameterdependentitem.go
+++ b/internal/sdk/models/shared/invalidparameterdependentitem.go
@@ -17,7 +17,6 @@ const (
 func (e Rule) ToPointer() *Rule {
 	return &e
 }
-
 func (e *Rule) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/invalidparameters.go
+++ b/internal/sdk/models/shared/invalidparameters.go
@@ -4,6 +4,7 @@ package shared
 
 import (
 	"errors"
+	"fmt"
 	"github.com/kong/terraform-provider-konnect/internal/sdk/internal/utils"
 )
 
@@ -73,7 +74,7 @@ func (u *InvalidParameters) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
-	return errors.New("could not unmarshal into supported union types")
+	return fmt.Errorf("could not unmarshal `%s` into any supported union types for InvalidParameters", string(data))
 }
 
 func (u InvalidParameters) MarshalJSON() ([]byte, error) {
@@ -89,5 +90,5 @@ func (u InvalidParameters) MarshalJSON() ([]byte, error) {
 		return utils.MarshalJSON(u.InvalidParameterDependentItem, "", true)
 	}
 
-	return nil, errors.New("could not marshal union type: all fields are null")
+	return nil, errors.New("could not marshal union type InvalidParameters: all fields are null")
 }

--- a/internal/sdk/models/shared/invalidrules.go
+++ b/internal/sdk/models/shared/invalidrules.go
@@ -43,7 +43,6 @@ const (
 func (e InvalidRules) ToPointer() *InvalidRules {
 	return &e
 }
-
 func (e *InvalidRules) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/iprestrictionplugin.go
+++ b/internal/sdk/models/shared/iprestrictionplugin.go
@@ -26,7 +26,6 @@ const (
 func (e IPRestrictionPluginProtocols) ToPointer() *IPRestrictionPluginProtocols {
 	return &e
 }
-
 func (e *IPRestrictionPluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/jqplugin.go
+++ b/internal/sdk/models/shared/jqplugin.go
@@ -26,7 +26,6 @@ const (
 func (e JQPluginProtocols) ToPointer() *JQPluginProtocols {
 	return &e
 }
-
 func (e *JQPluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/jwt.go
+++ b/internal/sdk/models/shared/jwt.go
@@ -24,7 +24,6 @@ const (
 func (e JWTAlgorithm) ToPointer() *JWTAlgorithm {
 	return &e
 }
-
 func (e *JWTAlgorithm) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/jwtplugin.go
+++ b/internal/sdk/models/shared/jwtplugin.go
@@ -26,7 +26,6 @@ const (
 func (e JWTPluginProtocols) ToPointer() *JWTPluginProtocols {
 	return &e
 }
-
 func (e *JWTPluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -105,7 +104,6 @@ const (
 func (e ClaimsToVerify) ToPointer() *ClaimsToVerify {
 	return &e
 }
-
 func (e *ClaimsToVerify) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/jwtsignerplugin.go
+++ b/internal/sdk/models/shared/jwtsignerplugin.go
@@ -26,7 +26,6 @@ const (
 func (e JWTSignerPluginProtocols) ToPointer() *JWTSignerPluginProtocols {
 	return &e
 }
-
 func (e *JWTSignerPluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -106,7 +105,6 @@ const (
 func (e AccessTokenConsumerBy) ToPointer() *AccessTokenConsumerBy {
 	return &e
 }
-
 func (e *AccessTokenConsumerBy) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -136,7 +134,6 @@ const (
 func (e AccessTokenIntrospectionConsumerBy) ToPointer() *AccessTokenIntrospectionConsumerBy {
 	return &e
 }
-
 func (e *AccessTokenIntrospectionConsumerBy) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -176,7 +173,6 @@ const (
 func (e AccessTokenSigningAlgorithm) ToPointer() *AccessTokenSigningAlgorithm {
 	return &e
 }
-
 func (e *AccessTokenSigningAlgorithm) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -224,7 +220,6 @@ const (
 func (e ChannelTokenConsumerBy) ToPointer() *ChannelTokenConsumerBy {
 	return &e
 }
-
 func (e *ChannelTokenConsumerBy) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -254,7 +249,6 @@ const (
 func (e ChannelTokenIntrospectionConsumerBy) ToPointer() *ChannelTokenIntrospectionConsumerBy {
 	return &e
 }
-
 func (e *ChannelTokenIntrospectionConsumerBy) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -294,7 +288,6 @@ const (
 func (e ChannelTokenSigningAlgorithm) ToPointer() *ChannelTokenSigningAlgorithm {
 	return &e
 }
-
 func (e *ChannelTokenSigningAlgorithm) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/keyauthplugin.go
+++ b/internal/sdk/models/shared/keyauthplugin.go
@@ -26,7 +26,6 @@ const (
 func (e KeyAuthPluginProtocols) ToPointer() *KeyAuthPluginProtocols {
 	return &e
 }
-
 func (e *KeyAuthPluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/networkstate.go
+++ b/internal/sdk/models/shared/networkstate.go
@@ -22,7 +22,6 @@ const (
 func (e NetworkState) ToPointer() *NetworkState {
 	return &e
 }
-
 func (e *NetworkState) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/oauth2plugin.go
+++ b/internal/sdk/models/shared/oauth2plugin.go
@@ -26,7 +26,6 @@ const (
 func (e Oauth2PluginProtocols) ToPointer() *Oauth2PluginProtocols {
 	return &e
 }
-
 func (e *Oauth2PluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -107,7 +106,6 @@ const (
 func (e Pkce) ToPointer() *Pkce {
 	return &e
 }
-
 func (e *Pkce) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/openidconnectplugin.go
+++ b/internal/sdk/models/shared/openidconnectplugin.go
@@ -26,7 +26,6 @@ const (
 func (e OpenidConnectPluginProtocols) ToPointer() *OpenidConnectPluginProtocols {
 	return &e
 }
-
 func (e *OpenidConnectPluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -112,7 +111,6 @@ const (
 func (e AuthMethods) ToPointer() *AuthMethods {
 	return &e
 }
-
 func (e *AuthMethods) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -156,7 +154,6 @@ const (
 func (e AuthorizationCookieSameSite) ToPointer() *AuthorizationCookieSameSite {
 	return &e
 }
-
 func (e *AuthorizationCookieSameSite) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -189,7 +186,6 @@ const (
 func (e BearerTokenParamType) ToPointer() *BearerTokenParamType {
 	return &e
 }
-
 func (e *BearerTokenParamType) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -231,7 +227,6 @@ const (
 func (e ClientAlg) ToPointer() *ClientAlg {
 	return &e
 }
-
 func (e *ClientAlg) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -285,7 +280,6 @@ const (
 func (e ClientAuth) ToPointer() *ClientAuth {
 	return &e
 }
-
 func (e *ClientAuth) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -323,7 +317,6 @@ const (
 func (e ClientCredentialsParamType) ToPointer() *ClientCredentialsParamType {
 	return &e
 }
-
 func (e *ClientCredentialsParamType) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -556,7 +549,6 @@ const (
 func (e ConsumerBy) ToPointer() *ConsumerBy {
 	return &e
 }
-
 func (e *ConsumerBy) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -592,7 +584,6 @@ const (
 func (e DisableSession) ToPointer() *DisableSession {
 	return &e
 }
-
 func (e *DisableSession) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -634,7 +625,6 @@ const (
 func (e IDTokenParamType) ToPointer() *IDTokenParamType {
 	return &e
 }
-
 func (e *IDTokenParamType) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -668,7 +658,6 @@ const (
 func (e IgnoreSignature) ToPointer() *IgnoreSignature {
 	return &e
 }
-
 func (e *IgnoreSignature) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -707,7 +696,6 @@ const (
 func (e IntrospectionAccept) ToPointer() *IntrospectionAccept {
 	return &e
 }
-
 func (e *IntrospectionAccept) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -742,7 +730,6 @@ const (
 func (e IntrospectionEndpointAuthMethod) ToPointer() *IntrospectionEndpointAuthMethod {
 	return &e
 }
-
 func (e *IntrospectionEndpointAuthMethod) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -781,7 +768,6 @@ const (
 func (e LoginAction) ToPointer() *LoginAction {
 	return &e
 }
-
 func (e *LoginAction) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -817,7 +803,6 @@ const (
 func (e LoginMethods) ToPointer() *LoginMethods {
 	return &e
 }
-
 func (e *LoginMethods) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -859,7 +844,6 @@ const (
 func (e LoginRedirectMode) ToPointer() *LoginRedirectMode {
 	return &e
 }
-
 func (e *LoginRedirectMode) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -889,7 +873,6 @@ const (
 func (e LoginTokens) ToPointer() *LoginTokens {
 	return &e
 }
-
 func (e *LoginTokens) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -923,7 +906,6 @@ const (
 func (e LogoutMethods) ToPointer() *LogoutMethods {
 	return &e
 }
-
 func (e *LogoutMethods) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -953,7 +935,6 @@ const (
 func (e PasswordParamType) ToPointer() *PasswordParamType {
 	return &e
 }
-
 func (e *PasswordParamType) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -984,7 +965,6 @@ const (
 func (e ProofOfPossessionMtls) ToPointer() *ProofOfPossessionMtls {
 	return &e
 }
-
 func (e *ProofOfPossessionMtls) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -1019,7 +999,6 @@ const (
 func (e PushedAuthorizationRequestEndpointAuthMethod) ToPointer() *PushedAuthorizationRequestEndpointAuthMethod {
 	return &e
 }
-
 func (e *PushedAuthorizationRequestEndpointAuthMethod) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -1057,7 +1036,6 @@ const (
 func (e RefreshTokenParamType) ToPointer() *RefreshTokenParamType {
 	return &e
 }
-
 func (e *RefreshTokenParamType) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -1088,7 +1066,6 @@ const (
 func (e ResponseMode) ToPointer() *ResponseMode {
 	return &e
 }
-
 func (e *ResponseMode) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -1123,7 +1100,6 @@ const (
 func (e RevocationEndpointAuthMethod) ToPointer() *RevocationEndpointAuthMethod {
 	return &e
 }
-
 func (e *RevocationEndpointAuthMethod) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -1163,7 +1139,6 @@ const (
 func (e SessionCookieSameSite) ToPointer() *SessionCookieSameSite {
 	return &e
 }
-
 func (e *SessionCookieSameSite) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -1231,7 +1206,6 @@ const (
 func (e SessionRequestHeaders) ToPointer() *SessionRequestHeaders {
 	return &e
 }
-
 func (e *SessionRequestHeaders) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -1273,7 +1247,6 @@ const (
 func (e SessionResponseHeaders) ToPointer() *SessionResponseHeaders {
 	return &e
 }
-
 func (e *SessionResponseHeaders) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -1313,7 +1286,6 @@ const (
 func (e SessionStorage) ToPointer() *SessionStorage {
 	return &e
 }
-
 func (e *SessionStorage) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -1350,7 +1322,6 @@ const (
 func (e TokenEndpointAuthMethod) ToPointer() *TokenEndpointAuthMethod {
 	return &e
 }
-
 func (e *TokenEndpointAuthMethod) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -1389,7 +1360,6 @@ const (
 func (e TokenHeadersGrants) ToPointer() *TokenHeadersGrants {
 	return &e
 }
-
 func (e *TokenHeadersGrants) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -1421,7 +1391,6 @@ const (
 func (e UserinfoAccept) ToPointer() *UserinfoAccept {
 	return &e
 }
-
 func (e *UserinfoAccept) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/opentelemetryplugin.go
+++ b/internal/sdk/models/shared/opentelemetryplugin.go
@@ -26,7 +26,6 @@ const (
 func (e OpentelemetryPluginProtocols) ToPointer() *OpentelemetryPluginProtocols {
 	return &e
 }
-
 func (e *OpentelemetryPluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -113,7 +112,6 @@ const (
 func (e HeaderType) ToPointer() *HeaderType {
 	return &e
 }
-
 func (e *HeaderType) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/plugin.go
+++ b/internal/sdk/models/shared/plugin.go
@@ -26,7 +26,6 @@ const (
 func (e PluginProtocols) ToPointer() *PluginProtocols {
 	return &e
 }
-
 func (e *PluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/portalproductversionpublishstatus.go
+++ b/internal/sdk/models/shared/portalproductversionpublishstatus.go
@@ -18,7 +18,6 @@ const (
 func (e PortalProductVersionPublishStatus) ToPointer() *PortalProductVersionPublishStatus {
 	return &e
 }
-
 func (e *PortalProductVersionPublishStatus) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/prefunctionplugin.go
+++ b/internal/sdk/models/shared/prefunctionplugin.go
@@ -26,7 +26,6 @@ const (
 func (e PreFunctionPluginProtocols) ToPointer() *PreFunctionPluginProtocols {
 	return &e
 }
-
 func (e *PreFunctionPluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/prometheusplugin.go
+++ b/internal/sdk/models/shared/prometheusplugin.go
@@ -26,7 +26,6 @@ const (
 func (e PrometheusPluginProtocols) ToPointer() *PrometheusPluginProtocols {
 	return &e
 }
-
 func (e *PrometheusPluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/providername.go
+++ b/internal/sdk/models/shared/providername.go
@@ -17,7 +17,6 @@ const (
 func (e ProviderName) ToPointer() *ProviderName {
 	return &e
 }
-
 func (e *ProviderName) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/proxycacheplugin.go
+++ b/internal/sdk/models/shared/proxycacheplugin.go
@@ -26,7 +26,6 @@ const (
 func (e ProxyCachePluginProtocols) ToPointer() *ProxyCachePluginProtocols {
 	return &e
 }
-
 func (e *ProxyCachePluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -131,7 +130,6 @@ const (
 func (e RequestMethod) ToPointer() *RequestMethod {
 	return &e
 }
-
 func (e *RequestMethod) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -203,7 +201,6 @@ const (
 func (e Strategy) ToPointer() *Strategy {
 	return &e
 }
-
 func (e *Strategy) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/ratelimitingadvancedplugin.go
+++ b/internal/sdk/models/shared/ratelimitingadvancedplugin.go
@@ -26,7 +26,6 @@ const (
 func (e RateLimitingAdvancedPluginProtocols) ToPointer() *RateLimitingAdvancedPluginProtocols {
 	return &e
 }
-
 func (e *RateLimitingAdvancedPluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -111,7 +110,6 @@ const (
 func (e Identifier) ToPointer() *Identifier {
 	return &e
 }
-
 func (e *Identifier) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -150,7 +148,6 @@ const (
 func (e SentinelRole) ToPointer() *SentinelRole {
 	return &e
 }
-
 func (e *SentinelRole) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -375,7 +372,6 @@ const (
 func (e RateLimitingAdvancedPluginStrategy) ToPointer() *RateLimitingAdvancedPluginStrategy {
 	return &e
 }
-
 func (e *RateLimitingAdvancedPluginStrategy) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -405,7 +401,6 @@ const (
 func (e WindowType) ToPointer() *WindowType {
 	return &e
 }
-
 func (e *WindowType) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/ratelimitingplugin.go
+++ b/internal/sdk/models/shared/ratelimitingplugin.go
@@ -26,7 +26,6 @@ const (
 func (e RateLimitingPluginProtocols) ToPointer() *RateLimitingPluginProtocols {
 	return &e
 }
-
 func (e *RateLimitingPluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -111,7 +110,6 @@ const (
 func (e LimitBy) ToPointer() *LimitBy {
 	return &e
 }
-
 func (e *LimitBy) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -150,7 +148,6 @@ const (
 func (e Policy) ToPointer() *Policy {
 	return &e
 }
-
 func (e *Policy) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/requestterminationplugin.go
+++ b/internal/sdk/models/shared/requestterminationplugin.go
@@ -26,7 +26,6 @@ const (
 func (e RequestTerminationPluginProtocols) ToPointer() *RequestTerminationPluginProtocols {
 	return &e
 }
-
 func (e *RequestTerminationPluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/requesttransformeradvancedplugin.go
+++ b/internal/sdk/models/shared/requesttransformeradvancedplugin.go
@@ -26,7 +26,6 @@ const (
 func (e RequestTransformerAdvancedPluginProtocols) ToPointer() *RequestTransformerAdvancedPluginProtocols {
 	return &e
 }
-
 func (e *RequestTransformerAdvancedPluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -106,7 +105,6 @@ const (
 func (e JSONTypes) ToPointer() *JSONTypes {
 	return &e
 }
-
 func (e *JSONTypes) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -182,7 +180,6 @@ const (
 func (e RequestTransformerAdvancedPluginJSONTypes) ToPointer() *RequestTransformerAdvancedPluginJSONTypes {
 	return &e
 }
-
 func (e *RequestTransformerAdvancedPluginJSONTypes) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -301,7 +298,6 @@ const (
 func (e RequestTransformerAdvancedPluginConfigJSONTypes) ToPointer() *RequestTransformerAdvancedPluginConfigJSONTypes {
 	return &e
 }
-
 func (e *RequestTransformerAdvancedPluginConfigJSONTypes) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/requesttransformerplugin.go
+++ b/internal/sdk/models/shared/requesttransformerplugin.go
@@ -26,7 +26,6 @@ const (
 func (e RequestTransformerPluginProtocols) ToPointer() *RequestTransformerPluginProtocols {
 	return &e
 }
-
 func (e *RequestTransformerPluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/responsetransformeradvancedplugin.go
+++ b/internal/sdk/models/shared/responsetransformeradvancedplugin.go
@@ -26,7 +26,6 @@ const (
 func (e ResponseTransformerAdvancedPluginProtocols) ToPointer() *ResponseTransformerAdvancedPluginProtocols {
 	return &e
 }
-
 func (e *ResponseTransformerAdvancedPluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -106,7 +105,6 @@ const (
 func (e ResponseTransformerAdvancedPluginJSONTypes) ToPointer() *ResponseTransformerAdvancedPluginJSONTypes {
 	return &e
 }
-
 func (e *ResponseTransformerAdvancedPluginJSONTypes) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -182,7 +180,6 @@ const (
 func (e ResponseTransformerAdvancedPluginConfigJSONTypes) ToPointer() *ResponseTransformerAdvancedPluginConfigJSONTypes {
 	return &e
 }
-
 func (e *ResponseTransformerAdvancedPluginConfigJSONTypes) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -293,7 +290,6 @@ const (
 func (e ResponseTransformerAdvancedPluginConfigReplaceJSONTypes) ToPointer() *ResponseTransformerAdvancedPluginConfigReplaceJSONTypes {
 	return &e
 }
-
 func (e *ResponseTransformerAdvancedPluginConfigReplaceJSONTypes) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/responsetransformerplugin.go
+++ b/internal/sdk/models/shared/responsetransformerplugin.go
@@ -26,7 +26,6 @@ const (
 func (e ResponseTransformerPluginProtocols) ToPointer() *ResponseTransformerPluginProtocols {
 	return &e
 }
-
 func (e *ResponseTransformerPluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -106,7 +105,6 @@ const (
 func (e ResponseTransformerPluginJSONTypes) ToPointer() *ResponseTransformerPluginJSONTypes {
 	return &e
 }
-
 func (e *ResponseTransformerPluginJSONTypes) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -165,7 +163,6 @@ const (
 func (e ResponseTransformerPluginConfigJSONTypes) ToPointer() *ResponseTransformerPluginConfigJSONTypes {
 	return &e
 }
-
 func (e *ResponseTransformerPluginConfigJSONTypes) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -254,7 +251,6 @@ const (
 func (e ResponseTransformerPluginConfigReplaceJSONTypes) ToPointer() *ResponseTransformerPluginConfigReplaceJSONTypes {
 	return &e
 }
-
 func (e *ResponseTransformerPluginConfigReplaceJSONTypes) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/route.go
+++ b/internal/sdk/models/shared/route.go
@@ -41,7 +41,6 @@ const (
 func (e RouteHTTPSRedirectStatusCode) ToPointer() *RouteHTTPSRedirectStatusCode {
 	return &e
 }
-
 func (e *RouteHTTPSRedirectStatusCode) UnmarshalJSON(data []byte) error {
 	var v int64
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -75,7 +74,6 @@ const (
 func (e RoutePathHandling) ToPointer() *RoutePathHandling {
 	return &e
 }
-
 func (e *RoutePathHandling) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -110,7 +108,6 @@ const (
 func (e RouteProtocols) ToPointer() *RouteProtocols {
 	return &e
 }
-
 func (e *RouteProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/samlplugin.go
+++ b/internal/sdk/models/shared/samlplugin.go
@@ -26,7 +26,6 @@ const (
 func (e SamlPluginProtocols) ToPointer() *SamlPluginProtocols {
 	return &e
 }
-
 func (e *SamlPluginProtocols) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -108,7 +107,6 @@ const (
 func (e NameidFormat) ToPointer() *NameidFormat {
 	return &e
 }
-
 func (e *NameidFormat) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -140,7 +138,6 @@ const (
 func (e RequestDigestAlgorithm) ToPointer() *RequestDigestAlgorithm {
 	return &e
 }
-
 func (e *RequestDigestAlgorithm) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -169,7 +166,6 @@ const (
 func (e RequestSignatureAlgorithm) ToPointer() *RequestSignatureAlgorithm {
 	return &e
 }
-
 func (e *RequestSignatureAlgorithm) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -199,7 +195,6 @@ const (
 func (e ResponseDigestAlgorithm) ToPointer() *ResponseDigestAlgorithm {
 	return &e
 }
-
 func (e *ResponseDigestAlgorithm) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -228,7 +223,6 @@ const (
 func (e ResponseSignatureAlgorithm) ToPointer() *ResponseSignatureAlgorithm {
 	return &e
 }
-
 func (e *ResponseSignatureAlgorithm) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -260,7 +254,6 @@ const (
 func (e SamlPluginSessionCookieSameSite) ToPointer() *SamlPluginSessionCookieSameSite {
 	return &e
 }
-
 func (e *SamlPluginSessionCookieSameSite) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -328,7 +321,6 @@ const (
 func (e SamlPluginSessionRequestHeaders) ToPointer() *SamlPluginSessionRequestHeaders {
 	return &e
 }
-
 func (e *SamlPluginSessionRequestHeaders) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -370,7 +362,6 @@ const (
 func (e SamlPluginSessionResponseHeaders) ToPointer() *SamlPluginSessionResponseHeaders {
 	return &e
 }
-
 func (e *SamlPluginSessionResponseHeaders) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -410,7 +401,6 @@ const (
 func (e SamlPluginSessionStorage) ToPointer() *SamlPluginSessionStorage {
 	return &e
 }
-
 func (e *SamlPluginSessionStorage) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/serviceunavailable.go
+++ b/internal/sdk/models/shared/serviceunavailable.go
@@ -17,7 +17,6 @@ const (
 func (e ServiceUnavailableStatus) ToPointer() *ServiceUnavailableStatus {
 	return &e
 }
-
 func (e *ServiceUnavailableStatus) UnmarshalJSON(data []byte) error {
 	var v int64
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/transitgatewayattachmentconfig.go
+++ b/internal/sdk/models/shared/transitgatewayattachmentconfig.go
@@ -4,6 +4,7 @@ package shared
 
 import (
 	"errors"
+	"fmt"
 	"github.com/kong/terraform-provider-konnect/internal/sdk/internal/utils"
 )
 
@@ -37,7 +38,7 @@ func (u *TransitGatewayAttachmentConfig) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
-	return errors.New("could not unmarshal into supported union types")
+	return fmt.Errorf("could not unmarshal `%s` into any supported union types for TransitGatewayAttachmentConfig", string(data))
 }
 
 func (u TransitGatewayAttachmentConfig) MarshalJSON() ([]byte, error) {
@@ -45,5 +46,5 @@ func (u TransitGatewayAttachmentConfig) MarshalJSON() ([]byte, error) {
 		return utils.MarshalJSON(u.AwsTransitGatewayAttachmentConfig, "", true)
 	}
 
-	return nil, errors.New("could not marshal union type: all fields are null")
+	return nil, errors.New("could not marshal union type TransitGatewayAttachmentConfig: all fields are null")
 }

--- a/internal/sdk/models/shared/transitgatewaystate.go
+++ b/internal/sdk/models/shared/transitgatewaystate.go
@@ -21,7 +21,6 @@ const (
 func (e TransitGatewayState) ToPointer() *TransitGatewayState {
 	return &e
 }
-
 func (e *TransitGatewayState) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/updateapiproductversiondto.go
+++ b/internal/sdk/models/shared/updateapiproductversiondto.go
@@ -20,7 +20,6 @@ const (
 func (e UpdateAPIProductVersionDTOPublishStatus) ToPointer() *UpdateAPIProductVersionDTOPublishStatus {
 	return &e
 }
-
 func (e *UpdateAPIProductVersionDTOPublishStatus) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/updateappauthstrategyrequest.go
+++ b/internal/sdk/models/shared/updateappauthstrategyrequest.go
@@ -4,6 +4,7 @@ package shared
 
 import (
 	"errors"
+	"fmt"
 	"github.com/kong/terraform-provider-konnect/internal/sdk/internal/utils"
 )
 
@@ -87,7 +88,7 @@ func (u *Configs) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
-	return errors.New("could not unmarshal into supported union types")
+	return fmt.Errorf("could not unmarshal `%s` into any supported union types for Configs", string(data))
 }
 
 func (u Configs) MarshalJSON() ([]byte, error) {
@@ -99,7 +100,7 @@ func (u Configs) MarshalJSON() ([]byte, error) {
 		return utils.MarshalJSON(u.Two, "", true)
 	}
 
-	return nil, errors.New("could not marshal union type: all fields are null")
+	return nil, errors.New("could not marshal union type Configs: all fields are null")
 }
 
 // UpdateAppAuthStrategyRequest - Request body for updating an Application Auth Strategy

--- a/internal/sdk/models/shared/updateappauthstrategyresponse.go
+++ b/internal/sdk/models/shared/updateappauthstrategyresponse.go
@@ -19,7 +19,6 @@ const (
 func (e AppAuthStrategyOpenIDConnectResponseUpdateAppAuthStrategyResponseStrategyType) ToPointer() *AppAuthStrategyOpenIDConnectResponseUpdateAppAuthStrategyResponseStrategyType {
 	return &e
 }
-
 func (e *AppAuthStrategyOpenIDConnectResponseUpdateAppAuthStrategyResponseStrategyType) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -195,7 +194,6 @@ const (
 func (e AppAuthStrategyKeyAuthResponseUpdateAppAuthStrategyResponseStrategyType) ToPointer() *AppAuthStrategyKeyAuthResponseUpdateAppAuthStrategyResponseStrategyType {
 	return &e
 }
-
 func (e *AppAuthStrategyKeyAuthResponseUpdateAppAuthStrategyResponseStrategyType) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -414,8 +412,8 @@ func (u *UpdateAppAuthStrategyResponse) UnmarshalJSON(data []byte) error {
 	switch dis.StrategyType {
 	case "key_auth":
 		appAuthStrategyKeyAuthResponseUpdateAppAuthStrategyResponseAppAuthStrategyKeyAuthResponse := new(AppAuthStrategyKeyAuthResponseUpdateAppAuthStrategyResponseAppAuthStrategyKeyAuthResponse)
-		if err := utils.UnmarshalJSON(data, &appAuthStrategyKeyAuthResponseUpdateAppAuthStrategyResponseAppAuthStrategyKeyAuthResponse, "", true, true); err != nil {
-			return fmt.Errorf("could not unmarshal expected type: %w", err)
+		if err := utils.UnmarshalJSON(data, &appAuthStrategyKeyAuthResponseUpdateAppAuthStrategyResponseAppAuthStrategyKeyAuthResponse, "", true, false); err != nil {
+			return fmt.Errorf("could not unmarshal `%s` into expected (StrategyType == key_auth) type AppAuthStrategyKeyAuthResponseUpdateAppAuthStrategyResponseAppAuthStrategyKeyAuthResponse within UpdateAppAuthStrategyResponse: %w", string(data), err)
 		}
 
 		u.AppAuthStrategyKeyAuthResponseUpdateAppAuthStrategyResponseAppAuthStrategyKeyAuthResponse = appAuthStrategyKeyAuthResponseUpdateAppAuthStrategyResponseAppAuthStrategyKeyAuthResponse
@@ -423,8 +421,8 @@ func (u *UpdateAppAuthStrategyResponse) UnmarshalJSON(data []byte) error {
 		return nil
 	case "openid_connect":
 		appAuthStrategyOpenIDConnectResponseUpdateAppAuthStrategyResponseAppAuthStrategyOpenIDConnectResponse := new(AppAuthStrategyOpenIDConnectResponseUpdateAppAuthStrategyResponseAppAuthStrategyOpenIDConnectResponse)
-		if err := utils.UnmarshalJSON(data, &appAuthStrategyOpenIDConnectResponseUpdateAppAuthStrategyResponseAppAuthStrategyOpenIDConnectResponse, "", true, true); err != nil {
-			return fmt.Errorf("could not unmarshal expected type: %w", err)
+		if err := utils.UnmarshalJSON(data, &appAuthStrategyOpenIDConnectResponseUpdateAppAuthStrategyResponseAppAuthStrategyOpenIDConnectResponse, "", true, false); err != nil {
+			return fmt.Errorf("could not unmarshal `%s` into expected (StrategyType == openid_connect) type AppAuthStrategyOpenIDConnectResponseUpdateAppAuthStrategyResponseAppAuthStrategyOpenIDConnectResponse within UpdateAppAuthStrategyResponse: %w", string(data), err)
 		}
 
 		u.AppAuthStrategyOpenIDConnectResponseUpdateAppAuthStrategyResponseAppAuthStrategyOpenIDConnectResponse = appAuthStrategyOpenIDConnectResponseUpdateAppAuthStrategyResponseAppAuthStrategyOpenIDConnectResponse
@@ -432,7 +430,7 @@ func (u *UpdateAppAuthStrategyResponse) UnmarshalJSON(data []byte) error {
 		return nil
 	}
 
-	return errors.New("could not unmarshal into supported union types")
+	return fmt.Errorf("could not unmarshal `%s` into any supported union types for UpdateAppAuthStrategyResponse", string(data))
 }
 
 func (u UpdateAppAuthStrategyResponse) MarshalJSON() ([]byte, error) {
@@ -444,5 +442,5 @@ func (u UpdateAppAuthStrategyResponse) MarshalJSON() ([]byte, error) {
 		return utils.MarshalJSON(u.AppAuthStrategyOpenIDConnectResponseUpdateAppAuthStrategyResponseAppAuthStrategyOpenIDConnectResponse, "", true)
 	}
 
-	return nil, errors.New("could not marshal union type: all fields are null")
+	return nil, errors.New("could not marshal union type UpdateAppAuthStrategyResponse: all fields are null")
 }

--- a/internal/sdk/models/shared/updatecontrolplanerequest.go
+++ b/internal/sdk/models/shared/updatecontrolplanerequest.go
@@ -18,7 +18,6 @@ const (
 func (e UpdateControlPlaneRequestAuthType) ToPointer() *UpdateControlPlaneRequestAuthType {
 	return &e
 }
-
 func (e *UpdateControlPlaneRequestAuthType) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/models/shared/upstream.go
+++ b/internal/sdk/models/shared/upstream.go
@@ -20,7 +20,6 @@ const (
 func (e UpstreamAlgorithm) ToPointer() *UpstreamAlgorithm {
 	return &e
 }
-
 func (e *UpstreamAlgorithm) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -68,7 +67,6 @@ const (
 func (e UpstreamHashFallback) ToPointer() *UpstreamHashFallback {
 	return &e
 }
-
 func (e *UpstreamHashFallback) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -114,7 +112,6 @@ const (
 func (e UpstreamHashOn) ToPointer() *UpstreamHashOn {
 	return &e
 }
-
 func (e *UpstreamHashOn) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -194,7 +191,6 @@ const (
 func (e UpstreamType) ToPointer() *UpstreamType {
 	return &e
 }
-
 func (e *UpstreamType) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {
@@ -400,7 +396,6 @@ const (
 func (e UpstreamHealthchecksType) ToPointer() *UpstreamHealthchecksType {
 	return &e
 }
-
 func (e *UpstreamHealthchecksType) UnmarshalJSON(data []byte) error {
 	var v string
 	if err := json.Unmarshal(data, &v); err != nil {

--- a/internal/sdk/networks.go
+++ b/internal/sdk/networks.go
@@ -183,6 +183,7 @@ func (s *Networks) CreateNetwork(ctx context.Context, request shared.CreateNetwo
 	}
 
 	return res, nil
+
 }
 
 // GetNetwork - Get Network
@@ -323,6 +324,7 @@ func (s *Networks) GetNetwork(ctx context.Context, request operations.GetNetwork
 	}
 
 	return res, nil
+
 }
 
 // UpdateNetwork - Update Network
@@ -493,6 +495,7 @@ func (s *Networks) UpdateNetwork(ctx context.Context, request operations.UpdateN
 	}
 
 	return res, nil
+
 }
 
 // DeleteNetwork - Delete Network
@@ -659,4 +662,5 @@ func (s *Networks) DeleteNetwork(ctx context.Context, request operations.DeleteN
 	}
 
 	return res, nil
+
 }

--- a/internal/sdk/plugins.go
+++ b/internal/sdk/plugins.go
@@ -136,6 +136,7 @@ func (s *Plugins) CreatePlugin(ctx context.Context, request operations.CreatePlu
 	}
 
 	return res, nil
+
 }
 
 // DeletePlugin - Delete a Plugin
@@ -226,6 +227,7 @@ func (s *Plugins) DeletePlugin(ctx context.Context, request operations.DeletePlu
 	}
 
 	return res, nil
+
 }
 
 // GetPlugin - Fetch a Plugin
@@ -328,6 +330,7 @@ func (s *Plugins) GetPlugin(ctx context.Context, request operations.GetPluginReq
 	}
 
 	return res, nil
+
 }
 
 // DeleteACLPlugin - Delete a ACL plugin
@@ -418,6 +421,7 @@ func (s *Plugins) DeleteACLPlugin(ctx context.Context, request operations.Delete
 	}
 
 	return res, nil
+
 }
 
 // GetACLPlugin - Get a ACL plugin
@@ -520,6 +524,7 @@ func (s *Plugins) GetACLPlugin(ctx context.Context, request operations.GetACLPlu
 	}
 
 	return res, nil
+
 }
 
 // UpdateACLPlugin - Update a ACL plugin
@@ -627,6 +632,7 @@ func (s *Plugins) UpdateACLPlugin(ctx context.Context, request operations.Update
 	}
 
 	return res, nil
+
 }
 
 // DeleteAipromptdecoratorPlugin - Delete a AIPromptDecorator plugin
@@ -717,6 +723,7 @@ func (s *Plugins) DeleteAipromptdecoratorPlugin(ctx context.Context, request ope
 	}
 
 	return res, nil
+
 }
 
 // GetAipromptdecoratorPlugin - Get a AIPromptDecorator plugin
@@ -819,6 +826,7 @@ func (s *Plugins) GetAipromptdecoratorPlugin(ctx context.Context, request operat
 	}
 
 	return res, nil
+
 }
 
 // UpdateAipromptdecoratorPlugin - Update a AIPromptDecorator plugin
@@ -926,6 +934,7 @@ func (s *Plugins) UpdateAipromptdecoratorPlugin(ctx context.Context, request ope
 	}
 
 	return res, nil
+
 }
 
 // DeleteAipromptguardPlugin - Delete a AIPromptGuard plugin
@@ -1016,6 +1025,7 @@ func (s *Plugins) DeleteAipromptguardPlugin(ctx context.Context, request operati
 	}
 
 	return res, nil
+
 }
 
 // GetAipromptguardPlugin - Get a AIPromptGuard plugin
@@ -1118,6 +1128,7 @@ func (s *Plugins) GetAipromptguardPlugin(ctx context.Context, request operations
 	}
 
 	return res, nil
+
 }
 
 // UpdateAipromptguardPlugin - Update a AIPromptGuard plugin
@@ -1225,6 +1236,7 @@ func (s *Plugins) UpdateAipromptguardPlugin(ctx context.Context, request operati
 	}
 
 	return res, nil
+
 }
 
 // DeleteAiprompttemplatePlugin - Delete a AIPromptTemplate plugin
@@ -1315,6 +1327,7 @@ func (s *Plugins) DeleteAiprompttemplatePlugin(ctx context.Context, request oper
 	}
 
 	return res, nil
+
 }
 
 // GetAiprompttemplatePlugin - Get a AIPromptTemplate plugin
@@ -1417,6 +1430,7 @@ func (s *Plugins) GetAiprompttemplatePlugin(ctx context.Context, request operati
 	}
 
 	return res, nil
+
 }
 
 // UpdateAiprompttemplatePlugin - Update a AIPromptTemplate plugin
@@ -1524,6 +1538,7 @@ func (s *Plugins) UpdateAiprompttemplatePlugin(ctx context.Context, request oper
 	}
 
 	return res, nil
+
 }
 
 // DeleteAiproxyPlugin - Delete a AIProxy plugin
@@ -1614,6 +1629,7 @@ func (s *Plugins) DeleteAiproxyPlugin(ctx context.Context, request operations.De
 	}
 
 	return res, nil
+
 }
 
 // GetAiproxyPlugin - Get a AIProxy plugin
@@ -1716,6 +1732,7 @@ func (s *Plugins) GetAiproxyPlugin(ctx context.Context, request operations.GetAi
 	}
 
 	return res, nil
+
 }
 
 // UpdateAiproxyPlugin - Update a AIProxy plugin
@@ -1823,6 +1840,7 @@ func (s *Plugins) UpdateAiproxyPlugin(ctx context.Context, request operations.Up
 	}
 
 	return res, nil
+
 }
 
 // DeleteAwslambdaPlugin - Delete a AWSLambda plugin
@@ -1913,6 +1931,7 @@ func (s *Plugins) DeleteAwslambdaPlugin(ctx context.Context, request operations.
 	}
 
 	return res, nil
+
 }
 
 // GetAwslambdaPlugin - Get a AWSLambda plugin
@@ -2015,6 +2034,7 @@ func (s *Plugins) GetAwslambdaPlugin(ctx context.Context, request operations.Get
 	}
 
 	return res, nil
+
 }
 
 // UpdateAwslambdaPlugin - Update a AWSLambda plugin
@@ -2122,6 +2142,7 @@ func (s *Plugins) UpdateAwslambdaPlugin(ctx context.Context, request operations.
 	}
 
 	return res, nil
+
 }
 
 // DeleteBasicauthPlugin - Delete a BasicAuth plugin
@@ -2212,6 +2233,7 @@ func (s *Plugins) DeleteBasicauthPlugin(ctx context.Context, request operations.
 	}
 
 	return res, nil
+
 }
 
 // GetBasicauthPlugin - Get a BasicAuth plugin
@@ -2314,6 +2336,7 @@ func (s *Plugins) GetBasicauthPlugin(ctx context.Context, request operations.Get
 	}
 
 	return res, nil
+
 }
 
 // UpdateBasicauthPlugin - Update a BasicAuth plugin
@@ -2421,6 +2444,7 @@ func (s *Plugins) UpdateBasicauthPlugin(ctx context.Context, request operations.
 	}
 
 	return res, nil
+
 }
 
 // DeleteCorrelationidPlugin - Delete a CorrelationId plugin
@@ -2511,6 +2535,7 @@ func (s *Plugins) DeleteCorrelationidPlugin(ctx context.Context, request operati
 	}
 
 	return res, nil
+
 }
 
 // GetCorrelationidPlugin - Get a CorrelationId plugin
@@ -2613,6 +2638,7 @@ func (s *Plugins) GetCorrelationidPlugin(ctx context.Context, request operations
 	}
 
 	return res, nil
+
 }
 
 // UpdateCorrelationidPlugin - Update a CorrelationId plugin
@@ -2720,6 +2746,7 @@ func (s *Plugins) UpdateCorrelationidPlugin(ctx context.Context, request operati
 	}
 
 	return res, nil
+
 }
 
 // DeleteCorsPlugin - Delete a CORS plugin
@@ -2810,6 +2837,7 @@ func (s *Plugins) DeleteCorsPlugin(ctx context.Context, request operations.Delet
 	}
 
 	return res, nil
+
 }
 
 // GetCorsPlugin - Get a CORS plugin
@@ -2912,6 +2940,7 @@ func (s *Plugins) GetCorsPlugin(ctx context.Context, request operations.GetCorsP
 	}
 
 	return res, nil
+
 }
 
 // UpdateCorsPlugin - Update a CORS plugin
@@ -3019,6 +3048,7 @@ func (s *Plugins) UpdateCorsPlugin(ctx context.Context, request operations.Updat
 	}
 
 	return res, nil
+
 }
 
 // DeleteFilelogPlugin - Delete a FileLog plugin
@@ -3109,6 +3139,7 @@ func (s *Plugins) DeleteFilelogPlugin(ctx context.Context, request operations.De
 	}
 
 	return res, nil
+
 }
 
 // GetFilelogPlugin - Get a FileLog plugin
@@ -3211,6 +3242,7 @@ func (s *Plugins) GetFilelogPlugin(ctx context.Context, request operations.GetFi
 	}
 
 	return res, nil
+
 }
 
 // UpdateFilelogPlugin - Update a FileLog plugin
@@ -3318,6 +3350,7 @@ func (s *Plugins) UpdateFilelogPlugin(ctx context.Context, request operations.Up
 	}
 
 	return res, nil
+
 }
 
 // DeleteIprestrictionPlugin - Delete a IpRestriction plugin
@@ -3408,6 +3441,7 @@ func (s *Plugins) DeleteIprestrictionPlugin(ctx context.Context, request operati
 	}
 
 	return res, nil
+
 }
 
 // GetIprestrictionPlugin - Get a IpRestriction plugin
@@ -3510,6 +3544,7 @@ func (s *Plugins) GetIprestrictionPlugin(ctx context.Context, request operations
 	}
 
 	return res, nil
+
 }
 
 // UpdateIprestrictionPlugin - Update a IpRestriction plugin
@@ -3617,6 +3652,7 @@ func (s *Plugins) UpdateIprestrictionPlugin(ctx context.Context, request operati
 	}
 
 	return res, nil
+
 }
 
 // DeleteJqPlugin - Delete a JQ plugin
@@ -3707,6 +3743,7 @@ func (s *Plugins) DeleteJqPlugin(ctx context.Context, request operations.DeleteJ
 	}
 
 	return res, nil
+
 }
 
 // GetJqPlugin - Get a JQ plugin
@@ -3809,6 +3846,7 @@ func (s *Plugins) GetJqPlugin(ctx context.Context, request operations.GetJqPlugi
 	}
 
 	return res, nil
+
 }
 
 // UpdateJqPlugin - Update a JQ plugin
@@ -3916,6 +3954,7 @@ func (s *Plugins) UpdateJqPlugin(ctx context.Context, request operations.UpdateJ
 	}
 
 	return res, nil
+
 }
 
 // DeleteJwtPlugin - Delete a JWT plugin
@@ -4006,6 +4045,7 @@ func (s *Plugins) DeleteJwtPlugin(ctx context.Context, request operations.Delete
 	}
 
 	return res, nil
+
 }
 
 // GetJwtPlugin - Get a JWT plugin
@@ -4108,6 +4148,7 @@ func (s *Plugins) GetJwtPlugin(ctx context.Context, request operations.GetJwtPlu
 	}
 
 	return res, nil
+
 }
 
 // UpdateJwtPlugin - Update a JWT plugin
@@ -4215,6 +4256,7 @@ func (s *Plugins) UpdateJwtPlugin(ctx context.Context, request operations.Update
 	}
 
 	return res, nil
+
 }
 
 // DeleteJwtsignerPlugin - Delete a JWTSigner plugin
@@ -4305,6 +4347,7 @@ func (s *Plugins) DeleteJwtsignerPlugin(ctx context.Context, request operations.
 	}
 
 	return res, nil
+
 }
 
 // GetJwtsignerPlugin - Get a JWTSigner plugin
@@ -4407,6 +4450,7 @@ func (s *Plugins) GetJwtsignerPlugin(ctx context.Context, request operations.Get
 	}
 
 	return res, nil
+
 }
 
 // UpdateJwtsignerPlugin - Update a JWTSigner plugin
@@ -4514,6 +4558,7 @@ func (s *Plugins) UpdateJwtsignerPlugin(ctx context.Context, request operations.
 	}
 
 	return res, nil
+
 }
 
 // DeleteKeyauthPlugin - Delete a KeyAuth plugin
@@ -4604,6 +4649,7 @@ func (s *Plugins) DeleteKeyauthPlugin(ctx context.Context, request operations.De
 	}
 
 	return res, nil
+
 }
 
 // GetKeyauthPlugin - Get a KeyAuth plugin
@@ -4706,6 +4752,7 @@ func (s *Plugins) GetKeyauthPlugin(ctx context.Context, request operations.GetKe
 	}
 
 	return res, nil
+
 }
 
 // UpdateKeyauthPlugin - Update a KeyAuth plugin
@@ -4813,6 +4860,7 @@ func (s *Plugins) UpdateKeyauthPlugin(ctx context.Context, request operations.Up
 	}
 
 	return res, nil
+
 }
 
 // DeleteOauth2Plugin - Delete a Oauth2 plugin
@@ -4903,6 +4951,7 @@ func (s *Plugins) DeleteOauth2Plugin(ctx context.Context, request operations.Del
 	}
 
 	return res, nil
+
 }
 
 // GetOauth2Plugin - Get a Oauth2 plugin
@@ -5005,6 +5054,7 @@ func (s *Plugins) GetOauth2Plugin(ctx context.Context, request operations.GetOau
 	}
 
 	return res, nil
+
 }
 
 // UpdateOauth2Plugin - Update a Oauth2 plugin
@@ -5112,6 +5162,7 @@ func (s *Plugins) UpdateOauth2Plugin(ctx context.Context, request operations.Upd
 	}
 
 	return res, nil
+
 }
 
 // DeleteOpenidconnectPlugin - Delete a OpenidConnect plugin
@@ -5202,6 +5253,7 @@ func (s *Plugins) DeleteOpenidconnectPlugin(ctx context.Context, request operati
 	}
 
 	return res, nil
+
 }
 
 // GetOpenidconnectPlugin - Get a OpenidConnect plugin
@@ -5304,6 +5356,7 @@ func (s *Plugins) GetOpenidconnectPlugin(ctx context.Context, request operations
 	}
 
 	return res, nil
+
 }
 
 // UpdateOpenidconnectPlugin - Update a OpenidConnect plugin
@@ -5411,6 +5464,7 @@ func (s *Plugins) UpdateOpenidconnectPlugin(ctx context.Context, request operati
 	}
 
 	return res, nil
+
 }
 
 // DeleteOpentelemetryPlugin - Delete a Opentelemetry plugin
@@ -5501,6 +5555,7 @@ func (s *Plugins) DeleteOpentelemetryPlugin(ctx context.Context, request operati
 	}
 
 	return res, nil
+
 }
 
 // GetOpentelemetryPlugin - Get a Opentelemetry plugin
@@ -5603,6 +5658,7 @@ func (s *Plugins) GetOpentelemetryPlugin(ctx context.Context, request operations
 	}
 
 	return res, nil
+
 }
 
 // UpdateOpentelemetryPlugin - Update a Opentelemetry plugin
@@ -5710,6 +5766,7 @@ func (s *Plugins) UpdateOpentelemetryPlugin(ctx context.Context, request operati
 	}
 
 	return res, nil
+
 }
 
 // DeletePrefunctionPlugin - Delete a PreFunction plugin
@@ -5800,6 +5857,7 @@ func (s *Plugins) DeletePrefunctionPlugin(ctx context.Context, request operation
 	}
 
 	return res, nil
+
 }
 
 // GetPrefunctionPlugin - Get a PreFunction plugin
@@ -5902,6 +5960,7 @@ func (s *Plugins) GetPrefunctionPlugin(ctx context.Context, request operations.G
 	}
 
 	return res, nil
+
 }
 
 // UpdatePrefunctionPlugin - Update a PreFunction plugin
@@ -6009,6 +6068,7 @@ func (s *Plugins) UpdatePrefunctionPlugin(ctx context.Context, request operation
 	}
 
 	return res, nil
+
 }
 
 // DeletePrometheusPlugin - Delete a Prometheus plugin
@@ -6099,6 +6159,7 @@ func (s *Plugins) DeletePrometheusPlugin(ctx context.Context, request operations
 	}
 
 	return res, nil
+
 }
 
 // GetPrometheusPlugin - Get a Prometheus plugin
@@ -6201,6 +6262,7 @@ func (s *Plugins) GetPrometheusPlugin(ctx context.Context, request operations.Ge
 	}
 
 	return res, nil
+
 }
 
 // UpdatePrometheusPlugin - Update a Prometheus plugin
@@ -6308,6 +6370,7 @@ func (s *Plugins) UpdatePrometheusPlugin(ctx context.Context, request operations
 	}
 
 	return res, nil
+
 }
 
 // DeleteProxycachePlugin - Delete a ProxyCache plugin
@@ -6398,6 +6461,7 @@ func (s *Plugins) DeleteProxycachePlugin(ctx context.Context, request operations
 	}
 
 	return res, nil
+
 }
 
 // GetProxycachePlugin - Get a ProxyCache plugin
@@ -6500,6 +6564,7 @@ func (s *Plugins) GetProxycachePlugin(ctx context.Context, request operations.Ge
 	}
 
 	return res, nil
+
 }
 
 // UpdateProxycachePlugin - Update a ProxyCache plugin
@@ -6607,6 +6672,7 @@ func (s *Plugins) UpdateProxycachePlugin(ctx context.Context, request operations
 	}
 
 	return res, nil
+
 }
 
 // DeleteRatelimitingPlugin - Delete a RateLimiting plugin
@@ -6697,6 +6763,7 @@ func (s *Plugins) DeleteRatelimitingPlugin(ctx context.Context, request operatio
 	}
 
 	return res, nil
+
 }
 
 // GetRatelimitingPlugin - Get a RateLimiting plugin
@@ -6799,6 +6866,7 @@ func (s *Plugins) GetRatelimitingPlugin(ctx context.Context, request operations.
 	}
 
 	return res, nil
+
 }
 
 // UpdateRatelimitingPlugin - Update a RateLimiting plugin
@@ -6906,6 +6974,7 @@ func (s *Plugins) UpdateRatelimitingPlugin(ctx context.Context, request operatio
 	}
 
 	return res, nil
+
 }
 
 // DeleteRatelimitingadvancedPlugin - Delete a RateLimitingAdvanced plugin
@@ -6996,6 +7065,7 @@ func (s *Plugins) DeleteRatelimitingadvancedPlugin(ctx context.Context, request 
 	}
 
 	return res, nil
+
 }
 
 // GetRatelimitingadvancedPlugin - Get a RateLimitingAdvanced plugin
@@ -7098,6 +7168,7 @@ func (s *Plugins) GetRatelimitingadvancedPlugin(ctx context.Context, request ope
 	}
 
 	return res, nil
+
 }
 
 // UpdateRatelimitingadvancedPlugin - Update a RateLimitingAdvanced plugin
@@ -7205,6 +7276,7 @@ func (s *Plugins) UpdateRatelimitingadvancedPlugin(ctx context.Context, request 
 	}
 
 	return res, nil
+
 }
 
 // DeleteRequestterminationPlugin - Delete a RequestTermination plugin
@@ -7295,6 +7367,7 @@ func (s *Plugins) DeleteRequestterminationPlugin(ctx context.Context, request op
 	}
 
 	return res, nil
+
 }
 
 // GetRequestterminationPlugin - Get a RequestTermination plugin
@@ -7397,6 +7470,7 @@ func (s *Plugins) GetRequestterminationPlugin(ctx context.Context, request opera
 	}
 
 	return res, nil
+
 }
 
 // UpdateRequestterminationPlugin - Update a RequestTermination plugin
@@ -7504,6 +7578,7 @@ func (s *Plugins) UpdateRequestterminationPlugin(ctx context.Context, request op
 	}
 
 	return res, nil
+
 }
 
 // DeleteRequesttransformerPlugin - Delete a RequestTransformer plugin
@@ -7594,6 +7669,7 @@ func (s *Plugins) DeleteRequesttransformerPlugin(ctx context.Context, request op
 	}
 
 	return res, nil
+
 }
 
 // GetRequesttransformerPlugin - Get a RequestTransformer plugin
@@ -7696,6 +7772,7 @@ func (s *Plugins) GetRequesttransformerPlugin(ctx context.Context, request opera
 	}
 
 	return res, nil
+
 }
 
 // UpdateRequesttransformerPlugin - Update a RequestTransformer plugin
@@ -7803,6 +7880,7 @@ func (s *Plugins) UpdateRequesttransformerPlugin(ctx context.Context, request op
 	}
 
 	return res, nil
+
 }
 
 // DeleteRequesttransformeradvancedPlugin - Delete a RequestTransformerAdvanced plugin
@@ -7893,6 +7971,7 @@ func (s *Plugins) DeleteRequesttransformeradvancedPlugin(ctx context.Context, re
 	}
 
 	return res, nil
+
 }
 
 // GetRequesttransformeradvancedPlugin - Get a RequestTransformerAdvanced plugin
@@ -7995,6 +8074,7 @@ func (s *Plugins) GetRequesttransformeradvancedPlugin(ctx context.Context, reque
 	}
 
 	return res, nil
+
 }
 
 // UpdateRequesttransformeradvancedPlugin - Update a RequestTransformerAdvanced plugin
@@ -8102,6 +8182,7 @@ func (s *Plugins) UpdateRequesttransformeradvancedPlugin(ctx context.Context, re
 	}
 
 	return res, nil
+
 }
 
 // DeleteResponsetransformerPlugin - Delete a ResponseTransformer plugin
@@ -8192,6 +8273,7 @@ func (s *Plugins) DeleteResponsetransformerPlugin(ctx context.Context, request o
 	}
 
 	return res, nil
+
 }
 
 // GetResponsetransformerPlugin - Get a ResponseTransformer plugin
@@ -8294,6 +8376,7 @@ func (s *Plugins) GetResponsetransformerPlugin(ctx context.Context, request oper
 	}
 
 	return res, nil
+
 }
 
 // UpdateResponsetransformerPlugin - Update a ResponseTransformer plugin
@@ -8401,6 +8484,7 @@ func (s *Plugins) UpdateResponsetransformerPlugin(ctx context.Context, request o
 	}
 
 	return res, nil
+
 }
 
 // DeleteResponsetransformeradvancedPlugin - Delete a ResponseTransformerAdvanced plugin
@@ -8491,6 +8575,7 @@ func (s *Plugins) DeleteResponsetransformeradvancedPlugin(ctx context.Context, r
 	}
 
 	return res, nil
+
 }
 
 // GetResponsetransformeradvancedPlugin - Get a ResponseTransformerAdvanced plugin
@@ -8593,6 +8678,7 @@ func (s *Plugins) GetResponsetransformeradvancedPlugin(ctx context.Context, requ
 	}
 
 	return res, nil
+
 }
 
 // UpdateResponsetransformeradvancedPlugin - Update a ResponseTransformerAdvanced plugin
@@ -8700,6 +8786,7 @@ func (s *Plugins) UpdateResponsetransformeradvancedPlugin(ctx context.Context, r
 	}
 
 	return res, nil
+
 }
 
 // DeleteSamlPlugin - Delete a Saml plugin
@@ -8790,6 +8877,7 @@ func (s *Plugins) DeleteSamlPlugin(ctx context.Context, request operations.Delet
 	}
 
 	return res, nil
+
 }
 
 // GetSamlPlugin - Get a Saml plugin
@@ -8892,6 +8980,7 @@ func (s *Plugins) GetSamlPlugin(ctx context.Context, request operations.GetSamlP
 	}
 
 	return res, nil
+
 }
 
 // UpdateSamlPlugin - Update a Saml plugin
@@ -8999,6 +9088,7 @@ func (s *Plugins) UpdateSamlPlugin(ctx context.Context, request operations.Updat
 	}
 
 	return res, nil
+
 }
 
 // CreateACLPlugin - Create a ACL plugin
@@ -9106,6 +9196,7 @@ func (s *Plugins) CreateACLPlugin(ctx context.Context, request operations.Create
 	}
 
 	return res, nil
+
 }
 
 // CreateAipromptdecoratorPlugin - Create a AIPromptDecorator plugin
@@ -9213,6 +9304,7 @@ func (s *Plugins) CreateAipromptdecoratorPlugin(ctx context.Context, request ope
 	}
 
 	return res, nil
+
 }
 
 // CreateAipromptguardPlugin - Create a AIPromptGuard plugin
@@ -9320,6 +9412,7 @@ func (s *Plugins) CreateAipromptguardPlugin(ctx context.Context, request operati
 	}
 
 	return res, nil
+
 }
 
 // CreateAiprompttemplatePlugin - Create a AIPromptTemplate plugin
@@ -9427,6 +9520,7 @@ func (s *Plugins) CreateAiprompttemplatePlugin(ctx context.Context, request oper
 	}
 
 	return res, nil
+
 }
 
 // CreateAiproxyPlugin - Create a AIProxy plugin
@@ -9534,6 +9628,7 @@ func (s *Plugins) CreateAiproxyPlugin(ctx context.Context, request operations.Cr
 	}
 
 	return res, nil
+
 }
 
 // CreateAwslambdaPlugin - Create a AWSLambda plugin
@@ -9641,6 +9736,7 @@ func (s *Plugins) CreateAwslambdaPlugin(ctx context.Context, request operations.
 	}
 
 	return res, nil
+
 }
 
 // CreateBasicauthPlugin - Create a BasicAuth plugin
@@ -9748,6 +9844,7 @@ func (s *Plugins) CreateBasicauthPlugin(ctx context.Context, request operations.
 	}
 
 	return res, nil
+
 }
 
 // CreateCorrelationidPlugin - Create a CorrelationId plugin
@@ -9855,6 +9952,7 @@ func (s *Plugins) CreateCorrelationidPlugin(ctx context.Context, request operati
 	}
 
 	return res, nil
+
 }
 
 // CreateCorsPlugin - Create a CORS plugin
@@ -9962,6 +10060,7 @@ func (s *Plugins) CreateCorsPlugin(ctx context.Context, request operations.Creat
 	}
 
 	return res, nil
+
 }
 
 // CreateFilelogPlugin - Create a FileLog plugin
@@ -10069,6 +10168,7 @@ func (s *Plugins) CreateFilelogPlugin(ctx context.Context, request operations.Cr
 	}
 
 	return res, nil
+
 }
 
 // CreateIprestrictionPlugin - Create a IpRestriction plugin
@@ -10176,6 +10276,7 @@ func (s *Plugins) CreateIprestrictionPlugin(ctx context.Context, request operati
 	}
 
 	return res, nil
+
 }
 
 // CreateJqPlugin - Create a JQ plugin
@@ -10283,6 +10384,7 @@ func (s *Plugins) CreateJqPlugin(ctx context.Context, request operations.CreateJ
 	}
 
 	return res, nil
+
 }
 
 // CreateJwtPlugin - Create a JWT plugin
@@ -10390,6 +10492,7 @@ func (s *Plugins) CreateJwtPlugin(ctx context.Context, request operations.Create
 	}
 
 	return res, nil
+
 }
 
 // CreateJwtsignerPlugin - Create a JWTSigner plugin
@@ -10497,6 +10600,7 @@ func (s *Plugins) CreateJwtsignerPlugin(ctx context.Context, request operations.
 	}
 
 	return res, nil
+
 }
 
 // CreateKeyauthPlugin - Create a KeyAuth plugin
@@ -10604,6 +10708,7 @@ func (s *Plugins) CreateKeyauthPlugin(ctx context.Context, request operations.Cr
 	}
 
 	return res, nil
+
 }
 
 // CreateOauth2Plugin - Create a Oauth2 plugin
@@ -10711,6 +10816,7 @@ func (s *Plugins) CreateOauth2Plugin(ctx context.Context, request operations.Cre
 	}
 
 	return res, nil
+
 }
 
 // CreateOpenidconnectPlugin - Create a OpenidConnect plugin
@@ -10818,6 +10924,7 @@ func (s *Plugins) CreateOpenidconnectPlugin(ctx context.Context, request operati
 	}
 
 	return res, nil
+
 }
 
 // CreateOpentelemetryPlugin - Create a Opentelemetry plugin
@@ -10925,6 +11032,7 @@ func (s *Plugins) CreateOpentelemetryPlugin(ctx context.Context, request operati
 	}
 
 	return res, nil
+
 }
 
 // CreatePrefunctionPlugin - Create a PreFunction plugin
@@ -11032,6 +11140,7 @@ func (s *Plugins) CreatePrefunctionPlugin(ctx context.Context, request operation
 	}
 
 	return res, nil
+
 }
 
 // CreatePrometheusPlugin - Create a Prometheus plugin
@@ -11139,6 +11248,7 @@ func (s *Plugins) CreatePrometheusPlugin(ctx context.Context, request operations
 	}
 
 	return res, nil
+
 }
 
 // CreateProxycachePlugin - Create a ProxyCache plugin
@@ -11246,6 +11356,7 @@ func (s *Plugins) CreateProxycachePlugin(ctx context.Context, request operations
 	}
 
 	return res, nil
+
 }
 
 // CreateRatelimitingPlugin - Create a RateLimiting plugin
@@ -11353,6 +11464,7 @@ func (s *Plugins) CreateRatelimitingPlugin(ctx context.Context, request operatio
 	}
 
 	return res, nil
+
 }
 
 // CreateRatelimitingadvancedPlugin - Create a RateLimitingAdvanced plugin
@@ -11460,6 +11572,7 @@ func (s *Plugins) CreateRatelimitingadvancedPlugin(ctx context.Context, request 
 	}
 
 	return res, nil
+
 }
 
 // CreateRequestterminationPlugin - Create a RequestTermination plugin
@@ -11567,6 +11680,7 @@ func (s *Plugins) CreateRequestterminationPlugin(ctx context.Context, request op
 	}
 
 	return res, nil
+
 }
 
 // CreateRequesttransformerPlugin - Create a RequestTransformer plugin
@@ -11674,6 +11788,7 @@ func (s *Plugins) CreateRequesttransformerPlugin(ctx context.Context, request op
 	}
 
 	return res, nil
+
 }
 
 // CreateRequesttransformeradvancedPlugin - Create a RequestTransformerAdvanced plugin
@@ -11781,6 +11896,7 @@ func (s *Plugins) CreateRequesttransformeradvancedPlugin(ctx context.Context, re
 	}
 
 	return res, nil
+
 }
 
 // CreateResponsetransformerPlugin - Create a ResponseTransformer plugin
@@ -11888,6 +12004,7 @@ func (s *Plugins) CreateResponsetransformerPlugin(ctx context.Context, request o
 	}
 
 	return res, nil
+
 }
 
 // CreateResponsetransformeradvancedPlugin - Create a ResponseTransformerAdvanced plugin
@@ -11995,6 +12112,7 @@ func (s *Plugins) CreateResponsetransformeradvancedPlugin(ctx context.Context, r
 	}
 
 	return res, nil
+
 }
 
 // CreateSamlPlugin - Create a Saml plugin
@@ -12102,4 +12220,5 @@ func (s *Plugins) CreateSamlPlugin(ctx context.Context, request operations.Creat
 	}
 
 	return res, nil
+
 }

--- a/internal/sdk/portalauthsettings.go
+++ b/internal/sdk/portalauthsettings.go
@@ -140,6 +140,7 @@ func (s *PortalAuthSettings) GetPortalAuthenticationSettings(ctx context.Context
 	}
 
 	return res, nil
+
 }
 
 // UpdatePortalAuthenticationSettings - Update Auth Settings
@@ -286,4 +287,5 @@ func (s *PortalAuthSettings) UpdatePortalAuthenticationSettings(ctx context.Cont
 	}
 
 	return res, nil
+
 }

--- a/internal/sdk/portalproductversions.go
+++ b/internal/sdk/portalproductversions.go
@@ -181,6 +181,7 @@ func (s *PortalProductVersions) GetPortalProductVersion(ctx context.Context, req
 	}
 
 	return res, nil
+
 }
 
 // ReplacePortalProductVersion - Replace a portal product version
@@ -339,6 +340,7 @@ func (s *PortalProductVersions) ReplacePortalProductVersion(ctx context.Context,
 	}
 
 	return res, nil
+
 }
 
 // DeletePortalProductVersion - Delete a portal product version
@@ -453,4 +455,5 @@ func (s *PortalProductVersions) DeletePortalProductVersion(ctx context.Context, 
 	}
 
 	return res, nil
+
 }

--- a/internal/sdk/portals.go
+++ b/internal/sdk/portals.go
@@ -169,6 +169,7 @@ func (s *Portals) ListPortals(ctx context.Context, request operations.ListPortal
 	}
 
 	return res, nil
+
 }
 
 // UpdatePortal - Update Portal
@@ -339,4 +340,5 @@ func (s *Portals) UpdatePortal(ctx context.Context, request operations.UpdatePor
 	}
 
 	return res, nil
+
 }

--- a/internal/sdk/provideraccounts.go
+++ b/internal/sdk/provideraccounts.go
@@ -168,4 +168,5 @@ func (s *ProviderAccounts) ListProviderAccounts(ctx context.Context, request ope
 	}
 
 	return res, nil
+
 }

--- a/internal/sdk/routes.go
+++ b/internal/sdk/routes.go
@@ -154,6 +154,7 @@ func (s *Routes) CreateRoute(ctx context.Context, request operations.CreateRoute
 	}
 
 	return res, nil
+
 }
 
 // DeleteRoute - Delete a Route
@@ -244,6 +245,7 @@ func (s *Routes) DeleteRoute(ctx context.Context, request operations.DeleteRoute
 	}
 
 	return res, nil
+
 }
 
 // GetRoute - Fetch a Route
@@ -346,4 +348,5 @@ func (s *Routes) GetRoute(ctx context.Context, request operations.GetRouteReques
 	}
 
 	return res, nil
+
 }

--- a/internal/sdk/services.go
+++ b/internal/sdk/services.go
@@ -137,6 +137,7 @@ func (s *Services) CreateService(ctx context.Context, request operations.CreateS
 	}
 
 	return res, nil
+
 }
 
 // DeleteService - Delete a Service
@@ -227,6 +228,7 @@ func (s *Services) DeleteService(ctx context.Context, request operations.DeleteS
 	}
 
 	return res, nil
+
 }
 
 // GetService - Fetch a Service
@@ -329,4 +331,5 @@ func (s *Services) GetService(ctx context.Context, request operations.GetService
 	}
 
 	return res, nil
+
 }

--- a/internal/sdk/snis.go
+++ b/internal/sdk/snis.go
@@ -133,6 +133,7 @@ func (s *SNIs) CreateSni(ctx context.Context, request operations.CreateSniReques
 	}
 
 	return res, nil
+
 }
 
 // DeleteSni - Delete an SNI
@@ -223,6 +224,7 @@ func (s *SNIs) DeleteSni(ctx context.Context, request operations.DeleteSniReques
 	}
 
 	return res, nil
+
 }
 
 // GetSni - Fetch an SNI
@@ -325,4 +327,5 @@ func (s *SNIs) GetSni(ctx context.Context, request operations.GetSniRequest) (*o
 	}
 
 	return res, nil
+
 }

--- a/internal/sdk/systemaccounts.go
+++ b/internal/sdk/systemaccounts.go
@@ -160,6 +160,7 @@ func (s *SystemAccounts) PostSystemAccounts(ctx context.Context, request *shared
 	}
 
 	return res, nil
+
 }
 
 // GetSystemAccountsID - Fetch System Account
@@ -290,6 +291,7 @@ func (s *SystemAccounts) GetSystemAccountsID(ctx context.Context, request operat
 	}
 
 	return res, nil
+
 }
 
 // PatchSystemAccountsID - Update System Account
@@ -438,6 +440,7 @@ func (s *SystemAccounts) PatchSystemAccountsID(ctx context.Context, request oper
 	}
 
 	return res, nil
+
 }
 
 // DeleteSystemAccountsID - Delete System Account
@@ -542,4 +545,5 @@ func (s *SystemAccounts) DeleteSystemAccountsID(ctx context.Context, request ope
 	}
 
 	return res, nil
+
 }

--- a/internal/sdk/systemaccountsaccesstokens.go
+++ b/internal/sdk/systemaccountsaccesstokens.go
@@ -171,6 +171,7 @@ func (s *SystemAccountsAccessTokens) PostSystemAccountsIDAccessTokens(ctx contex
 	}
 
 	return res, nil
+
 }
 
 // GetSystemAccountsIDAccessTokensID - Fetch System Account Access Token
@@ -301,6 +302,7 @@ func (s *SystemAccountsAccessTokens) GetSystemAccountsIDAccessTokensID(ctx conte
 	}
 
 	return res, nil
+
 }
 
 // PatchSystemAccountsIDAccessTokensID - Update System Account Access Token
@@ -449,6 +451,7 @@ func (s *SystemAccountsAccessTokens) PatchSystemAccountsIDAccessTokensID(ctx con
 	}
 
 	return res, nil
+
 }
 
 // DeleteSystemAccountsIDAccessTokensID - Delete System Account Access Token
@@ -553,4 +556,5 @@ func (s *SystemAccountsAccessTokens) DeleteSystemAccountsIDAccessTokensID(ctx co
 	}
 
 	return res, nil
+
 }

--- a/internal/sdk/systemaccountsroles.go
+++ b/internal/sdk/systemaccountsroles.go
@@ -171,6 +171,7 @@ func (s *SystemAccountsRoles) PostSystemAccountsAccountIDAssignedRoles(ctx conte
 	}
 
 	return res, nil
+
 }
 
 // DeleteSystemAccountsAccountIDAssignedRolesRoleID - Delete Assigned Role from System Account
@@ -275,4 +276,5 @@ func (s *SystemAccountsRoles) DeleteSystemAccountsAccountIDAssignedRolesRoleID(c
 	}
 
 	return res, nil
+
 }

--- a/internal/sdk/systemaccountsteammembership.go
+++ b/internal/sdk/systemaccountsteammembership.go
@@ -145,6 +145,7 @@ func (s *SystemAccountsTeamMembership) PostTeamsTeamIDSystemAccounts(ctx context
 	}
 
 	return res, nil
+
 }
 
 // DeleteTeamsTeamIDSystemAccountsAccountID - Remove System Account From Team
@@ -249,4 +250,5 @@ func (s *SystemAccountsTeamMembership) DeleteTeamsTeamIDSystemAccountsAccountID(
 	}
 
 	return res, nil
+
 }

--- a/internal/sdk/targets.go
+++ b/internal/sdk/targets.go
@@ -118,6 +118,7 @@ func (s *Targets) CreateTargetWithUpstream(ctx context.Context, request operatio
 	}
 
 	return res, nil
+
 }
 
 // DeleteTargetWithUpstream - Delete a a Target associated with a an Upstream
@@ -196,6 +197,7 @@ func (s *Targets) DeleteTargetWithUpstream(ctx context.Context, request operatio
 	}
 
 	return res, nil
+
 }
 
 // GetTargetWithUpstream - Fetch a Target associated with an Upstream
@@ -286,4 +288,5 @@ func (s *Targets) GetTargetWithUpstream(ctx context.Context, request operations.
 	}
 
 	return res, nil
+
 }

--- a/internal/sdk/transitgateways.go
+++ b/internal/sdk/transitgateways.go
@@ -225,6 +225,7 @@ func (s *TransitGateways) CreateTransitGateway(ctx context.Context, request oper
 	}
 
 	return res, nil
+
 }
 
 // GetTransitGateway - Get Transit Gateway
@@ -365,6 +366,7 @@ func (s *TransitGateways) GetTransitGateway(ctx context.Context, request operati
 	}
 
 	return res, nil
+
 }
 
 // DeleteTransitGateway - Delete Transit Gateway
@@ -531,4 +533,5 @@ func (s *TransitGateways) DeleteTransitGateway(ctx context.Context, request oper
 	}
 
 	return res, nil
+
 }

--- a/internal/sdk/upstreams.go
+++ b/internal/sdk/upstreams.go
@@ -134,6 +134,7 @@ func (s *Upstreams) CreateUpstream(ctx context.Context, request operations.Creat
 	}
 
 	return res, nil
+
 }
 
 // DeleteUpstream - Delete an Upstream
@@ -224,6 +225,7 @@ func (s *Upstreams) DeleteUpstream(ctx context.Context, request operations.Delet
 	}
 
 	return res, nil
+
 }
 
 // GetUpstream - Fetch an Upstream
@@ -326,4 +328,5 @@ func (s *Upstreams) GetUpstream(ctx context.Context, request operations.GetUpstr
 	}
 
 	return res, nil
+
 }

--- a/internal/sdk/vaults.go
+++ b/internal/sdk/vaults.go
@@ -137,6 +137,7 @@ func (s *Vaults) CreateVault(ctx context.Context, request operations.CreateVault
 	}
 
 	return res, nil
+
 }
 
 // DeleteVault - Delete a Vault
@@ -227,6 +228,7 @@ func (s *Vaults) DeleteVault(ctx context.Context, request operations.DeleteVault
 	}
 
 	return res, nil
+
 }
 
 // GetVault - Fetch a Vault
@@ -329,4 +331,5 @@ func (s *Vaults) GetVault(ctx context.Context, request operations.GetVaultReques
 	}
 
 	return res, nil
+
 }


### PR DESCRIPTION
Allow users to set provider attributes via environment variables

* `personal_access_token` = `KONNECT_TOKEN`
* `system_account_access_token` = `KONNECT_SPAT`
* `server_url` = `KONNECT_SERVER_URL`