### PR TITLE
chore: migrate to speakeasy workflows

### DIFF
--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -1,0 +1,10 @@
+workflowVersion: 1.0.0
+speakeasyVersion: latest
+sources:
+    kong:
+        inputs:
+            - location: openapi.yaml
+targets:
+    terraform:
+        target: terraform
+        source: kong

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 all: speakeasy
 
 speakeasy: check-speakeasy
-	speakeasy generate sdk --lang terraform -o . -s ./openapi.yaml
+	speakeasy run --skip-versioning --output console
 	@go mod tidy
 	@go generate .
 	@git clean -fd examples docs > /dev/null


### PR DESCRIPTION
The behaviour will be the same, with the exception of a workflow.lock file that will enable us to regression test generator changes against kong's terraform-provider-konnect.