### PR TITLE
Move global endpoint servers to per-operation server block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 ### Features
 * Add support for the `konnect_api_product_specification`, `konnect_gateway_custom_plugin_schema`, `konnect_team`, `konnect_team_role` and `konnect_team_user` resources
 
+### Bug Fixes
+* Make Cloud Gateways + Identity APIs point at `global.api.konghq.com` rather than the provided `server_url`
+
 ## 0.3.1
 > Released on 2024/06/14
 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -581,6 +581,8 @@ paths:
           $ref: '#/components/responses/CloudGatewaysConflict'
       tags:
         - Data-Plane Group Configurations
+      servers:
+        - url: https://global.api.konghq.com/
   /v2/cloud-gateways/configurations/{configurationId}:
     get:
       x-speakeasy-entity-operation: CloudGatewayConfiguration#get
@@ -602,6 +604,8 @@ paths:
           $ref: '#/components/responses/NotFound'
       tags:
         - Data-Plane Group Configurations
+      servers:
+        - url: https://global.api.konghq.com/
   /v2/cloud-gateways/custom-domains:
     post:
       x-speakeasy-entity-operation: CloudGatewayCustomDomain#create
@@ -633,6 +637,8 @@ paths:
           $ref: '#/components/responses/Conflict'
       tags:
         - Custom Domains
+      servers:
+        - url: https://global.api.konghq.com/
   /v2/cloud-gateways/custom-domains/{customDomainId}:
     get:
       x-speakeasy-entity-operation: CloudGatewayCustomDomain#read
@@ -654,6 +660,8 @@ paths:
           $ref: '#/components/responses/NotFound'
       tags:
         - Custom Domains
+      servers:
+        - url: https://global.api.konghq.com/
     delete:
       x-speakeasy-entity-operation: CloudGatewayCustomDomain#delete
       x-speakeasy-retries:
@@ -686,6 +694,8 @@ paths:
           $ref: '#/components/responses/NotFound'
       tags:
         - Custom Domains
+      servers:
+        - url: https://global.api.konghq.com/
   /v2/cloud-gateways/networks:
     post:
       x-speakeasy-entity-operation: CloudGatewayNetwork#create
@@ -711,6 +721,8 @@ paths:
           $ref: '#/components/responses/Conflict'
       tags:
         - Networks
+      servers:
+        - url: https://global.api.konghq.com/
   /v2/cloud-gateways/networks/{networkId}:
     get:
       x-speakeasy-entity-operation: CloudGatewayNetwork#read
@@ -730,6 +742,8 @@ paths:
           $ref: '#/components/responses/NotFound'
       tags:
         - Networks
+      servers:
+        - url: https://global.api.konghq.com/
     patch:
       x-speakeasy-entity-operation: CloudGatewayNetwork#update
       summary: Update Network
@@ -758,6 +772,8 @@ paths:
           $ref: '#/components/responses/Conflict'
       tags:
         - Networks
+      servers:
+        - url: https://global.api.konghq.com/
     delete:
       x-speakeasy-entity-operation: CloudGatewayNetwork#delete
       x-speakeasy-retries:
@@ -788,6 +804,8 @@ paths:
           $ref: '#/components/responses/NotFound'
       tags:
         - Networks
+      servers:
+        - url: https://global.api.konghq.com/
   /v2/cloud-gateways/networks/{networkId}/transit-gateways:
     post:
       x-speakeasy-entity-operation: CloudGatewayTransitGateway#create
@@ -832,6 +850,8 @@ paths:
           $ref: '#/components/responses/Conflict'
       tags:
         - Transit Gateways
+      servers:
+        - url: https://global.api.konghq.com/
   /v2/cloud-gateways/networks/{networkId}/transit-gateways/{transitGatewayId}:
     get:
       x-speakeasy-entity-operation: CloudGatewayTransitGateway#read
@@ -857,6 +877,8 @@ paths:
           $ref: '#/components/responses/NotFound'
       tags:
         - Transit Gateways
+      servers:
+        - url: https://global.api.konghq.com/
     delete:
       x-speakeasy-entity-operation: CloudGatewayTransitGateway#delete
       x-speakeasy-retries:
@@ -893,6 +915,8 @@ paths:
           $ref: '#/components/responses/NotFound'
       tags:
         - Transit Gateways
+      servers:
+        - url: https://global.api.konghq.com/
   /v2/cloud-gateways/provider-accounts:
     get:
       x-speakeasy-entity-operation: CloudGatewayProviderAccountList#read
@@ -915,6 +939,8 @@ paths:
           $ref: '#/components/responses/Forbidden'
       tags:
         - Provider Accounts
+      servers:
+        - url: https://global.api.konghq.com/
   /v2/control-planes:
     parameters: []
     post:
@@ -4758,6 +4784,8 @@ paths:
           $ref: '#/components/responses/Unauthorized'
         '409':
           $ref: '#/components/responses/IdentityConflict'
+      servers:
+        - url: https://global.api.konghq.com/
   /v3/system-accounts/{accountId}:
     get:
       x-speakeasy-entity-operation: SystemAccount#read
@@ -4777,6 +4805,8 @@ paths:
       description: >-
         Returns the system account (SA) for the SA ID specified as a path
         parameter.
+      servers:
+        - url: https://global.api.konghq.com/
     parameters:
       - schema:
           type: string
@@ -4807,6 +4837,8 @@ paths:
         - System Accounts
       requestBody:
         $ref: '#/components/requestBodies/UpdateSystemAccount'
+      servers:
+        - url: https://global.api.konghq.com/
     delete:
       x-speakeasy-entity-operation: SystemAccount#delete
       summary: Delete System Account
@@ -4825,6 +4857,8 @@ paths:
         account was not found.
       tags:
         - System Accounts
+      servers:
+        - url: https://global.api.konghq.com/
   /v3/system-accounts/{accountId}/access-tokens:
     parameters:
       - schema:
@@ -4857,6 +4891,8 @@ paths:
         $ref: '#/components/requestBodies/CreateSystemAccountAccessToken'
       tags:
         - System Accounts - Access Tokens
+      servers:
+        - url: https://global.api.konghq.com/
   /v3/system-accounts/{accountId}/access-tokens/{tokenId}:
     get:
       x-speakeasy-entity-operation: SystemAccountAccessToken#read
@@ -4877,6 +4913,8 @@ paths:
       parameters: []
       tags:
         - System Accounts - Access Tokens
+      servers:
+        - url: https://global.api.konghq.com/
     parameters:
       - schema:
           type: string
@@ -4913,6 +4951,8 @@ paths:
         $ref: '#/components/requestBodies/UpdateSystemAccountAccessToken'
       tags:
         - System Accounts - Access Tokens
+      servers:
+        - url: https://global.api.konghq.com/
     delete:
       x-speakeasy-entity-operation: SystemAccountAccessToken#delete
       summary: Delete System Account Access Token
@@ -4929,6 +4969,8 @@ paths:
       description: Deletes the specified token. Returns 404 if the token was not found.
       tags:
         - System Accounts - Access Tokens
+      servers:
+        - url: https://global.api.konghq.com/
   /v3/system-accounts/{accountId}/assigned-roles:
     parameters:
       - schema:
@@ -4959,6 +5001,8 @@ paths:
         $ref: '#/components/requestBodies/AssignRole'
       tags:
         - System Accounts - Roles
+      servers:
+        - url: https://global.api.konghq.com/
   /v3/system-accounts/{accountId}/assigned-roles/{roleId}:
     parameters:
       - schema:
@@ -4992,6 +5036,8 @@ paths:
         system account or assigned role were not found.
       tags:
         - System Accounts - Roles
+      servers:
+        - url: https://global.api.konghq.com/
   /v3/teams:
     parameters: []
     post:
@@ -5010,6 +5056,8 @@ paths:
       requestBody:
         $ref: '#/components/requestBodies/CreateTeam'
       description: 'Creates a team in the Konnect Organization. '
+      servers:
+        - url: https://global.api.konghq.com/
   /v3/teams/{teamId}:
     parameters:
       - schema:
@@ -5035,6 +5083,8 @@ paths:
       description: Returns information about a team from a given team ID.
       tags:
         - Teams
+      servers:
+        - url: https://global.api.konghq.com/
     patch:
       x-speakeasy-entity-operation: Team#update
       summary: Update Team
@@ -5051,6 +5101,8 @@ paths:
         $ref: '#/components/requestBodies/UpdateTeam'
       tags:
         - Teams
+      servers:
+        - url: https://global.api.konghq.com/
     delete:
       x-speakeasy-entity-operation: Team#delete
       summary: Delete Team
@@ -5065,6 +5117,8 @@ paths:
       description: Deletes an individual team. Returns 404 if the team is not found.
       tags:
         - Teams
+      servers:
+        - url: https://global.api.konghq.com/
   /v3/teams/{teamId}/assigned-roles:
     parameters:
       - schema:
@@ -5097,6 +5151,8 @@ paths:
         $ref: '#/components/requestBodies/AssignRole'
       tags:
         - Roles
+      servers:
+        - url: https://global.api.konghq.com/
   /v3/teams/{teamId}/assigned-roles/{roleId}:
     parameters:
       - schema:
@@ -5136,6 +5192,8 @@ paths:
       description: >-
         Removes an assigned role from a team. Returns 404 if the requested team
         or assigned role were not found.
+      servers:
+        - url: https://global.api.konghq.com/
   /v3/teams/{teamId}/system-accounts:
     parameters:
       - schema:
@@ -5166,6 +5224,8 @@ paths:
         $ref: '#/components/requestBodies/AddSystemAccountToTeam'
       tags:
         - System Accounts - Team Membership
+      servers:
+        - url: https://global.api.konghq.com/
   /v3/teams/{teamId}/system-accounts/{accountId}:
     parameters:
       - schema:
@@ -5198,6 +5258,8 @@ paths:
         account were not found.
       tags:
         - System Accounts - Team Membership
+      servers:
+        - url: https://global.api.konghq.com/
   /v3/teams/{teamId}/users:
     parameters:
       - schema:
@@ -5224,6 +5286,8 @@ paths:
         $ref: '#/components/requestBodies/AddUserToTeam'
       tags:
         - Team Membership
+      servers:
+        - url: https://global.api.konghq.com/
   /v3/teams/{teamId}/users/{userId}:
     parameters:
       - schema:
@@ -5260,6 +5324,8 @@ paths:
         the user or team were not found.
       tags:
         - Team Membership
+      servers:
+        - url: https://global.api.konghq.com/
 components:
   parameters:
     PageSize:


### PR DESCRIPTION
### Bug Fixes
* Make Cloud Gateways + Identity APIs point at `global.api.konghq.com` rather than the provided `server_url`

Resolves #22 