### PR TITLE
Manually bump version to update gen.yaml environment variables

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -5,8 +5,8 @@ management:
   docVersion: 2.0.0
   speakeasyVersion: 1.299.4
   generationVersion: 2.338.7
-  releaseVersion: 0.2.4
-  configChecksum: 0d4108667c33961683e0a696aa82c808
+  releaseVersion: 0.2.5
+  configChecksum: 8d4c1fe1abb4fe9a1534e68b330900ed
 features:
   terraform:
     additionalDependencies: 0.1.0

--- a/gen.yaml
+++ b/gen.yaml
@@ -13,13 +13,19 @@ generation:
     oAuth2ClientCredentialsEnabled: false
   baseServerURL: ""
 terraform:
-  version: 0.2.4
+  version: 0.2.5
   additionalDataSources: []
   additionalDependencies: {}
   additionalResources: []
   allowUnknownFieldsInWeakUnions: false
   author: kong
-  environmentVariables: []
+  environmentVariables:
+    - env: KONNECT_TOKEN
+      providerAttribute: personal_access_token
+    - env: KONNECT_SPAT
+      providerAttribute: system_account_access_token
+    - env: KONNECT_SERVER_URL
+      providerAttribute: server_url
   imports:
     option: openapi
     paths:

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -12,6 +12,7 @@ import (
 	"github.com/kong/terraform-provider-konnect/internal/sdk"
 	"github.com/kong/terraform-provider-konnect/internal/sdk/models/shared"
 	"net/http"
+	"os"
 )
 
 var _ provider.Provider = &KonnectProvider{}
@@ -72,6 +73,9 @@ func (p *KonnectProvider) Configure(ctx context.Context, req provider.ConfigureR
 
 	ServerURL := data.ServerURL.ValueString()
 
+	if ServerURL == "" && len(os.Getenv("KONNECT_SERVER_URL")) > 0 {
+		ServerURL = os.Getenv("KONNECT_SERVER_URL")
+	}
 	if ServerURL == "" {
 		ServerURL = "https://global.api.konghq.com"
 	}
@@ -80,13 +84,21 @@ func (p *KonnectProvider) Configure(ctx context.Context, req provider.ConfigureR
 	if !data.PersonalAccessToken.IsUnknown() && !data.PersonalAccessToken.IsNull() {
 		*personalAccessToken = data.PersonalAccessToken.ValueString()
 	} else {
-		personalAccessToken = nil
+		if len(os.Getenv("KONNECT_TOKEN")) > 0 {
+			*personalAccessToken = os.Getenv("KONNECT_TOKEN")
+		} else {
+			personalAccessToken = nil
+		}
 	}
 	systemAccountAccessToken := new(string)
 	if !data.SystemAccountAccessToken.IsUnknown() && !data.SystemAccountAccessToken.IsNull() {
 		*systemAccountAccessToken = data.SystemAccountAccessToken.ValueString()
 	} else {
-		systemAccountAccessToken = nil
+		if len(os.Getenv("KONNECT_SPAT")) > 0 {
+			*systemAccountAccessToken = os.Getenv("KONNECT_SPAT")
+		} else {
+			systemAccountAccessToken = nil
+		}
 	}
 	konnectAccessToken := new(string)
 	if !data.KonnectAccessToken.IsUnknown() && !data.KonnectAccessToken.IsNull() {


### PR DESCRIPTION
Allow users to set provider attributes via environment variables

* `personal_access_token` = `KONNECT_TOKEN`
* `system_account_access_token` = `KONNECT_SPAT`
* `server_url` = `KONNECT_SERVER_URL`