### PR TITLE
Release/2.0.2

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,18 +1,18 @@
 lockVersion: 2.0.0
 id: 9d20c53e-7836-4ea8-88b8-a75fb7dce3a2
 management:
-  docChecksum: 9a531b77d13c807727dc294c3ec22a10
+  docChecksum: eceaafa8f83b81bf1062ee8945d136c9
   docVersion: 2.0.0
-  speakeasyVersion: 1.430.0
-  generationVersion: 2.449.0
-  releaseVersion: 2.0.1
-  configChecksum: 76182f5ba79f472b48e7a7b149668879
+  speakeasyVersion: 1.438.1
+  generationVersion: 2.457.2
+  releaseVersion: 2.0.2
+  configChecksum: d484128879499dd5b31305f5ed0e34c2
 features:
   terraform:
     additionalDependencies: 0.1.0
     additionalProperties: 0.1.2
     constsAndDefaults: 0.2.0
-    core: 3.26.1
+    core: 3.26.2
     deprecations: 2.81.1
     envVarSecurityUsage: 0.1.0
     globalSecurity: 2.81.9

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -2,7 +2,7 @@ speakeasyVersion: 1.438.1
 sources:
     kong:
         sourceNamespace: kong
-        sourceRevisionDigest: sha256:32fb949ec91088e38e0cc140e8dd15f67054ead66317a96f613cd559921ec9ec
+        sourceRevisionDigest: sha256:4b2a1e5f7f47d1f27b29c2e4406f6068b0077d3d21de66023e5179fb980f54d3
         sourceBlobDigest: sha256:624ccae3a9e5df718a94ecc4824d70ba9425f674f20aba1ef42e451a4b831563
         tags:
             - latest
@@ -10,7 +10,7 @@ targets:
     terraform:
         source: kong
         sourceNamespace: kong
-        sourceRevisionDigest: sha256:32fb949ec91088e38e0cc140e8dd15f67054ead66317a96f613cd559921ec9ec
+        sourceRevisionDigest: sha256:4b2a1e5f7f47d1f27b29c2e4406f6068b0077d3d21de66023e5179fb980f54d3
         sourceBlobDigest: sha256:624ccae3a9e5df718a94ecc4824d70ba9425f674f20aba1ef42e451a4b831563
 workflow:
     workflowVersion: 1.0.0

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -1,20 +1,20 @@
-speakeasyVersion: 1.430.0
+speakeasyVersion: 1.438.1
 sources:
     kong:
         sourceNamespace: kong
-        sourceRevisionDigest: sha256:cfa69dcbf62acfcc6611041325238e835c1cfab3096b8507f72475e461fd7034
-        sourceBlobDigest: sha256:42ad154bc63dbacfcca1953464e8b7b9816b4a8388d6de53a36f2b3442fd304d
+        sourceRevisionDigest: sha256:32fb949ec91088e38e0cc140e8dd15f67054ead66317a96f613cd559921ec9ec
+        sourceBlobDigest: sha256:624ccae3a9e5df718a94ecc4824d70ba9425f674f20aba1ef42e451a4b831563
         tags:
             - latest
 targets:
     terraform:
         source: kong
         sourceNamespace: kong
-        sourceRevisionDigest: sha256:cfa69dcbf62acfcc6611041325238e835c1cfab3096b8507f72475e461fd7034
-        sourceBlobDigest: sha256:42ad154bc63dbacfcca1953464e8b7b9816b4a8388d6de53a36f2b3442fd304d
+        sourceRevisionDigest: sha256:32fb949ec91088e38e0cc140e8dd15f67054ead66317a96f613cd559921ec9ec
+        sourceBlobDigest: sha256:624ccae3a9e5df718a94ecc4824d70ba9425f674f20aba1ef42e451a4b831563
 workflow:
     workflowVersion: 1.0.0
-    speakeasyVersion: 1.430.0
+    speakeasyVersion: 1.438.1
     sources:
         kong:
             inputs:

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -1,5 +1,5 @@
 workflowVersion: 1.0.0
-speakeasyVersion: 1.430.0
+speakeasyVersion: 1.438.1
 sources:
     kong:
         inputs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.0.2
+> Released on 2024/11/12
+
+### Bug Fixes
+
+* Removing service, route, consumer etc scope from a plugin now sends `null` to the API, removing the link between the plugin and the resource.
+
 ## 2.0.1
 > Released on 2024/11/11
 

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,6 @@ speakeasy: check-speakeasy
 	@git clean -fd examples docs > /dev/null
 	@git checkout -- README.md examples/README.md
 	@rm USAGE.md
-	@find docs -type f | xargs sed -i 's/"see" : "documentation",/env = "test"/'
 
 FILES=$(shell find internal/provider -type f | grep data_source | grep -v portallist | grep -v cloudgatewayprovideraccountlist)
 remove-data-sources:

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ terraform {
   required_providers {
     konnect = {
       source  = "kong/konnect"
-      version = "2.0.1"
+      version = "2.0.2"
     }
   }
 }

--- a/docs/resources/api_product.md
+++ b/docs/resources/api_product.md
@@ -16,7 +16,7 @@ APIProduct Resource
 resource "konnect_api_product" "my_apiproduct" {
   description = "Text describing the API product"
   labels = {
-    env = "test"
+    key = "value",
   }
   name = "API Product"
   portal_ids = [

--- a/docs/resources/api_product_version.md
+++ b/docs/resources/api_product_version.md
@@ -21,7 +21,7 @@ resource "konnect_api_product_version" "my_apiproductversion" {
     id               = "09b4786a-3e48-4631-8f6b-62d1d8e1a7f3"
   }
   labels = {
-    env = "test"
+    key = "value",
   }
   name = "v1"
 }

--- a/docs/resources/application_auth_strategy.md
+++ b/docs/resources/application_auth_strategy.md
@@ -24,7 +24,7 @@ resource "konnect_application_auth_strategy" "my_applicationauthstrategy" {
     }
     display_name = "...my_display_name..."
     labels = {
-      env = "test"
+      key = "value",
     }
     name          = "...my_name..."
     strategy_type = "key_auth"
@@ -41,7 +41,7 @@ resource "konnect_application_auth_strategy" "my_applicationauthstrategy" {
         ]
         issuer = "...my_issuer..."
         labels = {
-          env = "test"
+          key = "value",
         }
         scopes = [
           "..."
@@ -51,7 +51,7 @@ resource "konnect_application_auth_strategy" "my_applicationauthstrategy" {
     dcr_provider_id = "184e9c55-484e-4f4f-9de7-f6001d8ab0e7"
     display_name    = "...my_display_name..."
     labels = {
-      env = "test"
+      key = "value",
     }
     name          = "...my_name..."
     strategy_type = "openid_connect"

--- a/docs/resources/gateway_control_plane.md
+++ b/docs/resources/gateway_control_plane.md
@@ -19,7 +19,7 @@ resource "konnect_gateway_control_plane" "my_gatewaycontrolplane" {
   cluster_type  = "CLUSTER_TYPE_CONTROL_PLANE"
   description   = "A test control plane for exploration."
   labels = {
-    env = "test"
+    key = "value",
   }
   name = "Test Control Plane"
   proxy_urls = [

--- a/docs/resources/gateway_plugin_acme.md
+++ b/docs/resources/gateway_plugin_acme.md
@@ -44,7 +44,7 @@ resource "konnect_gateway_plugin_acme" "my_gatewaypluginacme" {
         token   = "...my_token..."
       }
       kong = {
-        "see" : jsonencode("documentation"),
+        key = jsonencode("value"),
       }
       redis = {
         database = 6

--- a/docs/resources/gateway_plugin_file_log.md
+++ b/docs/resources/gateway_plugin_file_log.md
@@ -16,7 +16,7 @@ GatewayPluginFileLog Resource
 resource "konnect_gateway_plugin_file_log" "my_gatewaypluginfilelog" {
   config = {
     custom_fields_by_lua = {
-      "see" : jsonencode("documentation"),
+      key = jsonencode("value"),
     }
     path   = "...my_path..."
     reopen = false

--- a/docs/resources/gateway_plugin_http_log.md
+++ b/docs/resources/gateway_plugin_http_log.md
@@ -17,11 +17,11 @@ resource "konnect_gateway_plugin_http_log" "my_gatewaypluginhttplog" {
   config = {
     content_type = "application/json; charset=utf-8"
     custom_fields_by_lua = {
-      "see" : jsonencode("documentation"),
+      key = jsonencode("value"),
     }
     flush_timeout = 8.97
     headers = {
-      "see" : jsonencode("documentation"),
+      key = jsonencode("value"),
     }
     http_endpoint = "...my_http_endpoint..."
     keepalive     = 2.25

--- a/docs/resources/gateway_plugin_jwt_signer.md
+++ b/docs/resources/gateway_plugin_jwt_signer.md
@@ -66,13 +66,13 @@ resource "konnect_gateway_plugin_jwt_signer" "my_gatewaypluginjwtsigner" {
     access_token_upstream_header   = "...my_access_token_upstream_header..."
     access_token_upstream_leeway   = 1.88
     add_access_token_claims = {
-      "see" : jsonencode("documentation"),
+      key = jsonencode("value"),
     }
     add_channel_token_claims = {
-      "see" : jsonencode("documentation"),
+      key = jsonencode("value"),
     }
     add_claims = {
-      "see" : jsonencode("documentation"),
+      key = jsonencode("value"),
     }
     cache_access_token_introspection  = false
     cache_channel_token_introspection = true
@@ -140,13 +140,13 @@ resource "konnect_gateway_plugin_jwt_signer" "my_gatewaypluginjwtsigner" {
       "..."
     ]
     set_access_token_claims = {
-      "see" : jsonencode("documentation"),
+      key = jsonencode("value"),
     }
     set_channel_token_claims = {
-      "see" : jsonencode("documentation"),
+      key = jsonencode("value"),
     }
     set_claims = {
-      "see" : jsonencode("documentation"),
+      key = jsonencode("value"),
     }
     trust_access_token_introspection          = true
     trust_channel_token_introspection         = false

--- a/docs/resources/gateway_plugin_kafka_log.md
+++ b/docs/resources/gateway_plugin_kafka_log.md
@@ -30,7 +30,7 @@ resource "konnect_gateway_plugin_kafka_log" "my_gatewaypluginkafkalog" {
     ]
     cluster_name = "...my_cluster_name..."
     custom_fields_by_lua = {
-      "see" : jsonencode("documentation"),
+      key = jsonencode("value"),
     }
     keepalive                                          = 2
     keepalive_enabled                                  = true

--- a/docs/resources/gateway_plugin_loggly.md
+++ b/docs/resources/gateway_plugin_loggly.md
@@ -17,7 +17,7 @@ resource "konnect_gateway_plugin_loggly" "my_gatewaypluginloggly" {
   config = {
     client_errors_severity = "alert"
     custom_fields_by_lua = {
-      "see" : jsonencode("documentation"),
+      key = jsonencode("value"),
     }
     host                   = "...my_host..."
     key                    = "...my_key..."

--- a/docs/resources/gateway_plugin_oauth2_introspection.md
+++ b/docs/resources/gateway_plugin_oauth2_introspection.md
@@ -22,7 +22,7 @@ resource "konnect_gateway_plugin_oauth2_introspection" "my_gatewaypluginoauth2in
       "..."
     ]
     custom_introspection_headers = {
-      "see" : jsonencode("documentation"),
+      key = jsonencode("value"),
     }
     hide_credentials   = true
     introspect_request = false

--- a/docs/resources/gateway_plugin_opentelemetry.md
+++ b/docs/resources/gateway_plugin_opentelemetry.md
@@ -20,7 +20,7 @@ resource "konnect_gateway_plugin_opentelemetry" "my_gatewaypluginopentelemetry" 
     connect_timeout   = 1207240418
     header_type       = "w3c"
     headers = {
-      "see" : jsonencode("documentation"),
+      key = jsonencode("value"),
     }
     http_response_header_for_traceid = "...my_http_response_header_for_traceid..."
     logs_endpoint                    = "...my_logs_endpoint..."
@@ -48,7 +48,7 @@ resource "konnect_gateway_plugin_opentelemetry" "my_gatewaypluginopentelemetry" 
     }
     read_timeout = 1485093464
     resource_attributes = {
-      "see" : jsonencode("documentation"),
+      key = jsonencode("value"),
     }
     sampling_rate   = 0.37
     send_timeout    = 1637096441

--- a/docs/resources/gateway_plugin_response_ratelimiting.md
+++ b/docs/resources/gateway_plugin_response_ratelimiting.md
@@ -21,7 +21,7 @@ resource "konnect_gateway_plugin_response_ratelimiting" "my_gatewaypluginrespons
     hide_client_headers      = true
     limit_by                 = "ip"
     limits = {
-      "see" : jsonencode("documentation"),
+      key = jsonencode("value"),
     }
     policy = "local"
     redis = {

--- a/docs/resources/gateway_plugin_route_by_header.md
+++ b/docs/resources/gateway_plugin_route_by_header.md
@@ -18,7 +18,7 @@ resource "konnect_gateway_plugin_route_by_header" "my_gatewaypluginroutebyheader
     rules = [
       {
         condition = {
-          "see" : jsonencode("documentation"),
+          key = jsonencode("value"),
         }
         upstream_name = "...my_upstream_name..."
       }

--- a/docs/resources/gateway_plugin_syslog.md
+++ b/docs/resources/gateway_plugin_syslog.md
@@ -17,7 +17,7 @@ resource "konnect_gateway_plugin_syslog" "my_gatewaypluginsyslog" {
   config = {
     client_errors_severity = "emerg"
     custom_fields_by_lua = {
-      "see" : jsonencode("documentation"),
+      key = jsonencode("value"),
     }
     facility               = "local7"
     log_level              = "info"

--- a/docs/resources/gateway_plugin_tcp_log.md
+++ b/docs/resources/gateway_plugin_tcp_log.md
@@ -16,7 +16,7 @@ GatewayPluginTCPLog Resource
 resource "konnect_gateway_plugin_tcp_log" "my_gatewayplugintcplog" {
   config = {
     custom_fields_by_lua = {
-      "see" : jsonencode("documentation"),
+      key = jsonencode("value"),
     }
     host      = "...my_host..."
     keepalive = 1.57

--- a/docs/resources/gateway_plugin_udp_log.md
+++ b/docs/resources/gateway_plugin_udp_log.md
@@ -16,7 +16,7 @@ GatewayPluginUDPLog Resource
 resource "konnect_gateway_plugin_udp_log" "my_gatewaypluginudplog" {
   config = {
     custom_fields_by_lua = {
-      "see" : jsonencode("documentation"),
+      key = jsonencode("value"),
     }
     host    = "...my_host..."
     port    = 32780

--- a/docs/resources/gateway_route.md
+++ b/docs/resources/gateway_route.md
@@ -22,7 +22,7 @@ resource "konnect_gateway_route" "my_gatewayroute" {
     }
   ]
   headers = {
-    env = "test"
+    key = "value",
   }
   hosts = [
     "..."

--- a/docs/resources/gateway_sni.md
+++ b/docs/resources/gateway_sni.md
@@ -31,12 +31,12 @@ resource "konnect_gateway_sni" "my_gatewaysni" {
 
 ### Required
 
-- `certificate` (Attributes) The id (a UUID) of the certificate with which to associate the SNI hostname. The Certificate must have a valid private key associated with it to be used by the SNI object. (see [below for nested schema](#nestedatt--certificate))
 - `control_plane_id` (String) The UUID of your control plane. This variable is available in the Konnect manager. Requires replacement if changed.
 - `name` (String) The SNI name to associate with the given certificate.
 
 ### Optional
 
+- `certificate` (Attributes) The id (a UUID) of the certificate with which to associate the SNI hostname. The Certificate must have a valid private key associated with it to be used by the SNI object. (see [below for nested schema](#nestedatt--certificate))
 - `tags` (List of String) An optional set of strings associated with the SNIs for grouping and filtering.
 
 ### Read-Only

--- a/docs/resources/gateway_upstream.md
+++ b/docs/resources/gateway_upstream.md
@@ -33,7 +33,7 @@ resource "konnect_gateway_upstream" "my_gatewayupstream" {
     active = {
       concurrency = 6
       headers = {
-        env = "test"
+        key = "value",
       }
       healthy = {
         http_statuses = [

--- a/docs/resources/mesh_control_plane.md
+++ b/docs/resources/mesh_control_plane.md
@@ -16,7 +16,7 @@ MeshControlPlane Resource
 resource "konnect_mesh_control_plane" "my_meshcontrolplane" {
   description = "A control plane to handle traffic on development environment."
   labels = {
-    env = "test"
+    key = "value",
   }
   name = "Test control plane"
 }

--- a/docs/resources/portal.md
+++ b/docs/resources/portal.md
@@ -24,7 +24,7 @@ resource "konnect_portal" "my_portal" {
   force                                = "true"
   is_public                            = false
   labels = {
-    env = "test"
+    key = "value",
   }
   name         = "...my_name..."
   rbac_enabled = true

--- a/docs/resources/serverless_cloud_gateway.md
+++ b/docs/resources/serverless_cloud_gateway.md
@@ -22,7 +22,7 @@ resource "konnect_serverless_cloud_gateway" "my_serverlesscloudgateway" {
     region = "us"
   }
   labels = {
-    env = "test"
+    key = "value",
   }
 }
 ```

--- a/docs/resources/team.md
+++ b/docs/resources/team.md
@@ -16,7 +16,7 @@ Team Resource
 resource "konnect_team" "my_team" {
   description = "The Identity Management (IDM) team."
   labels = {
-    env = "test"
+    key = "value",
   }
   name = "IDM - Developers"
 }

--- a/gen.yaml
+++ b/gen.yaml
@@ -14,7 +14,7 @@ generation:
     oAuth2PasswordEnabled: false
   baseServerURL: ""
 terraform:
-  version: 2.0.1
+  version: 2.0.2
   additionalDataSources: []
   additionalDependencies: {}
   additionalResources:
@@ -23,6 +23,7 @@ terraform:
       resource: custom.NewCustomPluginResource
   allowUnknownFieldsInWeakUnions: false
   author: kong
+  defaultErrorName: SDKError
   environmentVariables:
     - env: KONNECT_TOKEN
       providerAttribute: personal_access_token

--- a/go.mod
+++ b/go.mod
@@ -5,10 +5,12 @@ go 1.22.0
 require (
 	github.com/cenkalti/backoff/v4 v4.2.0
 	github.com/ericlagergren/decimal v0.0.0-20221120152707-495c53812d05
+	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/terraform-plugin-docs v0.19.4
 	github.com/hashicorp/terraform-plugin-framework v1.12.0
 	github.com/hashicorp/terraform-plugin-framework-validators v0.13.0
 	github.com/hashicorp/terraform-plugin-go v0.24.0
+	github.com/hashicorp/terraform-plugin-log v0.9.0
 	github.com/kong/terraform-provider-konnect v1.0.0
 )
 
@@ -34,12 +36,10 @@ require (
 	github.com/hashicorp/go-hclog v1.5.0 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/go-plugin v1.6.1 // indirect
-	github.com/hashicorp/go-uuid v1.0.3 // indirect
 	github.com/hashicorp/go-version v1.7.0 // indirect
 	github.com/hashicorp/hc-install v0.7.0 // indirect
 	github.com/hashicorp/terraform-exec v0.21.0 // indirect
 	github.com/hashicorp/terraform-json v0.22.1 // indirect
-	github.com/hashicorp/terraform-plugin-log v0.9.0 // indirect
 	github.com/hashicorp/terraform-registry-address v0.2.3 // indirect
 	github.com/hashicorp/terraform-svchost v0.1.1 // indirect
 	github.com/hashicorp/yamux v0.1.1 // indirect

--- a/internal/provider/gatewayacl_data_source.go
+++ b/internal/provider/gatewayacl_data_source.go
@@ -29,7 +29,7 @@ type GatewayACLDataSource struct {
 
 // GatewayACLDataSourceModel describes the data model.
 type GatewayACLDataSourceModel struct {
-	Consumer       *tfTypes.ACLConsumer `tfsdk:"consumer"`
+	Consumer       *tfTypes.ACLConsumer `tfsdk:"consumer" tfPlanOnly:"true"`
 	ConsumerID     types.String         `tfsdk:"consumer_id"`
 	ControlPlaneID types.String         `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64          `tfsdk:"created_at"`

--- a/internal/provider/gatewayacl_resource.go
+++ b/internal/provider/gatewayacl_resource.go
@@ -7,10 +7,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -37,7 +39,7 @@ type GatewayACLResource struct {
 
 // GatewayACLResourceModel describes the resource data model.
 type GatewayACLResourceModel struct {
-	Consumer       *tfTypes.ACLConsumer `tfsdk:"consumer"`
+	Consumer       *tfTypes.ACLConsumer `tfsdk:"consumer" tfPlanOnly:"true"`
 	ConsumerID     types.String         `tfsdk:"consumer_id"`
 	ControlPlaneID types.String         `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64          `tfsdk:"created_at"`
@@ -56,6 +58,9 @@ func (r *GatewayACLResource) Schema(ctx context.Context, req resource.SchemaRequ
 		Attributes: map[string]schema.Attribute{
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaybasicauth_data_source.go
+++ b/internal/provider/gatewaybasicauth_data_source.go
@@ -29,7 +29,7 @@ type GatewayBasicAuthDataSource struct {
 
 // GatewayBasicAuthDataSourceModel describes the data model.
 type GatewayBasicAuthDataSourceModel struct {
-	Consumer       *tfTypes.ACLConsumer `tfsdk:"consumer"`
+	Consumer       *tfTypes.ACLConsumer `tfsdk:"consumer" tfPlanOnly:"true"`
 	ConsumerID     types.String         `tfsdk:"consumer_id"`
 	ControlPlaneID types.String         `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64          `tfsdk:"created_at"`

--- a/internal/provider/gatewaybasicauth_resource.go
+++ b/internal/provider/gatewaybasicauth_resource.go
@@ -7,10 +7,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -37,7 +39,7 @@ type GatewayBasicAuthResource struct {
 
 // GatewayBasicAuthResourceModel describes the resource data model.
 type GatewayBasicAuthResourceModel struct {
-	Consumer       *tfTypes.ACLConsumer `tfsdk:"consumer"`
+	Consumer       *tfTypes.ACLConsumer `tfsdk:"consumer" tfPlanOnly:"true"`
 	ConsumerID     types.String         `tfsdk:"consumer_id"`
 	ControlPlaneID types.String         `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64          `tfsdk:"created_at"`
@@ -57,6 +59,9 @@ func (r *GatewayBasicAuthResource) Schema(ctx context.Context, req resource.Sche
 		Attributes: map[string]schema.Attribute{
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewayhmacauth_data_source.go
+++ b/internal/provider/gatewayhmacauth_data_source.go
@@ -29,7 +29,7 @@ type GatewayHMACAuthDataSource struct {
 
 // GatewayHMACAuthDataSourceModel describes the data model.
 type GatewayHMACAuthDataSourceModel struct {
-	Consumer       *tfTypes.ACLConsumer `tfsdk:"consumer"`
+	Consumer       *tfTypes.ACLConsumer `tfsdk:"consumer" tfPlanOnly:"true"`
 	ConsumerID     types.String         `tfsdk:"consumer_id"`
 	ControlPlaneID types.String         `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64          `tfsdk:"created_at"`

--- a/internal/provider/gatewayhmacauth_resource.go
+++ b/internal/provider/gatewayhmacauth_resource.go
@@ -7,10 +7,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -37,7 +39,7 @@ type GatewayHMACAuthResource struct {
 
 // GatewayHMACAuthResourceModel describes the resource data model.
 type GatewayHMACAuthResourceModel struct {
-	Consumer       *tfTypes.ACLConsumer `tfsdk:"consumer"`
+	Consumer       *tfTypes.ACLConsumer `tfsdk:"consumer" tfPlanOnly:"true"`
 	ConsumerID     types.String         `tfsdk:"consumer_id"`
 	ControlPlaneID types.String         `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64          `tfsdk:"created_at"`
@@ -57,6 +59,9 @@ func (r *GatewayHMACAuthResource) Schema(ctx context.Context, req resource.Schem
 		Attributes: map[string]schema.Attribute{
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewayjwt_data_source.go
+++ b/internal/provider/gatewayjwt_data_source.go
@@ -30,7 +30,7 @@ type GatewayJWTDataSource struct {
 // GatewayJWTDataSourceModel describes the data model.
 type GatewayJWTDataSourceModel struct {
 	Algorithm      types.String         `tfsdk:"algorithm"`
-	Consumer       *tfTypes.ACLConsumer `tfsdk:"consumer"`
+	Consumer       *tfTypes.ACLConsumer `tfsdk:"consumer" tfPlanOnly:"true"`
 	ConsumerID     types.String         `tfsdk:"consumer_id"`
 	ControlPlaneID types.String         `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64          `tfsdk:"created_at"`

--- a/internal/provider/gatewayjwt_resource.go
+++ b/internal/provider/gatewayjwt_resource.go
@@ -8,10 +8,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -40,7 +42,7 @@ type GatewayJWTResource struct {
 // GatewayJWTResourceModel describes the resource data model.
 type GatewayJWTResourceModel struct {
 	Algorithm      types.String         `tfsdk:"algorithm"`
-	Consumer       *tfTypes.ACLConsumer `tfsdk:"consumer"`
+	Consumer       *tfTypes.ACLConsumer `tfsdk:"consumer" tfPlanOnly:"true"`
 	ConsumerID     types.String         `tfsdk:"consumer_id"`
 	ControlPlaneID types.String         `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64          `tfsdk:"created_at"`
@@ -87,6 +89,9 @@ func (r *GatewayJWTResource) Schema(ctx context.Context, req resource.SchemaRequ
 			},
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaykey_data_source.go
+++ b/internal/provider/gatewaykey_data_source.go
@@ -36,7 +36,7 @@ type GatewayKeyDataSourceModel struct {
 	Kid            types.String         `tfsdk:"kid"`
 	Name           types.String         `tfsdk:"name"`
 	Pem            *tfTypes.Pem         `tfsdk:"pem"`
-	Set            *tfTypes.ACLConsumer `tfsdk:"set"`
+	Set            *tfTypes.ACLConsumer `tfsdk:"set" tfPlanOnly:"true"`
 	Tags           []types.String       `tfsdk:"tags"`
 	UpdatedAt      types.Int64          `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaykey_resource.go
+++ b/internal/provider/gatewaykey_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -41,7 +43,7 @@ type GatewayKeyResourceModel struct {
 	Kid            types.String         `tfsdk:"kid"`
 	Name           types.String         `tfsdk:"name"`
 	Pem            *tfTypes.Pem         `tfsdk:"pem"`
-	Set            *tfTypes.ACLConsumer `tfsdk:"set"`
+	Set            *tfTypes.ACLConsumer `tfsdk:"set" tfPlanOnly:"true"`
 	Tags           []types.String       `tfsdk:"tags"`
 	UpdatedAt      types.Int64          `tfsdk:"updated_at"`
 }
@@ -101,6 +103,9 @@ func (r *GatewayKeyResource) Schema(ctx context.Context, req resource.SchemaRequ
 			"set": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaykeyauth_data_source.go
+++ b/internal/provider/gatewaykeyauth_data_source.go
@@ -29,7 +29,7 @@ type GatewayKeyAuthDataSource struct {
 
 // GatewayKeyAuthDataSourceModel describes the data model.
 type GatewayKeyAuthDataSourceModel struct {
-	Consumer       *tfTypes.ACLConsumer `tfsdk:"consumer"`
+	Consumer       *tfTypes.ACLConsumer `tfsdk:"consumer" tfPlanOnly:"true"`
 	ConsumerID     types.String         `tfsdk:"consumer_id"`
 	ControlPlaneID types.String         `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64          `tfsdk:"created_at"`

--- a/internal/provider/gatewaykeyauth_resource.go
+++ b/internal/provider/gatewaykeyauth_resource.go
@@ -7,10 +7,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -37,7 +39,7 @@ type GatewayKeyAuthResource struct {
 
 // GatewayKeyAuthResourceModel describes the resource data model.
 type GatewayKeyAuthResourceModel struct {
-	Consumer       *tfTypes.ACLConsumer `tfsdk:"consumer"`
+	Consumer       *tfTypes.ACLConsumer `tfsdk:"consumer" tfPlanOnly:"true"`
 	ConsumerID     types.String         `tfsdk:"consumer_id"`
 	ControlPlaneID types.String         `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64          `tfsdk:"created_at"`
@@ -56,6 +58,9 @@ func (r *GatewayKeyAuthResource) Schema(ctx context.Context, req resource.Schema
 		Attributes: map[string]schema.Attribute{
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginacl_data_source.go
+++ b/internal/provider/gatewaypluginacl_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginACLDataSource struct {
 // GatewayPluginACLDataSourceModel describes the data model.
 type GatewayPluginACLDataSourceModel struct {
 	Config         tfTypes.ACLPluginConfig    `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String               `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                `tfsdk:"created_at"`
 	Enabled        types.Bool                 `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginACLDataSourceModel struct {
 	InstanceName   types.String               `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering `tfsdk:"ordering"`
 	Protocols      []types.String             `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer       `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer       `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer       `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer       `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String             `tfsdk:"tags"`
 	UpdatedAt      types.Int64                `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginacl_resource.go
+++ b/internal/provider/gatewaypluginacl_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -35,8 +37,8 @@ type GatewayPluginACLResource struct {
 // GatewayPluginACLResourceModel describes the resource data model.
 type GatewayPluginACLResourceModel struct {
 	Config         tfTypes.ACLPluginConfig    `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String               `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                `tfsdk:"created_at"`
 	Enabled        types.Bool                 `tfsdk:"enabled"`
@@ -44,8 +46,8 @@ type GatewayPluginACLResourceModel struct {
 	InstanceName   types.String               `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering `tfsdk:"ordering"`
 	Protocols      []types.String             `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer       `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer       `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer       `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer       `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String             `tfsdk:"tags"`
 	UpdatedAt      types.Int64                `tfsdk:"updated_at"`
 }
@@ -92,6 +94,9 @@ func (r *GatewayPluginACLResource) Schema(ctx context.Context, req resource.Sche
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -103,6 +108,9 @@ func (r *GatewayPluginACLResource) Schema(ctx context.Context, req resource.Sche
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -171,6 +179,9 @@ func (r *GatewayPluginACLResource) Schema(ctx context.Context, req resource.Sche
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -182,6 +193,9 @@ func (r *GatewayPluginACLResource) Schema(ctx context.Context, req resource.Sche
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginacme_data_source.go
+++ b/internal/provider/gatewaypluginacme_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginAcmeDataSource struct {
 // GatewayPluginAcmeDataSourceModel describes the data model.
 type GatewayPluginAcmeDataSourceModel struct {
 	Config         tfTypes.AcmePluginConfig   `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String               `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                `tfsdk:"created_at"`
 	Enabled        types.Bool                 `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginAcmeDataSourceModel struct {
 	InstanceName   types.String               `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering `tfsdk:"ordering"`
 	Protocols      []types.String             `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer       `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer       `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer       `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer       `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String             `tfsdk:"tags"`
 	UpdatedAt      types.Int64                `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginacme_resource.go
+++ b/internal/provider/gatewaypluginacme_resource.go
@@ -10,9 +10,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -42,8 +44,8 @@ type GatewayPluginAcmeResource struct {
 // GatewayPluginAcmeResourceModel describes the resource data model.
 type GatewayPluginAcmeResourceModel struct {
 	Config         tfTypes.AcmePluginConfig   `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String               `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                `tfsdk:"created_at"`
 	Enabled        types.Bool                 `tfsdk:"enabled"`
@@ -51,8 +53,8 @@ type GatewayPluginAcmeResourceModel struct {
 	InstanceName   types.String               `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering `tfsdk:"ordering"`
 	Protocols      []types.String             `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer       `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer       `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer       `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer       `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String             `tfsdk:"tags"`
 	UpdatedAt      types.Int64                `tfsdk:"updated_at"`
 }
@@ -403,6 +405,9 @@ func (r *GatewayPluginAcmeResource) Schema(ctx context.Context, req resource.Sch
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -414,6 +419,9 @@ func (r *GatewayPluginAcmeResource) Schema(ctx context.Context, req resource.Sch
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -482,6 +490,9 @@ func (r *GatewayPluginAcmeResource) Schema(ctx context.Context, req resource.Sch
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -493,6 +504,9 @@ func (r *GatewayPluginAcmeResource) Schema(ctx context.Context, req resource.Sch
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginaipromptdecorator_data_source.go
+++ b/internal/provider/gatewaypluginaipromptdecorator_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginAiPromptDecoratorDataSource struct {
 // GatewayPluginAiPromptDecoratorDataSourceModel describes the data model.
 type GatewayPluginAiPromptDecoratorDataSourceModel struct {
 	Config         tfTypes.AiPromptDecoratorPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                  `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                  `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                  `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                  `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                          `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                           `tfsdk:"created_at"`
 	Enabled        types.Bool                            `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginAiPromptDecoratorDataSourceModel struct {
 	InstanceName   types.String                          `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering            `tfsdk:"ordering"`
 	Protocols      []types.String                        `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                  `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                  `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                  `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                  `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                        `tfsdk:"tags"`
 	UpdatedAt      types.Int64                           `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginaipromptdecorator_resource.go
+++ b/internal/provider/gatewaypluginaipromptdecorator_resource.go
@@ -8,9 +8,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -39,8 +41,8 @@ type GatewayPluginAiPromptDecoratorResource struct {
 // GatewayPluginAiPromptDecoratorResourceModel describes the resource data model.
 type GatewayPluginAiPromptDecoratorResourceModel struct {
 	Config         tfTypes.AiPromptDecoratorPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                  `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                  `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                  `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                  `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                          `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                           `tfsdk:"created_at"`
 	Enabled        types.Bool                            `tfsdk:"enabled"`
@@ -48,8 +50,8 @@ type GatewayPluginAiPromptDecoratorResourceModel struct {
 	InstanceName   types.String                          `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering            `tfsdk:"ordering"`
 	Protocols      []types.String                        `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                  `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                  `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                  `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                  `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                        `tfsdk:"tags"`
 	UpdatedAt      types.Int64                           `tfsdk:"updated_at"`
 }
@@ -147,6 +149,9 @@ func (r *GatewayPluginAiPromptDecoratorResource) Schema(ctx context.Context, req
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -158,6 +163,9 @@ func (r *GatewayPluginAiPromptDecoratorResource) Schema(ctx context.Context, req
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -226,6 +234,9 @@ func (r *GatewayPluginAiPromptDecoratorResource) Schema(ctx context.Context, req
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -237,6 +248,9 @@ func (r *GatewayPluginAiPromptDecoratorResource) Schema(ctx context.Context, req
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginaipromptguard_data_source.go
+++ b/internal/provider/gatewaypluginaipromptguard_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginAiPromptGuardDataSource struct {
 // GatewayPluginAiPromptGuardDataSourceModel describes the data model.
 type GatewayPluginAiPromptGuardDataSourceModel struct {
 	Config         tfTypes.AiPromptGuardPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer              `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer              `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer              `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer              `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                      `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                       `tfsdk:"created_at"`
 	Enabled        types.Bool                        `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginAiPromptGuardDataSourceModel struct {
 	InstanceName   types.String                      `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering        `tfsdk:"ordering"`
 	Protocols      []types.String                    `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer              `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer              `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer              `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer              `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                    `tfsdk:"tags"`
 	UpdatedAt      types.Int64                       `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginaipromptguard_resource.go
+++ b/internal/provider/gatewaypluginaipromptguard_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -35,8 +37,8 @@ type GatewayPluginAiPromptGuardResource struct {
 // GatewayPluginAiPromptGuardResourceModel describes the resource data model.
 type GatewayPluginAiPromptGuardResourceModel struct {
 	Config         tfTypes.AiPromptGuardPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer              `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer              `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer              `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer              `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                      `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                       `tfsdk:"created_at"`
 	Enabled        types.Bool                        `tfsdk:"enabled"`
@@ -44,8 +46,8 @@ type GatewayPluginAiPromptGuardResourceModel struct {
 	InstanceName   types.String                      `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering        `tfsdk:"ordering"`
 	Protocols      []types.String                    `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer              `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer              `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer              `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer              `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                    `tfsdk:"tags"`
 	UpdatedAt      types.Int64                       `tfsdk:"updated_at"`
 }
@@ -93,6 +95,9 @@ func (r *GatewayPluginAiPromptGuardResource) Schema(ctx context.Context, req res
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -104,6 +109,9 @@ func (r *GatewayPluginAiPromptGuardResource) Schema(ctx context.Context, req res
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -172,6 +180,9 @@ func (r *GatewayPluginAiPromptGuardResource) Schema(ctx context.Context, req res
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -183,6 +194,9 @@ func (r *GatewayPluginAiPromptGuardResource) Schema(ctx context.Context, req res
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginaiprompttemplate_data_source.go
+++ b/internal/provider/gatewaypluginaiprompttemplate_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginAiPromptTemplateDataSource struct {
 // GatewayPluginAiPromptTemplateDataSourceModel describes the data model.
 type GatewayPluginAiPromptTemplateDataSourceModel struct {
 	Config         tfTypes.AiPromptTemplatePluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                 `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                 `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                 `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                 `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                         `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                          `tfsdk:"created_at"`
 	Enabled        types.Bool                           `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginAiPromptTemplateDataSourceModel struct {
 	InstanceName   types.String                         `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering           `tfsdk:"ordering"`
 	Protocols      []types.String                       `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                 `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                 `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                 `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                 `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                       `tfsdk:"tags"`
 	UpdatedAt      types.Int64                          `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginaiprompttemplate_resource.go
+++ b/internal/provider/gatewaypluginaiprompttemplate_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -38,8 +40,8 @@ type GatewayPluginAiPromptTemplateResource struct {
 // GatewayPluginAiPromptTemplateResourceModel describes the resource data model.
 type GatewayPluginAiPromptTemplateResourceModel struct {
 	Config         tfTypes.AiPromptTemplatePluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                 `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                 `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                 `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                 `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                         `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                          `tfsdk:"created_at"`
 	Enabled        types.Bool                           `tfsdk:"enabled"`
@@ -47,8 +49,8 @@ type GatewayPluginAiPromptTemplateResourceModel struct {
 	InstanceName   types.String                         `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering           `tfsdk:"ordering"`
 	Protocols      []types.String                       `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                 `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                 `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                 `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                 `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                       `tfsdk:"tags"`
 	UpdatedAt      types.Int64                          `tfsdk:"updated_at"`
 }
@@ -112,6 +114,9 @@ func (r *GatewayPluginAiPromptTemplateResource) Schema(ctx context.Context, req 
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -123,6 +128,9 @@ func (r *GatewayPluginAiPromptTemplateResource) Schema(ctx context.Context, req 
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -191,6 +199,9 @@ func (r *GatewayPluginAiPromptTemplateResource) Schema(ctx context.Context, req 
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -202,6 +213,9 @@ func (r *GatewayPluginAiPromptTemplateResource) Schema(ctx context.Context, req 
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginaiproxy_data_source.go
+++ b/internal/provider/gatewaypluginaiproxy_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginAiProxyDataSource struct {
 // GatewayPluginAiProxyDataSourceModel describes the data model.
 type GatewayPluginAiProxyDataSourceModel struct {
 	Config         tfTypes.AiProxyPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer        `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer        `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer        `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer        `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                 `tfsdk:"created_at"`
 	Enabled        types.Bool                  `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginAiProxyDataSourceModel struct {
 	InstanceName   types.String                `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering  `tfsdk:"ordering"`
 	Protocols      []types.String              `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer        `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer        `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer        `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer        `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String              `tfsdk:"tags"`
 	UpdatedAt      types.Int64                 `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginaiproxy_resource.go
+++ b/internal/provider/gatewaypluginaiproxy_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -38,8 +40,8 @@ type GatewayPluginAiProxyResource struct {
 // GatewayPluginAiProxyResourceModel describes the resource data model.
 type GatewayPluginAiProxyResourceModel struct {
 	Config         tfTypes.AiProxyPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer        `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer        `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer        `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer        `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                 `tfsdk:"created_at"`
 	Enabled        types.Bool                  `tfsdk:"enabled"`
@@ -47,8 +49,8 @@ type GatewayPluginAiProxyResourceModel struct {
 	InstanceName   types.String                `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering  `tfsdk:"ordering"`
 	Protocols      []types.String              `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer        `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer        `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer        `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer        `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String              `tfsdk:"tags"`
 	UpdatedAt      types.Int64                 `tfsdk:"updated_at"`
 }
@@ -354,6 +356,9 @@ func (r *GatewayPluginAiProxyResource) Schema(ctx context.Context, req resource.
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -365,6 +370,9 @@ func (r *GatewayPluginAiProxyResource) Schema(ctx context.Context, req resource.
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -433,6 +441,9 @@ func (r *GatewayPluginAiProxyResource) Schema(ctx context.Context, req resource.
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -444,6 +455,9 @@ func (r *GatewayPluginAiProxyResource) Schema(ctx context.Context, req resource.
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginairequesttransformer_data_source.go
+++ b/internal/provider/gatewaypluginairequesttransformer_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginAiRequestTransformerDataSource struct {
 // GatewayPluginAiRequestTransformerDataSourceModel describes the data model.
 type GatewayPluginAiRequestTransformerDataSourceModel struct {
 	Config         tfTypes.AiRequestTransformerPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                     `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                     `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                     `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                     `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                             `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                              `tfsdk:"created_at"`
 	Enabled        types.Bool                               `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginAiRequestTransformerDataSourceModel struct {
 	InstanceName   types.String                             `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering               `tfsdk:"ordering"`
 	Protocols      []types.String                           `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                     `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                     `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                     `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                     `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                           `tfsdk:"tags"`
 	UpdatedAt      types.Int64                              `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginairequesttransformer_resource.go
+++ b/internal/provider/gatewaypluginairequesttransformer_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -38,8 +40,8 @@ type GatewayPluginAiRequestTransformerResource struct {
 // GatewayPluginAiRequestTransformerResourceModel describes the resource data model.
 type GatewayPluginAiRequestTransformerResourceModel struct {
 	Config         tfTypes.AiRequestTransformerPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                     `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                     `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                     `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                     `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                             `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                              `tfsdk:"created_at"`
 	Enabled        types.Bool                               `tfsdk:"enabled"`
@@ -47,8 +49,8 @@ type GatewayPluginAiRequestTransformerResourceModel struct {
 	InstanceName   types.String                             `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering               `tfsdk:"ordering"`
 	Protocols      []types.String                           `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                     `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                     `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                     `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                     `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                           `tfsdk:"tags"`
 	UpdatedAt      types.Int64                              `tfsdk:"updated_at"`
 }
@@ -389,6 +391,9 @@ func (r *GatewayPluginAiRequestTransformerResource) Schema(ctx context.Context, 
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -400,6 +405,9 @@ func (r *GatewayPluginAiRequestTransformerResource) Schema(ctx context.Context, 
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -468,6 +476,9 @@ func (r *GatewayPluginAiRequestTransformerResource) Schema(ctx context.Context, 
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -479,6 +490,9 @@ func (r *GatewayPluginAiRequestTransformerResource) Schema(ctx context.Context, 
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginairesponsetransformer_data_source.go
+++ b/internal/provider/gatewaypluginairesponsetransformer_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginAiResponseTransformerDataSource struct {
 // GatewayPluginAiResponseTransformerDataSourceModel describes the data model.
 type GatewayPluginAiResponseTransformerDataSourceModel struct {
 	Config         tfTypes.AiResponseTransformerPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                      `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                      `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                      `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                      `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                              `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                               `tfsdk:"created_at"`
 	Enabled        types.Bool                                `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginAiResponseTransformerDataSourceModel struct {
 	InstanceName   types.String                              `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering                `tfsdk:"ordering"`
 	Protocols      []types.String                            `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                      `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                      `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                      `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                      `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                            `tfsdk:"tags"`
 	UpdatedAt      types.Int64                               `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginairesponsetransformer_resource.go
+++ b/internal/provider/gatewaypluginairesponsetransformer_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -38,8 +40,8 @@ type GatewayPluginAiResponseTransformerResource struct {
 // GatewayPluginAiResponseTransformerResourceModel describes the resource data model.
 type GatewayPluginAiResponseTransformerResourceModel struct {
 	Config         tfTypes.AiResponseTransformerPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                      `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                      `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                      `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                      `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                              `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                               `tfsdk:"created_at"`
 	Enabled        types.Bool                                `tfsdk:"enabled"`
@@ -47,8 +49,8 @@ type GatewayPluginAiResponseTransformerResourceModel struct {
 	InstanceName   types.String                              `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering                `tfsdk:"ordering"`
 	Protocols      []types.String                            `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                      `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                      `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                      `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                      `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                            `tfsdk:"tags"`
 	UpdatedAt      types.Int64                               `tfsdk:"updated_at"`
 }
@@ -394,6 +396,9 @@ func (r *GatewayPluginAiResponseTransformerResource) Schema(ctx context.Context,
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -405,6 +410,9 @@ func (r *GatewayPluginAiResponseTransformerResource) Schema(ctx context.Context,
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -473,6 +481,9 @@ func (r *GatewayPluginAiResponseTransformerResource) Schema(ctx context.Context,
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -484,6 +495,9 @@ func (r *GatewayPluginAiResponseTransformerResource) Schema(ctx context.Context,
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginawslambda_data_source.go
+++ b/internal/provider/gatewaypluginawslambda_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginAwsLambdaDataSource struct {
 // GatewayPluginAwsLambdaDataSourceModel describes the data model.
 type GatewayPluginAwsLambdaDataSourceModel struct {
 	Config         tfTypes.AwsLambdaPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer          `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer          `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer          `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer          `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                  `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                   `tfsdk:"created_at"`
 	Enabled        types.Bool                    `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginAwsLambdaDataSourceModel struct {
 	InstanceName   types.String                  `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering    `tfsdk:"ordering"`
 	Protocols      []types.String                `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer          `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer          `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer          `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer          `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                `tfsdk:"tags"`
 	UpdatedAt      types.Int64                   `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginawslambda_resource.go
+++ b/internal/provider/gatewaypluginawslambda_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -38,8 +40,8 @@ type GatewayPluginAwsLambdaResource struct {
 // GatewayPluginAwsLambdaResourceModel describes the resource data model.
 type GatewayPluginAwsLambdaResourceModel struct {
 	Config         tfTypes.AwsLambdaPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer          `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer          `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer          `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer          `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                  `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                   `tfsdk:"created_at"`
 	Enabled        types.Bool                    `tfsdk:"enabled"`
@@ -47,8 +49,8 @@ type GatewayPluginAwsLambdaResourceModel struct {
 	InstanceName   types.String                  `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering    `tfsdk:"ordering"`
 	Protocols      []types.String                `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer          `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer          `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer          `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer          `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                `tfsdk:"tags"`
 	UpdatedAt      types.Int64                   `tfsdk:"updated_at"`
 }
@@ -231,6 +233,9 @@ func (r *GatewayPluginAwsLambdaResource) Schema(ctx context.Context, req resourc
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -242,6 +247,9 @@ func (r *GatewayPluginAwsLambdaResource) Schema(ctx context.Context, req resourc
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -310,6 +318,9 @@ func (r *GatewayPluginAwsLambdaResource) Schema(ctx context.Context, req resourc
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -321,6 +332,9 @@ func (r *GatewayPluginAwsLambdaResource) Schema(ctx context.Context, req resourc
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginazurefunctions_data_source.go
+++ b/internal/provider/gatewaypluginazurefunctions_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginAzureFunctionsDataSource struct {
 // GatewayPluginAzureFunctionsDataSourceModel describes the data model.
 type GatewayPluginAzureFunctionsDataSourceModel struct {
 	Config         tfTypes.AzureFunctionsPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer               `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer               `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer               `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer               `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                       `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                        `tfsdk:"created_at"`
 	Enabled        types.Bool                         `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginAzureFunctionsDataSourceModel struct {
 	InstanceName   types.String                       `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering         `tfsdk:"ordering"`
 	Protocols      []types.String                     `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer               `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer               `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer               `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer               `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                     `tfsdk:"tags"`
 	UpdatedAt      types.Int64                        `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginazurefunctions_resource.go
+++ b/internal/provider/gatewaypluginazurefunctions_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -35,8 +37,8 @@ type GatewayPluginAzureFunctionsResource struct {
 // GatewayPluginAzureFunctionsResourceModel describes the resource data model.
 type GatewayPluginAzureFunctionsResourceModel struct {
 	Config         tfTypes.AzureFunctionsPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer               `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer               `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer               `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer               `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                       `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                        `tfsdk:"created_at"`
 	Enabled        types.Bool                         `tfsdk:"enabled"`
@@ -44,8 +46,8 @@ type GatewayPluginAzureFunctionsResourceModel struct {
 	InstanceName   types.String                       `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering         `tfsdk:"ordering"`
 	Protocols      []types.String                     `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer               `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer               `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer               `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer               `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                     `tfsdk:"tags"`
 	UpdatedAt      types.Int64                        `tfsdk:"updated_at"`
 }
@@ -116,6 +118,9 @@ func (r *GatewayPluginAzureFunctionsResource) Schema(ctx context.Context, req re
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -127,6 +132,9 @@ func (r *GatewayPluginAzureFunctionsResource) Schema(ctx context.Context, req re
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -195,6 +203,9 @@ func (r *GatewayPluginAzureFunctionsResource) Schema(ctx context.Context, req re
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -206,6 +217,9 @@ func (r *GatewayPluginAzureFunctionsResource) Schema(ctx context.Context, req re
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginbasicauth_data_source.go
+++ b/internal/provider/gatewaypluginbasicauth_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginBasicAuthDataSource struct {
 // GatewayPluginBasicAuthDataSourceModel describes the data model.
 type GatewayPluginBasicAuthDataSourceModel struct {
 	Config         tfTypes.BasicAuthPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer          `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer          `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer          `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer          `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                  `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                   `tfsdk:"created_at"`
 	Enabled        types.Bool                    `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginBasicAuthDataSourceModel struct {
 	InstanceName   types.String                  `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering    `tfsdk:"ordering"`
 	Protocols      []types.String                `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer          `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer          `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer          `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer          `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                `tfsdk:"tags"`
 	UpdatedAt      types.Int64                   `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginbasicauth_resource.go
+++ b/internal/provider/gatewaypluginbasicauth_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -35,8 +37,8 @@ type GatewayPluginBasicAuthResource struct {
 // GatewayPluginBasicAuthResourceModel describes the resource data model.
 type GatewayPluginBasicAuthResourceModel struct {
 	Config         tfTypes.BasicAuthPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer          `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer          `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer          `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer          `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                  `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                   `tfsdk:"created_at"`
 	Enabled        types.Bool                    `tfsdk:"enabled"`
@@ -44,8 +46,8 @@ type GatewayPluginBasicAuthResourceModel struct {
 	InstanceName   types.String                  `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering    `tfsdk:"ordering"`
 	Protocols      []types.String                `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer          `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer          `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer          `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer          `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                `tfsdk:"tags"`
 	UpdatedAt      types.Int64                   `tfsdk:"updated_at"`
 }
@@ -81,6 +83,9 @@ func (r *GatewayPluginBasicAuthResource) Schema(ctx context.Context, req resourc
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -92,6 +97,9 @@ func (r *GatewayPluginBasicAuthResource) Schema(ctx context.Context, req resourc
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -160,6 +168,9 @@ func (r *GatewayPluginBasicAuthResource) Schema(ctx context.Context, req resourc
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -171,6 +182,9 @@ func (r *GatewayPluginBasicAuthResource) Schema(ctx context.Context, req resourc
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginbotdetection_data_source.go
+++ b/internal/provider/gatewaypluginbotdetection_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginBotDetectionDataSource struct {
 // GatewayPluginBotDetectionDataSourceModel describes the data model.
 type GatewayPluginBotDetectionDataSourceModel struct {
 	Config         tfTypes.BotDetectionPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer             `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer             `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer             `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer             `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                     `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                      `tfsdk:"created_at"`
 	Enabled        types.Bool                       `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginBotDetectionDataSourceModel struct {
 	InstanceName   types.String                     `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering       `tfsdk:"ordering"`
 	Protocols      []types.String                   `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer             `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer             `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer             `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer             `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                   `tfsdk:"tags"`
 	UpdatedAt      types.Int64                      `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginbotdetection_resource.go
+++ b/internal/provider/gatewaypluginbotdetection_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -35,8 +37,8 @@ type GatewayPluginBotDetectionResource struct {
 // GatewayPluginBotDetectionResourceModel describes the resource data model.
 type GatewayPluginBotDetectionResourceModel struct {
 	Config         tfTypes.BotDetectionPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer             `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer             `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer             `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer             `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                     `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                      `tfsdk:"created_at"`
 	Enabled        types.Bool                       `tfsdk:"enabled"`
@@ -44,8 +46,8 @@ type GatewayPluginBotDetectionResourceModel struct {
 	InstanceName   types.String                     `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering       `tfsdk:"ordering"`
 	Protocols      []types.String                   `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer             `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer             `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer             `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer             `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                   `tfsdk:"tags"`
 	UpdatedAt      types.Int64                      `tfsdk:"updated_at"`
 }
@@ -78,6 +80,9 @@ func (r *GatewayPluginBotDetectionResource) Schema(ctx context.Context, req reso
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -89,6 +94,9 @@ func (r *GatewayPluginBotDetectionResource) Schema(ctx context.Context, req reso
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -157,6 +165,9 @@ func (r *GatewayPluginBotDetectionResource) Schema(ctx context.Context, req reso
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -168,6 +179,9 @@ func (r *GatewayPluginBotDetectionResource) Schema(ctx context.Context, req reso
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewayplugincanary_data_source.go
+++ b/internal/provider/gatewayplugincanary_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginCanaryDataSource struct {
 // GatewayPluginCanaryDataSourceModel describes the data model.
 type GatewayPluginCanaryDataSourceModel struct {
 	Config         tfTypes.CanaryPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String               `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                `tfsdk:"created_at"`
 	Enabled        types.Bool                 `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginCanaryDataSourceModel struct {
 	InstanceName   types.String               `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering `tfsdk:"ordering"`
 	Protocols      []types.String             `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer       `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer       `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer       `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer       `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String             `tfsdk:"tags"`
 	UpdatedAt      types.Int64                `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewayplugincanary_resource.go
+++ b/internal/provider/gatewayplugincanary_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -38,8 +40,8 @@ type GatewayPluginCanaryResource struct {
 // GatewayPluginCanaryResourceModel describes the resource data model.
 type GatewayPluginCanaryResourceModel struct {
 	Config         tfTypes.CanaryPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String               `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                `tfsdk:"created_at"`
 	Enabled        types.Bool                 `tfsdk:"enabled"`
@@ -47,8 +49,8 @@ type GatewayPluginCanaryResourceModel struct {
 	InstanceName   types.String               `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering `tfsdk:"ordering"`
 	Protocols      []types.String             `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer       `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer       `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer       `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer       `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String             `tfsdk:"tags"`
 	UpdatedAt      types.Int64                `tfsdk:"updated_at"`
 }
@@ -154,6 +156,9 @@ func (r *GatewayPluginCanaryResource) Schema(ctx context.Context, req resource.S
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -165,6 +170,9 @@ func (r *GatewayPluginCanaryResource) Schema(ctx context.Context, req resource.S
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -233,6 +241,9 @@ func (r *GatewayPluginCanaryResource) Schema(ctx context.Context, req resource.S
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -244,6 +255,9 @@ func (r *GatewayPluginCanaryResource) Schema(ctx context.Context, req resource.S
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewayplugincorrelationid_data_source.go
+++ b/internal/provider/gatewayplugincorrelationid_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginCorrelationIDDataSource struct {
 // GatewayPluginCorrelationIDDataSourceModel describes the data model.
 type GatewayPluginCorrelationIDDataSourceModel struct {
 	Config         tfTypes.CorrelationIDPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer              `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer              `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer              `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer              `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                      `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                       `tfsdk:"created_at"`
 	Enabled        types.Bool                        `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginCorrelationIDDataSourceModel struct {
 	InstanceName   types.String                      `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering        `tfsdk:"ordering"`
 	Protocols      []types.String                    `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer              `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer              `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer              `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer              `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                    `tfsdk:"tags"`
 	UpdatedAt      types.Int64                       `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewayplugincorrelationid_resource.go
+++ b/internal/provider/gatewayplugincorrelationid_resource.go
@@ -8,9 +8,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -37,8 +39,8 @@ type GatewayPluginCorrelationIDResource struct {
 // GatewayPluginCorrelationIDResourceModel describes the resource data model.
 type GatewayPluginCorrelationIDResourceModel struct {
 	Config         tfTypes.CorrelationIDPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer              `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer              `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer              `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer              `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                      `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                       `tfsdk:"created_at"`
 	Enabled        types.Bool                        `tfsdk:"enabled"`
@@ -46,8 +48,8 @@ type GatewayPluginCorrelationIDResourceModel struct {
 	InstanceName   types.String                      `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering        `tfsdk:"ordering"`
 	Protocols      []types.String                    `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer              `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer              `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer              `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer              `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                    `tfsdk:"tags"`
 	UpdatedAt      types.Int64                       `tfsdk:"updated_at"`
 }
@@ -90,6 +92,9 @@ func (r *GatewayPluginCorrelationIDResource) Schema(ctx context.Context, req res
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -101,6 +106,9 @@ func (r *GatewayPluginCorrelationIDResource) Schema(ctx context.Context, req res
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -169,6 +177,9 @@ func (r *GatewayPluginCorrelationIDResource) Schema(ctx context.Context, req res
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -180,6 +191,9 @@ func (r *GatewayPluginCorrelationIDResource) Schema(ctx context.Context, req res
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewayplugincors_data_source.go
+++ b/internal/provider/gatewayplugincors_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginCorsDataSource struct {
 // GatewayPluginCorsDataSourceModel describes the data model.
 type GatewayPluginCorsDataSourceModel struct {
 	Config         tfTypes.CorsPluginConfig   `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String               `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                `tfsdk:"created_at"`
 	Enabled        types.Bool                 `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginCorsDataSourceModel struct {
 	InstanceName   types.String               `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering `tfsdk:"ordering"`
 	Protocols      []types.String             `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer       `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer       `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer       `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer       `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String             `tfsdk:"tags"`
 	UpdatedAt      types.Int64                `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewayplugincors_resource.go
+++ b/internal/provider/gatewayplugincors_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -35,8 +37,8 @@ type GatewayPluginCorsResource struct {
 // GatewayPluginCorsResourceModel describes the resource data model.
 type GatewayPluginCorsResourceModel struct {
 	Config         tfTypes.CorsPluginConfig   `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String               `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                `tfsdk:"created_at"`
 	Enabled        types.Bool                 `tfsdk:"enabled"`
@@ -44,8 +46,8 @@ type GatewayPluginCorsResourceModel struct {
 	InstanceName   types.String               `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering `tfsdk:"ordering"`
 	Protocols      []types.String             `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer       `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer       `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer       `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer       `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String             `tfsdk:"tags"`
 	UpdatedAt      types.Int64                `tfsdk:"updated_at"`
 }
@@ -110,6 +112,9 @@ func (r *GatewayPluginCorsResource) Schema(ctx context.Context, req resource.Sch
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -121,6 +126,9 @@ func (r *GatewayPluginCorsResource) Schema(ctx context.Context, req resource.Sch
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -189,6 +197,9 @@ func (r *GatewayPluginCorsResource) Schema(ctx context.Context, req resource.Sch
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -200,6 +211,9 @@ func (r *GatewayPluginCorsResource) Schema(ctx context.Context, req resource.Sch
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewayplugindatadog_data_source.go
+++ b/internal/provider/gatewayplugindatadog_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginDatadogDataSource struct {
 // GatewayPluginDatadogDataSourceModel describes the data model.
 type GatewayPluginDatadogDataSourceModel struct {
 	Config         tfTypes.DatadogPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer        `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer        `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer        `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer        `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                 `tfsdk:"created_at"`
 	Enabled        types.Bool                  `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginDatadogDataSourceModel struct {
 	InstanceName   types.String                `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering  `tfsdk:"ordering"`
 	Protocols      []types.String              `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer        `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer        `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer        `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer        `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String              `tfsdk:"tags"`
 	UpdatedAt      types.Int64                 `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewayplugindatadog_resource.go
+++ b/internal/provider/gatewayplugindatadog_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -40,8 +42,8 @@ type GatewayPluginDatadogResource struct {
 // GatewayPluginDatadogResourceModel describes the resource data model.
 type GatewayPluginDatadogResourceModel struct {
 	Config         tfTypes.DatadogPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer        `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer        `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer        `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer        `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                 `tfsdk:"created_at"`
 	Enabled        types.Bool                  `tfsdk:"enabled"`
@@ -49,8 +51,8 @@ type GatewayPluginDatadogResourceModel struct {
 	InstanceName   types.String                `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering  `tfsdk:"ordering"`
 	Protocols      []types.String              `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer        `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer        `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer        `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer        `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String              `tfsdk:"tags"`
 	UpdatedAt      types.Int64                 `tfsdk:"updated_at"`
 }
@@ -242,6 +244,9 @@ func (r *GatewayPluginDatadogResource) Schema(ctx context.Context, req resource.
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -253,6 +258,9 @@ func (r *GatewayPluginDatadogResource) Schema(ctx context.Context, req resource.
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -321,6 +329,9 @@ func (r *GatewayPluginDatadogResource) Schema(ctx context.Context, req resource.
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -332,6 +343,9 @@ func (r *GatewayPluginDatadogResource) Schema(ctx context.Context, req resource.
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewayplugindegraphql_data_source.go
+++ b/internal/provider/gatewayplugindegraphql_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginDegraphqlDataSource struct {
 // GatewayPluginDegraphqlDataSourceModel describes the data model.
 type GatewayPluginDegraphqlDataSourceModel struct {
 	Config         tfTypes.DegraphqlPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer          `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer          `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer          `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer          `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                  `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                   `tfsdk:"created_at"`
 	Enabled        types.Bool                    `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginDegraphqlDataSourceModel struct {
 	InstanceName   types.String                  `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering    `tfsdk:"ordering"`
 	Protocols      []types.String                `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer          `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer          `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer          `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer          `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                `tfsdk:"tags"`
 	UpdatedAt      types.Int64                   `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewayplugindegraphql_resource.go
+++ b/internal/provider/gatewayplugindegraphql_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -35,8 +37,8 @@ type GatewayPluginDegraphqlResource struct {
 // GatewayPluginDegraphqlResourceModel describes the resource data model.
 type GatewayPluginDegraphqlResourceModel struct {
 	Config         tfTypes.DegraphqlPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer          `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer          `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer          `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer          `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                  `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                   `tfsdk:"created_at"`
 	Enabled        types.Bool                    `tfsdk:"enabled"`
@@ -44,8 +46,8 @@ type GatewayPluginDegraphqlResourceModel struct {
 	InstanceName   types.String                  `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering    `tfsdk:"ordering"`
 	Protocols      []types.String                `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer          `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer          `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer          `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer          `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                `tfsdk:"tags"`
 	UpdatedAt      types.Int64                   `tfsdk:"updated_at"`
 }
@@ -71,6 +73,9 @@ func (r *GatewayPluginDegraphqlResource) Schema(ctx context.Context, req resourc
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -82,6 +87,9 @@ func (r *GatewayPluginDegraphqlResource) Schema(ctx context.Context, req resourc
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -150,6 +158,9 @@ func (r *GatewayPluginDegraphqlResource) Schema(ctx context.Context, req resourc
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -161,6 +172,9 @@ func (r *GatewayPluginDegraphqlResource) Schema(ctx context.Context, req resourc
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginexittransformer_data_source.go
+++ b/internal/provider/gatewaypluginexittransformer_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginExitTransformerDataSource struct {
 // GatewayPluginExitTransformerDataSourceModel describes the data model.
 type GatewayPluginExitTransformerDataSourceModel struct {
 	Config         tfTypes.ExitTransformerPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                        `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                         `tfsdk:"created_at"`
 	Enabled        types.Bool                          `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginExitTransformerDataSourceModel struct {
 	InstanceName   types.String                        `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering          `tfsdk:"ordering"`
 	Protocols      []types.String                      `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                      `tfsdk:"tags"`
 	UpdatedAt      types.Int64                         `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginexittransformer_resource.go
+++ b/internal/provider/gatewaypluginexittransformer_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -35,8 +37,8 @@ type GatewayPluginExitTransformerResource struct {
 // GatewayPluginExitTransformerResourceModel describes the resource data model.
 type GatewayPluginExitTransformerResourceModel struct {
 	Config         tfTypes.ExitTransformerPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                        `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                         `tfsdk:"created_at"`
 	Enabled        types.Bool                          `tfsdk:"enabled"`
@@ -44,8 +46,8 @@ type GatewayPluginExitTransformerResourceModel struct {
 	InstanceName   types.String                        `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering          `tfsdk:"ordering"`
 	Protocols      []types.String                      `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                      `tfsdk:"tags"`
 	UpdatedAt      types.Int64                         `tfsdk:"updated_at"`
 }
@@ -81,6 +83,9 @@ func (r *GatewayPluginExitTransformerResource) Schema(ctx context.Context, req r
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -92,6 +97,9 @@ func (r *GatewayPluginExitTransformerResource) Schema(ctx context.Context, req r
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -160,6 +168,9 @@ func (r *GatewayPluginExitTransformerResource) Schema(ctx context.Context, req r
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -171,6 +182,9 @@ func (r *GatewayPluginExitTransformerResource) Schema(ctx context.Context, req r
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginfilelog_data_source.go
+++ b/internal/provider/gatewaypluginfilelog_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginFileLogDataSource struct {
 // GatewayPluginFileLogDataSourceModel describes the data model.
 type GatewayPluginFileLogDataSourceModel struct {
 	Config         tfTypes.FileLogPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer        `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer        `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer        `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer        `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                 `tfsdk:"created_at"`
 	Enabled        types.Bool                  `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginFileLogDataSourceModel struct {
 	InstanceName   types.String                `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering  `tfsdk:"ordering"`
 	Protocols      []types.String              `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer        `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer        `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer        `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer        `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String              `tfsdk:"tags"`
 	UpdatedAt      types.Int64                 `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginfilelog_resource.go
+++ b/internal/provider/gatewaypluginfilelog_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -40,8 +42,8 @@ type GatewayPluginFileLogResource struct {
 // GatewayPluginFileLogResourceModel describes the resource data model.
 type GatewayPluginFileLogResourceModel struct {
 	Config         tfTypes.FileLogPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer        `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer        `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer        `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer        `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                 `tfsdk:"created_at"`
 	Enabled        types.Bool                  `tfsdk:"enabled"`
@@ -49,8 +51,8 @@ type GatewayPluginFileLogResourceModel struct {
 	InstanceName   types.String                `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering  `tfsdk:"ordering"`
 	Protocols      []types.String              `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer        `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer        `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer        `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer        `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String              `tfsdk:"tags"`
 	UpdatedAt      types.Int64                 `tfsdk:"updated_at"`
 }
@@ -93,6 +95,9 @@ func (r *GatewayPluginFileLogResource) Schema(ctx context.Context, req resource.
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -104,6 +109,9 @@ func (r *GatewayPluginFileLogResource) Schema(ctx context.Context, req resource.
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -172,6 +180,9 @@ func (r *GatewayPluginFileLogResource) Schema(ctx context.Context, req resource.
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -183,6 +194,9 @@ func (r *GatewayPluginFileLogResource) Schema(ctx context.Context, req resource.
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginforwardproxy_data_source.go
+++ b/internal/provider/gatewaypluginforwardproxy_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginForwardProxyDataSource struct {
 // GatewayPluginForwardProxyDataSourceModel describes the data model.
 type GatewayPluginForwardProxyDataSourceModel struct {
 	Config         tfTypes.ForwardProxyPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer             `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer             `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer             `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer             `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                     `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                      `tfsdk:"created_at"`
 	Enabled        types.Bool                       `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginForwardProxyDataSourceModel struct {
 	InstanceName   types.String                     `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering       `tfsdk:"ordering"`
 	Protocols      []types.String                   `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer             `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer             `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer             `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer             `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                   `tfsdk:"tags"`
 	UpdatedAt      types.Int64                      `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginforwardproxy_resource.go
+++ b/internal/provider/gatewaypluginforwardproxy_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -38,8 +40,8 @@ type GatewayPluginForwardProxyResource struct {
 // GatewayPluginForwardProxyResourceModel describes the resource data model.
 type GatewayPluginForwardProxyResourceModel struct {
 	Config         tfTypes.ForwardProxyPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer             `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer             `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer             `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer             `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                     `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                      `tfsdk:"created_at"`
 	Enabled        types.Bool                       `tfsdk:"enabled"`
@@ -47,8 +49,8 @@ type GatewayPluginForwardProxyResourceModel struct {
 	InstanceName   types.String                     `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering       `tfsdk:"ordering"`
 	Protocols      []types.String                   `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer             `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer             `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer             `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer             `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                   `tfsdk:"tags"`
 	UpdatedAt      types.Int64                      `tfsdk:"updated_at"`
 }
@@ -132,6 +134,9 @@ func (r *GatewayPluginForwardProxyResource) Schema(ctx context.Context, req reso
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -143,6 +148,9 @@ func (r *GatewayPluginForwardProxyResource) Schema(ctx context.Context, req reso
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -211,6 +219,9 @@ func (r *GatewayPluginForwardProxyResource) Schema(ctx context.Context, req reso
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -222,6 +233,9 @@ func (r *GatewayPluginForwardProxyResource) Schema(ctx context.Context, req reso
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewayplugingraphqlproxycacheadvanced_data_source.go
+++ b/internal/provider/gatewayplugingraphqlproxycacheadvanced_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginGraphqlProxyCacheAdvancedDataSource struct {
 // GatewayPluginGraphqlProxyCacheAdvancedDataSourceModel describes the data model.
 type GatewayPluginGraphqlProxyCacheAdvancedDataSourceModel struct {
 	Config         tfTypes.GraphqlProxyCacheAdvancedPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                          `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                          `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                          `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                          `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                                  `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                                   `tfsdk:"created_at"`
 	Enabled        types.Bool                                    `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginGraphqlProxyCacheAdvancedDataSourceModel struct {
 	InstanceName   types.String                                  `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering                    `tfsdk:"ordering"`
 	Protocols      []types.String                                `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                          `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                          `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                          `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                          `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                                `tfsdk:"tags"`
 	UpdatedAt      types.Int64                                   `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewayplugingraphqlproxycacheadvanced_resource.go
+++ b/internal/provider/gatewayplugingraphqlproxycacheadvanced_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -39,8 +41,8 @@ type GatewayPluginGraphqlProxyCacheAdvancedResource struct {
 // GatewayPluginGraphqlProxyCacheAdvancedResourceModel describes the resource data model.
 type GatewayPluginGraphqlProxyCacheAdvancedResourceModel struct {
 	Config         tfTypes.GraphqlProxyCacheAdvancedPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                          `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                          `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                          `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                          `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                                  `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                                   `tfsdk:"created_at"`
 	Enabled        types.Bool                                    `tfsdk:"enabled"`
@@ -48,8 +50,8 @@ type GatewayPluginGraphqlProxyCacheAdvancedResourceModel struct {
 	InstanceName   types.String                                  `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering                    `tfsdk:"ordering"`
 	Protocols      []types.String                                `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                          `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                          `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                          `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                          `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                                `tfsdk:"tags"`
 	UpdatedAt      types.Int64                                   `tfsdk:"updated_at"`
 }
@@ -284,6 +286,9 @@ func (r *GatewayPluginGraphqlProxyCacheAdvancedResource) Schema(ctx context.Cont
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -295,6 +300,9 @@ func (r *GatewayPluginGraphqlProxyCacheAdvancedResource) Schema(ctx context.Cont
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -363,6 +371,9 @@ func (r *GatewayPluginGraphqlProxyCacheAdvancedResource) Schema(ctx context.Cont
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -374,6 +385,9 @@ func (r *GatewayPluginGraphqlProxyCacheAdvancedResource) Schema(ctx context.Cont
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewayplugingraphqlratelimitingadvanced_data_source.go
+++ b/internal/provider/gatewayplugingraphqlratelimitingadvanced_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginGraphqlRateLimitingAdvancedDataSource struct {
 // GatewayPluginGraphqlRateLimitingAdvancedDataSourceModel describes the data model.
 type GatewayPluginGraphqlRateLimitingAdvancedDataSourceModel struct {
 	Config         tfTypes.GraphqlRateLimitingAdvancedPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                            `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                            `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                            `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                            `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                                    `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                                     `tfsdk:"created_at"`
 	Enabled        types.Bool                                      `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginGraphqlRateLimitingAdvancedDataSourceModel struct {
 	InstanceName   types.String                                    `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering                      `tfsdk:"ordering"`
 	Protocols      []types.String                                  `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                            `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                            `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                            `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                            `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                                  `tfsdk:"tags"`
 	UpdatedAt      types.Int64                                     `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewayplugingraphqlratelimitingadvanced_resource.go
+++ b/internal/provider/gatewayplugingraphqlratelimitingadvanced_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -39,8 +41,8 @@ type GatewayPluginGraphqlRateLimitingAdvancedResource struct {
 // GatewayPluginGraphqlRateLimitingAdvancedResourceModel describes the resource data model.
 type GatewayPluginGraphqlRateLimitingAdvancedResourceModel struct {
 	Config         tfTypes.GraphqlRateLimitingAdvancedPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                            `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                            `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                            `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                            `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                                    `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                                     `tfsdk:"created_at"`
 	Enabled        types.Bool                                      `tfsdk:"enabled"`
@@ -48,8 +50,8 @@ type GatewayPluginGraphqlRateLimitingAdvancedResourceModel struct {
 	InstanceName   types.String                                    `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering                      `tfsdk:"ordering"`
 	Protocols      []types.String                                  `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                            `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                            `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                            `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                            `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                                  `tfsdk:"tags"`
 	UpdatedAt      types.Int64                                     `tfsdk:"updated_at"`
 }
@@ -333,6 +335,9 @@ func (r *GatewayPluginGraphqlRateLimitingAdvancedResource) Schema(ctx context.Co
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -344,6 +349,9 @@ func (r *GatewayPluginGraphqlRateLimitingAdvancedResource) Schema(ctx context.Co
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -412,6 +420,9 @@ func (r *GatewayPluginGraphqlRateLimitingAdvancedResource) Schema(ctx context.Co
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -423,6 +434,9 @@ func (r *GatewayPluginGraphqlRateLimitingAdvancedResource) Schema(ctx context.Co
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewayplugingrpcgateway_data_source.go
+++ b/internal/provider/gatewayplugingrpcgateway_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginGrpcGatewayDataSource struct {
 // GatewayPluginGrpcGatewayDataSourceModel describes the data model.
 type GatewayPluginGrpcGatewayDataSourceModel struct {
 	Config         tfTypes.GrpcGatewayPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer            `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer            `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer            `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer            `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                    `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                     `tfsdk:"created_at"`
 	Enabled        types.Bool                      `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginGrpcGatewayDataSourceModel struct {
 	InstanceName   types.String                    `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering      `tfsdk:"ordering"`
 	Protocols      []types.String                  `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer            `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer            `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer            `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer            `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                  `tfsdk:"tags"`
 	UpdatedAt      types.Int64                     `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewayplugingrpcgateway_resource.go
+++ b/internal/provider/gatewayplugingrpcgateway_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -35,8 +37,8 @@ type GatewayPluginGrpcGatewayResource struct {
 // GatewayPluginGrpcGatewayResourceModel describes the resource data model.
 type GatewayPluginGrpcGatewayResourceModel struct {
 	Config         tfTypes.GrpcGatewayPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer            `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer            `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer            `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer            `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                    `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                     `tfsdk:"created_at"`
 	Enabled        types.Bool                      `tfsdk:"enabled"`
@@ -44,8 +46,8 @@ type GatewayPluginGrpcGatewayResourceModel struct {
 	InstanceName   types.String                    `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering      `tfsdk:"ordering"`
 	Protocols      []types.String                  `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer            `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer            `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer            `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer            `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                  `tfsdk:"tags"`
 	UpdatedAt      types.Int64                     `tfsdk:"updated_at"`
 }
@@ -71,6 +73,9 @@ func (r *GatewayPluginGrpcGatewayResource) Schema(ctx context.Context, req resou
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -82,6 +87,9 @@ func (r *GatewayPluginGrpcGatewayResource) Schema(ctx context.Context, req resou
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -150,6 +158,9 @@ func (r *GatewayPluginGrpcGatewayResource) Schema(ctx context.Context, req resou
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -161,6 +172,9 @@ func (r *GatewayPluginGrpcGatewayResource) Schema(ctx context.Context, req resou
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewayplugingrpcweb_data_source.go
+++ b/internal/provider/gatewayplugingrpcweb_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginGrpcWebDataSource struct {
 // GatewayPluginGrpcWebDataSourceModel describes the data model.
 type GatewayPluginGrpcWebDataSourceModel struct {
 	Config         tfTypes.GrpcWebPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer        `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer        `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer        `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer        `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                 `tfsdk:"created_at"`
 	Enabled        types.Bool                  `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginGrpcWebDataSourceModel struct {
 	InstanceName   types.String                `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering  `tfsdk:"ordering"`
 	Protocols      []types.String              `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer        `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer        `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer        `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer        `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String              `tfsdk:"tags"`
 	UpdatedAt      types.Int64                 `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewayplugingrpcweb_resource.go
+++ b/internal/provider/gatewayplugingrpcweb_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -35,8 +37,8 @@ type GatewayPluginGrpcWebResource struct {
 // GatewayPluginGrpcWebResourceModel describes the resource data model.
 type GatewayPluginGrpcWebResourceModel struct {
 	Config         tfTypes.GrpcWebPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer        `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer        `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer        `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer        `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                 `tfsdk:"created_at"`
 	Enabled        types.Bool                  `tfsdk:"enabled"`
@@ -44,8 +46,8 @@ type GatewayPluginGrpcWebResourceModel struct {
 	InstanceName   types.String                `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering  `tfsdk:"ordering"`
 	Protocols      []types.String              `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer        `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer        `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer        `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer        `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String              `tfsdk:"tags"`
 	UpdatedAt      types.Int64                 `tfsdk:"updated_at"`
 }
@@ -81,6 +83,9 @@ func (r *GatewayPluginGrpcWebResource) Schema(ctx context.Context, req resource.
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -92,6 +97,9 @@ func (r *GatewayPluginGrpcWebResource) Schema(ctx context.Context, req resource.
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -160,6 +168,9 @@ func (r *GatewayPluginGrpcWebResource) Schema(ctx context.Context, req resource.
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -171,6 +182,9 @@ func (r *GatewayPluginGrpcWebResource) Schema(ctx context.Context, req resource.
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginhmacauth_data_source.go
+++ b/internal/provider/gatewaypluginhmacauth_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginHmacAuthDataSource struct {
 // GatewayPluginHmacAuthDataSourceModel describes the data model.
 type GatewayPluginHmacAuthDataSourceModel struct {
 	Config         tfTypes.HmacAuthPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer         `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer         `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer         `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer         `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                 `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                  `tfsdk:"created_at"`
 	Enabled        types.Bool                   `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginHmacAuthDataSourceModel struct {
 	InstanceName   types.String                 `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering   `tfsdk:"ordering"`
 	Protocols      []types.String               `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer         `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer         `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer         `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer         `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String               `tfsdk:"tags"`
 	UpdatedAt      types.Int64                  `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginhmacauth_resource.go
+++ b/internal/provider/gatewaypluginhmacauth_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -35,8 +37,8 @@ type GatewayPluginHmacAuthResource struct {
 // GatewayPluginHmacAuthResourceModel describes the resource data model.
 type GatewayPluginHmacAuthResourceModel struct {
 	Config         tfTypes.HmacAuthPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer         `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer         `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer         `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer         `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                 `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                  `tfsdk:"created_at"`
 	Enabled        types.Bool                   `tfsdk:"enabled"`
@@ -44,8 +46,8 @@ type GatewayPluginHmacAuthResourceModel struct {
 	InstanceName   types.String                 `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering   `tfsdk:"ordering"`
 	Protocols      []types.String               `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer         `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer         `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer         `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer         `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String               `tfsdk:"tags"`
 	UpdatedAt      types.Int64                  `tfsdk:"updated_at"`
 }
@@ -103,6 +105,9 @@ func (r *GatewayPluginHmacAuthResource) Schema(ctx context.Context, req resource
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -114,6 +119,9 @@ func (r *GatewayPluginHmacAuthResource) Schema(ctx context.Context, req resource
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -182,6 +190,9 @@ func (r *GatewayPluginHmacAuthResource) Schema(ctx context.Context, req resource
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -193,6 +204,9 @@ func (r *GatewayPluginHmacAuthResource) Schema(ctx context.Context, req resource
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginhttplog_data_source.go
+++ b/internal/provider/gatewaypluginhttplog_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginHTTPLogDataSource struct {
 // GatewayPluginHTTPLogDataSourceModel describes the data model.
 type GatewayPluginHTTPLogDataSourceModel struct {
 	Config         tfTypes.HTTPLogPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer        `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer        `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer        `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer        `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                 `tfsdk:"created_at"`
 	Enabled        types.Bool                  `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginHTTPLogDataSourceModel struct {
 	InstanceName   types.String                `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering  `tfsdk:"ordering"`
 	Protocols      []types.String              `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer        `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer        `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer        `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer        `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String              `tfsdk:"tags"`
 	UpdatedAt      types.Int64                 `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginhttplog_resource.go
+++ b/internal/provider/gatewaypluginhttplog_resource.go
@@ -10,9 +10,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -40,8 +42,8 @@ type GatewayPluginHTTPLogResource struct {
 // GatewayPluginHTTPLogResourceModel describes the resource data model.
 type GatewayPluginHTTPLogResourceModel struct {
 	Config         tfTypes.HTTPLogPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer        `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer        `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer        `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer        `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                 `tfsdk:"created_at"`
 	Enabled        types.Bool                  `tfsdk:"enabled"`
@@ -49,8 +51,8 @@ type GatewayPluginHTTPLogResourceModel struct {
 	InstanceName   types.String                `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering  `tfsdk:"ordering"`
 	Protocols      []types.String              `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer        `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer        `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer        `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer        `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String              `tfsdk:"tags"`
 	UpdatedAt      types.Int64                 `tfsdk:"updated_at"`
 }
@@ -197,6 +199,9 @@ func (r *GatewayPluginHTTPLogResource) Schema(ctx context.Context, req resource.
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -208,6 +213,9 @@ func (r *GatewayPluginHTTPLogResource) Schema(ctx context.Context, req resource.
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -276,6 +284,9 @@ func (r *GatewayPluginHTTPLogResource) Schema(ctx context.Context, req resource.
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -287,6 +298,9 @@ func (r *GatewayPluginHTTPLogResource) Schema(ctx context.Context, req resource.
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginiprestriction_data_source.go
+++ b/internal/provider/gatewaypluginiprestriction_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginIPRestrictionDataSource struct {
 // GatewayPluginIPRestrictionDataSourceModel describes the data model.
 type GatewayPluginIPRestrictionDataSourceModel struct {
 	Config         tfTypes.IPRestrictionPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer              `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer              `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer              `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer              `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                      `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                       `tfsdk:"created_at"`
 	Enabled        types.Bool                        `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginIPRestrictionDataSourceModel struct {
 	InstanceName   types.String                      `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering        `tfsdk:"ordering"`
 	Protocols      []types.String                    `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer              `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer              `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer              `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer              `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                    `tfsdk:"tags"`
 	UpdatedAt      types.Int64                       `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginiprestriction_resource.go
+++ b/internal/provider/gatewaypluginiprestriction_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -35,8 +37,8 @@ type GatewayPluginIPRestrictionResource struct {
 // GatewayPluginIPRestrictionResourceModel describes the resource data model.
 type GatewayPluginIPRestrictionResourceModel struct {
 	Config         tfTypes.IPRestrictionPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer              `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer              `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer              `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer              `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                      `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                       `tfsdk:"created_at"`
 	Enabled        types.Bool                        `tfsdk:"enabled"`
@@ -44,8 +46,8 @@ type GatewayPluginIPRestrictionResourceModel struct {
 	InstanceName   types.String                      `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering        `tfsdk:"ordering"`
 	Protocols      []types.String                    `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer              `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer              `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer              `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer              `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                    `tfsdk:"tags"`
 	UpdatedAt      types.Int64                       `tfsdk:"updated_at"`
 }
@@ -88,6 +90,9 @@ func (r *GatewayPluginIPRestrictionResource) Schema(ctx context.Context, req res
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -99,6 +104,9 @@ func (r *GatewayPluginIPRestrictionResource) Schema(ctx context.Context, req res
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -167,6 +175,9 @@ func (r *GatewayPluginIPRestrictionResource) Schema(ctx context.Context, req res
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -178,6 +189,9 @@ func (r *GatewayPluginIPRestrictionResource) Schema(ctx context.Context, req res
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginjq_data_source.go
+++ b/internal/provider/gatewaypluginjq_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginJqDataSource struct {
 // GatewayPluginJqDataSourceModel describes the data model.
 type GatewayPluginJqDataSourceModel struct {
 	Config         tfTypes.JqPluginConfig     `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String               `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                `tfsdk:"created_at"`
 	Enabled        types.Bool                 `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginJqDataSourceModel struct {
 	InstanceName   types.String               `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering `tfsdk:"ordering"`
 	Protocols      []types.String             `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer       `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer       `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer       `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer       `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String             `tfsdk:"tags"`
 	UpdatedAt      types.Int64                `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginjq_resource.go
+++ b/internal/provider/gatewaypluginjq_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -35,8 +37,8 @@ type GatewayPluginJqResource struct {
 // GatewayPluginJqResourceModel describes the resource data model.
 type GatewayPluginJqResourceModel struct {
 	Config         tfTypes.JqPluginConfig     `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String               `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                `tfsdk:"created_at"`
 	Enabled        types.Bool                 `tfsdk:"enabled"`
@@ -44,8 +46,8 @@ type GatewayPluginJqResourceModel struct {
 	InstanceName   types.String               `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering `tfsdk:"ordering"`
 	Protocols      []types.String             `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer       `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer       `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer       `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer       `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String             `tfsdk:"tags"`
 	UpdatedAt      types.Int64                `tfsdk:"updated_at"`
 }
@@ -141,6 +143,9 @@ func (r *GatewayPluginJqResource) Schema(ctx context.Context, req resource.Schem
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -152,6 +157,9 @@ func (r *GatewayPluginJqResource) Schema(ctx context.Context, req resource.Schem
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -220,6 +228,9 @@ func (r *GatewayPluginJqResource) Schema(ctx context.Context, req resource.Schem
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -231,6 +242,9 @@ func (r *GatewayPluginJqResource) Schema(ctx context.Context, req resource.Schem
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginjwedecrypt_data_source.go
+++ b/internal/provider/gatewaypluginjwedecrypt_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginJweDecryptDataSource struct {
 // GatewayPluginJweDecryptDataSourceModel describes the data model.
 type GatewayPluginJweDecryptDataSourceModel struct {
 	Config         tfTypes.JweDecryptPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer           `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer           `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer           `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer           `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                   `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                    `tfsdk:"created_at"`
 	Enabled        types.Bool                     `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginJweDecryptDataSourceModel struct {
 	InstanceName   types.String                   `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering     `tfsdk:"ordering"`
 	Protocols      []types.String                 `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer           `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer           `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer           `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer           `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                 `tfsdk:"tags"`
 	UpdatedAt      types.Int64                    `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginjwedecrypt_resource.go
+++ b/internal/provider/gatewaypluginjwedecrypt_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -35,8 +37,8 @@ type GatewayPluginJweDecryptResource struct {
 // GatewayPluginJweDecryptResourceModel describes the resource data model.
 type GatewayPluginJweDecryptResourceModel struct {
 	Config         tfTypes.JweDecryptPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer           `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer           `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer           `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer           `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                   `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                    `tfsdk:"created_at"`
 	Enabled        types.Bool                     `tfsdk:"enabled"`
@@ -44,8 +46,8 @@ type GatewayPluginJweDecryptResourceModel struct {
 	InstanceName   types.String                   `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering     `tfsdk:"ordering"`
 	Protocols      []types.String                 `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer           `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer           `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer           `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer           `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                 `tfsdk:"tags"`
 	UpdatedAt      types.Int64                    `tfsdk:"updated_at"`
 }
@@ -87,6 +89,9 @@ func (r *GatewayPluginJweDecryptResource) Schema(ctx context.Context, req resour
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -98,6 +103,9 @@ func (r *GatewayPluginJweDecryptResource) Schema(ctx context.Context, req resour
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -166,6 +174,9 @@ func (r *GatewayPluginJweDecryptResource) Schema(ctx context.Context, req resour
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -177,6 +188,9 @@ func (r *GatewayPluginJweDecryptResource) Schema(ctx context.Context, req resour
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginjwt_data_source.go
+++ b/internal/provider/gatewaypluginjwt_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginJwtDataSource struct {
 // GatewayPluginJwtDataSourceModel describes the data model.
 type GatewayPluginJwtDataSourceModel struct {
 	Config         tfTypes.JwtPluginConfig    `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String               `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                `tfsdk:"created_at"`
 	Enabled        types.Bool                 `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginJwtDataSourceModel struct {
 	InstanceName   types.String               `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering `tfsdk:"ordering"`
 	Protocols      []types.String             `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer       `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer       `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer       `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer       `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String             `tfsdk:"tags"`
 	UpdatedAt      types.Int64                `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginjwt_resource.go
+++ b/internal/provider/gatewaypluginjwt_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -35,8 +37,8 @@ type GatewayPluginJwtResource struct {
 // GatewayPluginJwtResourceModel describes the resource data model.
 type GatewayPluginJwtResourceModel struct {
 	Config         tfTypes.JwtPluginConfig    `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String               `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                `tfsdk:"created_at"`
 	Enabled        types.Bool                 `tfsdk:"enabled"`
@@ -44,8 +46,8 @@ type GatewayPluginJwtResourceModel struct {
 	InstanceName   types.String               `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering `tfsdk:"ordering"`
 	Protocols      []types.String             `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer       `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer       `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer       `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer       `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String             `tfsdk:"tags"`
 	UpdatedAt      types.Int64                `tfsdk:"updated_at"`
 }
@@ -120,6 +122,9 @@ func (r *GatewayPluginJwtResource) Schema(ctx context.Context, req resource.Sche
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -131,6 +136,9 @@ func (r *GatewayPluginJwtResource) Schema(ctx context.Context, req resource.Sche
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -199,6 +207,9 @@ func (r *GatewayPluginJwtResource) Schema(ctx context.Context, req resource.Sche
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -210,6 +221,9 @@ func (r *GatewayPluginJwtResource) Schema(ctx context.Context, req resource.Sche
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginjwtsigner_data_source.go
+++ b/internal/provider/gatewaypluginjwtsigner_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginJwtSignerDataSource struct {
 // GatewayPluginJwtSignerDataSourceModel describes the data model.
 type GatewayPluginJwtSignerDataSourceModel struct {
 	Config         tfTypes.JwtSignerPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer          `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer          `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer          `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer          `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                  `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                   `tfsdk:"created_at"`
 	Enabled        types.Bool                    `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginJwtSignerDataSourceModel struct {
 	InstanceName   types.String                  `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering    `tfsdk:"ordering"`
 	Protocols      []types.String                `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer          `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer          `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer          `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer          `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                `tfsdk:"tags"`
 	UpdatedAt      types.Int64                   `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginjwtsigner_resource.go
+++ b/internal/provider/gatewaypluginjwtsigner_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -39,8 +41,8 @@ type GatewayPluginJwtSignerResource struct {
 // GatewayPluginJwtSignerResourceModel describes the resource data model.
 type GatewayPluginJwtSignerResourceModel struct {
 	Config         tfTypes.JwtSignerPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer          `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer          `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer          `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer          `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                  `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                   `tfsdk:"created_at"`
 	Enabled        types.Bool                    `tfsdk:"enabled"`
@@ -48,8 +50,8 @@ type GatewayPluginJwtSignerResourceModel struct {
 	InstanceName   types.String                  `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering    `tfsdk:"ordering"`
 	Protocols      []types.String                `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer          `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer          `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer          `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer          `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                `tfsdk:"tags"`
 	UpdatedAt      types.Int64                   `tfsdk:"updated_at"`
 }
@@ -610,6 +612,9 @@ func (r *GatewayPluginJwtSignerResource) Schema(ctx context.Context, req resourc
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -621,6 +626,9 @@ func (r *GatewayPluginJwtSignerResource) Schema(ctx context.Context, req resourc
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -689,6 +697,9 @@ func (r *GatewayPluginJwtSignerResource) Schema(ctx context.Context, req resourc
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -700,6 +711,9 @@ func (r *GatewayPluginJwtSignerResource) Schema(ctx context.Context, req resourc
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginkafkalog_data_source.go
+++ b/internal/provider/gatewaypluginkafkalog_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginKafkaLogDataSource struct {
 // GatewayPluginKafkaLogDataSourceModel describes the data model.
 type GatewayPluginKafkaLogDataSourceModel struct {
 	Config         tfTypes.KafkaLogPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer         `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer         `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer         `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer         `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                 `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                  `tfsdk:"created_at"`
 	Enabled        types.Bool                   `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginKafkaLogDataSourceModel struct {
 	InstanceName   types.String                 `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering   `tfsdk:"ordering"`
 	Protocols      []types.String               `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer         `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer         `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer         `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer         `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String               `tfsdk:"tags"`
 	UpdatedAt      types.Int64                  `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginkafkalog_resource.go
+++ b/internal/provider/gatewaypluginkafkalog_resource.go
@@ -10,9 +10,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -43,8 +45,8 @@ type GatewayPluginKafkaLogResource struct {
 // GatewayPluginKafkaLogResourceModel describes the resource data model.
 type GatewayPluginKafkaLogResourceModel struct {
 	Config         tfTypes.KafkaLogPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer         `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer         `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer         `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer         `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                 `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                  `tfsdk:"created_at"`
 	Enabled        types.Bool                   `tfsdk:"enabled"`
@@ -52,8 +54,8 @@ type GatewayPluginKafkaLogResourceModel struct {
 	InstanceName   types.String                 `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering   `tfsdk:"ordering"`
 	Protocols      []types.String               `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer         `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer         `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer         `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer         `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String               `tfsdk:"tags"`
 	UpdatedAt      types.Int64                  `tfsdk:"updated_at"`
 }
@@ -240,6 +242,9 @@ func (r *GatewayPluginKafkaLogResource) Schema(ctx context.Context, req resource
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -251,6 +256,9 @@ func (r *GatewayPluginKafkaLogResource) Schema(ctx context.Context, req resource
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -319,6 +327,9 @@ func (r *GatewayPluginKafkaLogResource) Schema(ctx context.Context, req resource
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -330,6 +341,9 @@ func (r *GatewayPluginKafkaLogResource) Schema(ctx context.Context, req resource
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginkafkaupstream_data_source.go
+++ b/internal/provider/gatewaypluginkafkaupstream_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginKafkaUpstreamDataSource struct {
 // GatewayPluginKafkaUpstreamDataSourceModel describes the data model.
 type GatewayPluginKafkaUpstreamDataSourceModel struct {
 	Config         tfTypes.KafkaUpstreamPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer              `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer              `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer              `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer              `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                      `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                       `tfsdk:"created_at"`
 	Enabled        types.Bool                        `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginKafkaUpstreamDataSourceModel struct {
 	InstanceName   types.String                      `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering        `tfsdk:"ordering"`
 	Protocols      []types.String                    `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer              `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer              `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer              `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer              `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                    `tfsdk:"tags"`
 	UpdatedAt      types.Int64                       `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginkafkaupstream_resource.go
+++ b/internal/provider/gatewaypluginkafkaupstream_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -41,8 +43,8 @@ type GatewayPluginKafkaUpstreamResource struct {
 // GatewayPluginKafkaUpstreamResourceModel describes the resource data model.
 type GatewayPluginKafkaUpstreamResourceModel struct {
 	Config         tfTypes.KafkaUpstreamPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer              `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer              `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer              `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer              `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                      `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                       `tfsdk:"created_at"`
 	Enabled        types.Bool                        `tfsdk:"enabled"`
@@ -50,8 +52,8 @@ type GatewayPluginKafkaUpstreamResourceModel struct {
 	InstanceName   types.String                      `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering        `tfsdk:"ordering"`
 	Protocols      []types.String                    `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer              `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer              `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer              `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer              `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                    `tfsdk:"tags"`
 	UpdatedAt      types.Int64                       `tfsdk:"updated_at"`
 }
@@ -250,6 +252,9 @@ func (r *GatewayPluginKafkaUpstreamResource) Schema(ctx context.Context, req res
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -261,6 +266,9 @@ func (r *GatewayPluginKafkaUpstreamResource) Schema(ctx context.Context, req res
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -329,6 +337,9 @@ func (r *GatewayPluginKafkaUpstreamResource) Schema(ctx context.Context, req res
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -340,6 +351,9 @@ func (r *GatewayPluginKafkaUpstreamResource) Schema(ctx context.Context, req res
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginkeyauth_data_source.go
+++ b/internal/provider/gatewaypluginkeyauth_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginKeyAuthDataSource struct {
 // GatewayPluginKeyAuthDataSourceModel describes the data model.
 type GatewayPluginKeyAuthDataSourceModel struct {
 	Config         tfTypes.KeyAuthPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer        `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer        `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer        `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer        `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                 `tfsdk:"created_at"`
 	Enabled        types.Bool                  `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginKeyAuthDataSourceModel struct {
 	InstanceName   types.String                `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering  `tfsdk:"ordering"`
 	Protocols      []types.String              `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer        `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer        `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer        `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer        `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String              `tfsdk:"tags"`
 	UpdatedAt      types.Int64                 `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginkeyauth_resource.go
+++ b/internal/provider/gatewaypluginkeyauth_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -35,8 +37,8 @@ type GatewayPluginKeyAuthResource struct {
 // GatewayPluginKeyAuthResourceModel describes the resource data model.
 type GatewayPluginKeyAuthResourceModel struct {
 	Config         tfTypes.KeyAuthPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer        `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer        `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer        `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer        `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                 `tfsdk:"created_at"`
 	Enabled        types.Bool                  `tfsdk:"enabled"`
@@ -44,8 +46,8 @@ type GatewayPluginKeyAuthResourceModel struct {
 	InstanceName   types.String                `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering  `tfsdk:"ordering"`
 	Protocols      []types.String              `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer        `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer        `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer        `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer        `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String              `tfsdk:"tags"`
 	UpdatedAt      types.Int64                 `tfsdk:"updated_at"`
 }
@@ -107,6 +109,9 @@ func (r *GatewayPluginKeyAuthResource) Schema(ctx context.Context, req resource.
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -118,6 +123,9 @@ func (r *GatewayPluginKeyAuthResource) Schema(ctx context.Context, req resource.
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -186,6 +194,9 @@ func (r *GatewayPluginKeyAuthResource) Schema(ctx context.Context, req resource.
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -197,6 +208,9 @@ func (r *GatewayPluginKeyAuthResource) Schema(ctx context.Context, req resource.
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginkeyauthenc_data_source.go
+++ b/internal/provider/gatewaypluginkeyauthenc_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginKeyAuthEncDataSource struct {
 // GatewayPluginKeyAuthEncDataSourceModel describes the data model.
 type GatewayPluginKeyAuthEncDataSourceModel struct {
 	Config         tfTypes.KeyAuthPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer        `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer        `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer        `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer        `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                 `tfsdk:"created_at"`
 	Enabled        types.Bool                  `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginKeyAuthEncDataSourceModel struct {
 	InstanceName   types.String                `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering  `tfsdk:"ordering"`
 	Protocols      []types.String              `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer        `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer        `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer        `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer        `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String              `tfsdk:"tags"`
 	UpdatedAt      types.Int64                 `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginkeyauthenc_resource.go
+++ b/internal/provider/gatewaypluginkeyauthenc_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -35,8 +37,8 @@ type GatewayPluginKeyAuthEncResource struct {
 // GatewayPluginKeyAuthEncResourceModel describes the resource data model.
 type GatewayPluginKeyAuthEncResourceModel struct {
 	Config         tfTypes.KeyAuthPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer        `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer        `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer        `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer        `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                 `tfsdk:"created_at"`
 	Enabled        types.Bool                  `tfsdk:"enabled"`
@@ -44,8 +46,8 @@ type GatewayPluginKeyAuthEncResourceModel struct {
 	InstanceName   types.String                `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering  `tfsdk:"ordering"`
 	Protocols      []types.String              `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer        `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer        `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer        `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer        `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String              `tfsdk:"tags"`
 	UpdatedAt      types.Int64                 `tfsdk:"updated_at"`
 }
@@ -107,6 +109,9 @@ func (r *GatewayPluginKeyAuthEncResource) Schema(ctx context.Context, req resour
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -118,6 +123,9 @@ func (r *GatewayPluginKeyAuthEncResource) Schema(ctx context.Context, req resour
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -186,6 +194,9 @@ func (r *GatewayPluginKeyAuthEncResource) Schema(ctx context.Context, req resour
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -197,6 +208,9 @@ func (r *GatewayPluginKeyAuthEncResource) Schema(ctx context.Context, req resour
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginkonnectapplicationauth_data_source.go
+++ b/internal/provider/gatewaypluginkonnectapplicationauth_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginKonnectApplicationAuthDataSource struct {
 // GatewayPluginKonnectApplicationAuthDataSourceModel describes the data model.
 type GatewayPluginKonnectApplicationAuthDataSourceModel struct {
 	Config         tfTypes.KonnectApplicationAuthPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                       `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                       `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                       `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                       `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                               `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                                `tfsdk:"created_at"`
 	Enabled        types.Bool                                 `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginKonnectApplicationAuthDataSourceModel struct {
 	InstanceName   types.String                               `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering                 `tfsdk:"ordering"`
 	Protocols      []types.String                             `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                       `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                       `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                       `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                       `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                             `tfsdk:"tags"`
 	UpdatedAt      types.Int64                                `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginkonnectapplicationauth_resource.go
+++ b/internal/provider/gatewaypluginkonnectapplicationauth_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -40,8 +42,8 @@ type GatewayPluginKonnectApplicationAuthResource struct {
 // GatewayPluginKonnectApplicationAuthResourceModel describes the resource data model.
 type GatewayPluginKonnectApplicationAuthResourceModel struct {
 	Config         tfTypes.KonnectApplicationAuthPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                       `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                       `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                       `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                       `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                               `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                                `tfsdk:"created_at"`
 	Enabled        types.Bool                                 `tfsdk:"enabled"`
@@ -49,8 +51,8 @@ type GatewayPluginKonnectApplicationAuthResourceModel struct {
 	InstanceName   types.String                               `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering                 `tfsdk:"ordering"`
 	Protocols      []types.String                             `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                       `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                       `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                       `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                       `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                             `tfsdk:"tags"`
 	UpdatedAt      types.Int64                                `tfsdk:"updated_at"`
 }
@@ -1937,6 +1939,9 @@ func (r *GatewayPluginKonnectApplicationAuthResource) Schema(ctx context.Context
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -1948,6 +1953,9 @@ func (r *GatewayPluginKonnectApplicationAuthResource) Schema(ctx context.Context
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -2016,6 +2024,9 @@ func (r *GatewayPluginKonnectApplicationAuthResource) Schema(ctx context.Context
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -2027,6 +2038,9 @@ func (r *GatewayPluginKonnectApplicationAuthResource) Schema(ctx context.Context
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginldapauth_data_source.go
+++ b/internal/provider/gatewaypluginldapauth_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginLdapAuthDataSource struct {
 // GatewayPluginLdapAuthDataSourceModel describes the data model.
 type GatewayPluginLdapAuthDataSourceModel struct {
 	Config         tfTypes.LdapAuthPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer         `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer         `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer         `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer         `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                 `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                  `tfsdk:"created_at"`
 	Enabled        types.Bool                   `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginLdapAuthDataSourceModel struct {
 	InstanceName   types.String                 `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering   `tfsdk:"ordering"`
 	Protocols      []types.String               `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer         `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer         `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer         `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer         `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String               `tfsdk:"tags"`
 	UpdatedAt      types.Int64                  `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginldapauth_resource.go
+++ b/internal/provider/gatewaypluginldapauth_resource.go
@@ -8,9 +8,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -37,8 +39,8 @@ type GatewayPluginLdapAuthResource struct {
 // GatewayPluginLdapAuthResourceModel describes the resource data model.
 type GatewayPluginLdapAuthResourceModel struct {
 	Config         tfTypes.LdapAuthPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer         `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer         `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer         `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer         `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                 `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                  `tfsdk:"created_at"`
 	Enabled        types.Bool                   `tfsdk:"enabled"`
@@ -46,8 +48,8 @@ type GatewayPluginLdapAuthResourceModel struct {
 	InstanceName   types.String                 `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering   `tfsdk:"ordering"`
 	Protocols      []types.String               `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer         `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer         `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer         `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer         `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String               `tfsdk:"tags"`
 	UpdatedAt      types.Int64                  `tfsdk:"updated_at"`
 }
@@ -141,6 +143,9 @@ func (r *GatewayPluginLdapAuthResource) Schema(ctx context.Context, req resource
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -152,6 +157,9 @@ func (r *GatewayPluginLdapAuthResource) Schema(ctx context.Context, req resource
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -220,6 +228,9 @@ func (r *GatewayPluginLdapAuthResource) Schema(ctx context.Context, req resource
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -231,6 +242,9 @@ func (r *GatewayPluginLdapAuthResource) Schema(ctx context.Context, req resource
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginldapauthadvanced_data_source.go
+++ b/internal/provider/gatewaypluginldapauthadvanced_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginLdapAuthAdvancedDataSource struct {
 // GatewayPluginLdapAuthAdvancedDataSourceModel describes the data model.
 type GatewayPluginLdapAuthAdvancedDataSourceModel struct {
 	Config         tfTypes.LdapAuthAdvancedPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                 `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                 `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                 `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                 `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                         `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                          `tfsdk:"created_at"`
 	Enabled        types.Bool                           `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginLdapAuthAdvancedDataSourceModel struct {
 	InstanceName   types.String                         `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering           `tfsdk:"ordering"`
 	Protocols      []types.String                       `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                 `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                 `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                 `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                 `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                       `tfsdk:"tags"`
 	UpdatedAt      types.Int64                          `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginldapauthadvanced_resource.go
+++ b/internal/provider/gatewaypluginldapauthadvanced_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -35,8 +37,8 @@ type GatewayPluginLdapAuthAdvancedResource struct {
 // GatewayPluginLdapAuthAdvancedResourceModel describes the resource data model.
 type GatewayPluginLdapAuthAdvancedResourceModel struct {
 	Config         tfTypes.LdapAuthAdvancedPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                 `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                 `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                 `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                 `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                         `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                          `tfsdk:"created_at"`
 	Enabled        types.Bool                           `tfsdk:"enabled"`
@@ -44,8 +46,8 @@ type GatewayPluginLdapAuthAdvancedResourceModel struct {
 	InstanceName   types.String                         `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering           `tfsdk:"ordering"`
 	Protocols      []types.String                       `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                 `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                 `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                 `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                 `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                       `tfsdk:"tags"`
 	UpdatedAt      types.Int64                          `tfsdk:"updated_at"`
 }
@@ -183,6 +185,9 @@ func (r *GatewayPluginLdapAuthAdvancedResource) Schema(ctx context.Context, req 
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -194,6 +199,9 @@ func (r *GatewayPluginLdapAuthAdvancedResource) Schema(ctx context.Context, req 
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -262,6 +270,9 @@ func (r *GatewayPluginLdapAuthAdvancedResource) Schema(ctx context.Context, req 
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -273,6 +284,9 @@ func (r *GatewayPluginLdapAuthAdvancedResource) Schema(ctx context.Context, req 
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginloggly_data_source.go
+++ b/internal/provider/gatewaypluginloggly_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginLogglyDataSource struct {
 // GatewayPluginLogglyDataSourceModel describes the data model.
 type GatewayPluginLogglyDataSourceModel struct {
 	Config         tfTypes.LogglyPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String               `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                `tfsdk:"created_at"`
 	Enabled        types.Bool                 `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginLogglyDataSourceModel struct {
 	InstanceName   types.String               `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering `tfsdk:"ordering"`
 	Protocols      []types.String             `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer       `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer       `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer       `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer       `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String             `tfsdk:"tags"`
 	UpdatedAt      types.Int64                `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginloggly_resource.go
+++ b/internal/provider/gatewaypluginloggly_resource.go
@@ -10,9 +10,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -40,8 +42,8 @@ type GatewayPluginLogglyResource struct {
 // GatewayPluginLogglyResourceModel describes the resource data model.
 type GatewayPluginLogglyResourceModel struct {
 	Config         tfTypes.LogglyPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String               `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                `tfsdk:"created_at"`
 	Enabled        types.Bool                 `tfsdk:"enabled"`
@@ -49,8 +51,8 @@ type GatewayPluginLogglyResourceModel struct {
 	InstanceName   types.String               `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering `tfsdk:"ordering"`
 	Protocols      []types.String             `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer       `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer       `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer       `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer       `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String             `tfsdk:"tags"`
 	UpdatedAt      types.Int64                `tfsdk:"updated_at"`
 }
@@ -174,6 +176,9 @@ func (r *GatewayPluginLogglyResource) Schema(ctx context.Context, req resource.S
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -185,6 +190,9 @@ func (r *GatewayPluginLogglyResource) Schema(ctx context.Context, req resource.S
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -253,6 +261,9 @@ func (r *GatewayPluginLogglyResource) Schema(ctx context.Context, req resource.S
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -264,6 +275,9 @@ func (r *GatewayPluginLogglyResource) Schema(ctx context.Context, req resource.S
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginmocking_data_source.go
+++ b/internal/provider/gatewaypluginmocking_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginMockingDataSource struct {
 // GatewayPluginMockingDataSourceModel describes the data model.
 type GatewayPluginMockingDataSourceModel struct {
 	Config         tfTypes.MockingPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer        `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer        `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer        `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer        `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                 `tfsdk:"created_at"`
 	Enabled        types.Bool                  `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginMockingDataSourceModel struct {
 	InstanceName   types.String                `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering  `tfsdk:"ordering"`
 	Protocols      []types.String              `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer        `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer        `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer        `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer        `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String              `tfsdk:"tags"`
 	UpdatedAt      types.Int64                 `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginmocking_resource.go
+++ b/internal/provider/gatewaypluginmocking_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -35,8 +37,8 @@ type GatewayPluginMockingResource struct {
 // GatewayPluginMockingResourceModel describes the resource data model.
 type GatewayPluginMockingResourceModel struct {
 	Config         tfTypes.MockingPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer        `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer        `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer        `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer        `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                 `tfsdk:"created_at"`
 	Enabled        types.Bool                  `tfsdk:"enabled"`
@@ -44,8 +46,8 @@ type GatewayPluginMockingResourceModel struct {
 	InstanceName   types.String                `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering  `tfsdk:"ordering"`
 	Protocols      []types.String              `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer        `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer        `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer        `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer        `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String              `tfsdk:"tags"`
 	UpdatedAt      types.Int64                 `tfsdk:"updated_at"`
 }
@@ -117,6 +119,9 @@ func (r *GatewayPluginMockingResource) Schema(ctx context.Context, req resource.
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -128,6 +133,9 @@ func (r *GatewayPluginMockingResource) Schema(ctx context.Context, req resource.
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -196,6 +204,9 @@ func (r *GatewayPluginMockingResource) Schema(ctx context.Context, req resource.
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -207,6 +218,9 @@ func (r *GatewayPluginMockingResource) Schema(ctx context.Context, req resource.
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginmtlsauth_data_source.go
+++ b/internal/provider/gatewaypluginmtlsauth_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginMtlsAuthDataSource struct {
 // GatewayPluginMtlsAuthDataSourceModel describes the data model.
 type GatewayPluginMtlsAuthDataSourceModel struct {
 	Config         tfTypes.MtlsAuthPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer         `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer         `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer         `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer         `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                 `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                  `tfsdk:"created_at"`
 	Enabled        types.Bool                   `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginMtlsAuthDataSourceModel struct {
 	InstanceName   types.String                 `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering   `tfsdk:"ordering"`
 	Protocols      []types.String               `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer         `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer         `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer         `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer         `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String               `tfsdk:"tags"`
 	UpdatedAt      types.Int64                  `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginmtlsauth_resource.go
+++ b/internal/provider/gatewaypluginmtlsauth_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -38,8 +40,8 @@ type GatewayPluginMtlsAuthResource struct {
 // GatewayPluginMtlsAuthResourceModel describes the resource data model.
 type GatewayPluginMtlsAuthResourceModel struct {
 	Config         tfTypes.MtlsAuthPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer         `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer         `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer         `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer         `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                 `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                  `tfsdk:"created_at"`
 	Enabled        types.Bool                   `tfsdk:"enabled"`
@@ -47,8 +49,8 @@ type GatewayPluginMtlsAuthResourceModel struct {
 	InstanceName   types.String                 `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering   `tfsdk:"ordering"`
 	Protocols      []types.String               `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer         `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer         `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer         `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer         `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String               `tfsdk:"tags"`
 	UpdatedAt      types.Int64                  `tfsdk:"updated_at"`
 }
@@ -167,6 +169,9 @@ func (r *GatewayPluginMtlsAuthResource) Schema(ctx context.Context, req resource
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -178,6 +183,9 @@ func (r *GatewayPluginMtlsAuthResource) Schema(ctx context.Context, req resource
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -246,6 +254,9 @@ func (r *GatewayPluginMtlsAuthResource) Schema(ctx context.Context, req resource
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -257,6 +268,9 @@ func (r *GatewayPluginMtlsAuthResource) Schema(ctx context.Context, req resource
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginoasvalidation_data_source.go
+++ b/internal/provider/gatewaypluginoasvalidation_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginOasValidationDataSource struct {
 // GatewayPluginOasValidationDataSourceModel describes the data model.
 type GatewayPluginOasValidationDataSourceModel struct {
 	Config         tfTypes.OasValidationPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer              `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer              `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer              `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer              `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                      `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                       `tfsdk:"created_at"`
 	Enabled        types.Bool                        `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginOasValidationDataSourceModel struct {
 	InstanceName   types.String                      `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering        `tfsdk:"ordering"`
 	Protocols      []types.String                    `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer              `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer              `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer              `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer              `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                    `tfsdk:"tags"`
 	UpdatedAt      types.Int64                       `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginoasvalidation_resource.go
+++ b/internal/provider/gatewaypluginoasvalidation_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -35,8 +37,8 @@ type GatewayPluginOasValidationResource struct {
 // GatewayPluginOasValidationResourceModel describes the resource data model.
 type GatewayPluginOasValidationResourceModel struct {
 	Config         tfTypes.OasValidationPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer              `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer              `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer              `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer              `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                      `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                       `tfsdk:"created_at"`
 	Enabled        types.Bool                        `tfsdk:"enabled"`
@@ -44,8 +46,8 @@ type GatewayPluginOasValidationResourceModel struct {
 	InstanceName   types.String                      `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering        `tfsdk:"ordering"`
 	Protocols      []types.String                    `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer              `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer              `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer              `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer              `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                    `tfsdk:"tags"`
 	UpdatedAt      types.Int64                       `tfsdk:"updated_at"`
 }
@@ -141,6 +143,9 @@ func (r *GatewayPluginOasValidationResource) Schema(ctx context.Context, req res
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -152,6 +157,9 @@ func (r *GatewayPluginOasValidationResource) Schema(ctx context.Context, req res
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -220,6 +228,9 @@ func (r *GatewayPluginOasValidationResource) Schema(ctx context.Context, req res
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -231,6 +242,9 @@ func (r *GatewayPluginOasValidationResource) Schema(ctx context.Context, req res
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginoauth2_data_source.go
+++ b/internal/provider/gatewaypluginoauth2_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginOauth2DataSource struct {
 // GatewayPluginOauth2DataSourceModel describes the data model.
 type GatewayPluginOauth2DataSourceModel struct {
 	Config         tfTypes.Oauth2PluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String               `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                `tfsdk:"created_at"`
 	Enabled        types.Bool                 `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginOauth2DataSourceModel struct {
 	InstanceName   types.String               `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering `tfsdk:"ordering"`
 	Protocols      []types.String             `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer       `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer       `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer       `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer       `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String             `tfsdk:"tags"`
 	UpdatedAt      types.Int64                `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginoauth2_resource.go
+++ b/internal/provider/gatewaypluginoauth2_resource.go
@@ -8,9 +8,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -37,8 +39,8 @@ type GatewayPluginOauth2Resource struct {
 // GatewayPluginOauth2ResourceModel describes the resource data model.
 type GatewayPluginOauth2ResourceModel struct {
 	Config         tfTypes.Oauth2PluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String               `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                `tfsdk:"created_at"`
 	Enabled        types.Bool                 `tfsdk:"enabled"`
@@ -46,8 +48,8 @@ type GatewayPluginOauth2ResourceModel struct {
 	InstanceName   types.String               `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering `tfsdk:"ordering"`
 	Protocols      []types.String             `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer       `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer       `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer       `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer       `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String             `tfsdk:"tags"`
 	UpdatedAt      types.Int64                `tfsdk:"updated_at"`
 }
@@ -165,6 +167,9 @@ func (r *GatewayPluginOauth2Resource) Schema(ctx context.Context, req resource.S
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -176,6 +181,9 @@ func (r *GatewayPluginOauth2Resource) Schema(ctx context.Context, req resource.S
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -244,6 +252,9 @@ func (r *GatewayPluginOauth2Resource) Schema(ctx context.Context, req resource.S
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -255,6 +266,9 @@ func (r *GatewayPluginOauth2Resource) Schema(ctx context.Context, req resource.S
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginoauth2introspection_data_source.go
+++ b/internal/provider/gatewaypluginoauth2introspection_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginOauth2IntrospectionDataSource struct {
 // GatewayPluginOauth2IntrospectionDataSourceModel describes the data model.
 type GatewayPluginOauth2IntrospectionDataSourceModel struct {
 	Config         tfTypes.Oauth2IntrospectionPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                    `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                    `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                    `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                    `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                            `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                             `tfsdk:"created_at"`
 	Enabled        types.Bool                              `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginOauth2IntrospectionDataSourceModel struct {
 	InstanceName   types.String                            `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering              `tfsdk:"ordering"`
 	Protocols      []types.String                          `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                    `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                    `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                    `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                    `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                          `tfsdk:"tags"`
 	UpdatedAt      types.Int64                             `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginoauth2introspection_resource.go
+++ b/internal/provider/gatewaypluginoauth2introspection_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -39,8 +41,8 @@ type GatewayPluginOauth2IntrospectionResource struct {
 // GatewayPluginOauth2IntrospectionResourceModel describes the resource data model.
 type GatewayPluginOauth2IntrospectionResourceModel struct {
 	Config         tfTypes.Oauth2IntrospectionPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                    `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                    `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                    `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                    `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                            `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                             `tfsdk:"created_at"`
 	Enabled        types.Bool                              `tfsdk:"enabled"`
@@ -48,8 +50,8 @@ type GatewayPluginOauth2IntrospectionResourceModel struct {
 	InstanceName   types.String                            `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering              `tfsdk:"ordering"`
 	Protocols      []types.String                          `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                    `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                    `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                    `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                    `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                          `tfsdk:"tags"`
 	UpdatedAt      types.Int64                             `tfsdk:"updated_at"`
 }
@@ -146,6 +148,9 @@ func (r *GatewayPluginOauth2IntrospectionResource) Schema(ctx context.Context, r
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -157,6 +162,9 @@ func (r *GatewayPluginOauth2IntrospectionResource) Schema(ctx context.Context, r
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -225,6 +233,9 @@ func (r *GatewayPluginOauth2IntrospectionResource) Schema(ctx context.Context, r
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -236,6 +247,9 @@ func (r *GatewayPluginOauth2IntrospectionResource) Schema(ctx context.Context, r
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginopa_data_source.go
+++ b/internal/provider/gatewaypluginopa_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginOpaDataSource struct {
 // GatewayPluginOpaDataSourceModel describes the data model.
 type GatewayPluginOpaDataSourceModel struct {
 	Config         tfTypes.OpaPluginConfig    `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String               `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                `tfsdk:"created_at"`
 	Enabled        types.Bool                 `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginOpaDataSourceModel struct {
 	InstanceName   types.String               `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering `tfsdk:"ordering"`
 	Protocols      []types.String             `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer       `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer       `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer       `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer       `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String             `tfsdk:"tags"`
 	UpdatedAt      types.Int64                `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginopa_resource.go
+++ b/internal/provider/gatewaypluginopa_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -38,8 +40,8 @@ type GatewayPluginOpaResource struct {
 // GatewayPluginOpaResourceModel describes the resource data model.
 type GatewayPluginOpaResourceModel struct {
 	Config         tfTypes.OpaPluginConfig    `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String               `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                `tfsdk:"created_at"`
 	Enabled        types.Bool                 `tfsdk:"enabled"`
@@ -47,8 +49,8 @@ type GatewayPluginOpaResourceModel struct {
 	InstanceName   types.String               `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering `tfsdk:"ordering"`
 	Protocols      []types.String             `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer       `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer       `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer       `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer       `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String             `tfsdk:"tags"`
 	UpdatedAt      types.Int64                `tfsdk:"updated_at"`
 }
@@ -132,6 +134,9 @@ func (r *GatewayPluginOpaResource) Schema(ctx context.Context, req resource.Sche
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -143,6 +148,9 @@ func (r *GatewayPluginOpaResource) Schema(ctx context.Context, req resource.Sche
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -211,6 +219,9 @@ func (r *GatewayPluginOpaResource) Schema(ctx context.Context, req resource.Sche
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -222,6 +233,9 @@ func (r *GatewayPluginOpaResource) Schema(ctx context.Context, req resource.Sche
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginopenidconnect_data_source.go
+++ b/internal/provider/gatewaypluginopenidconnect_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginOpenidConnectDataSource struct {
 // GatewayPluginOpenidConnectDataSourceModel describes the data model.
 type GatewayPluginOpenidConnectDataSourceModel struct {
 	Config         tfTypes.OpenidConnectPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer              `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer              `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer              `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer              `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                      `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                       `tfsdk:"created_at"`
 	Enabled        types.Bool                        `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginOpenidConnectDataSourceModel struct {
 	InstanceName   types.String                      `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering        `tfsdk:"ordering"`
 	Protocols      []types.String                    `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer              `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer              `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer              `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer              `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                    `tfsdk:"tags"`
 	UpdatedAt      types.Int64                       `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginopenidconnect_resource.go
+++ b/internal/provider/gatewaypluginopenidconnect_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -39,8 +41,8 @@ type GatewayPluginOpenidConnectResource struct {
 // GatewayPluginOpenidConnectResourceModel describes the resource data model.
 type GatewayPluginOpenidConnectResourceModel struct {
 	Config         tfTypes.OpenidConnectPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer              `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer              `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer              `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer              `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                      `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                       `tfsdk:"created_at"`
 	Enabled        types.Bool                        `tfsdk:"enabled"`
@@ -48,8 +50,8 @@ type GatewayPluginOpenidConnectResourceModel struct {
 	InstanceName   types.String                      `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering        `tfsdk:"ordering"`
 	Protocols      []types.String                    `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer              `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer              `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer              `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer              `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                    `tfsdk:"tags"`
 	UpdatedAt      types.Int64                       `tfsdk:"updated_at"`
 }
@@ -1831,6 +1833,9 @@ func (r *GatewayPluginOpenidConnectResource) Schema(ctx context.Context, req res
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -1842,6 +1847,9 @@ func (r *GatewayPluginOpenidConnectResource) Schema(ctx context.Context, req res
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -1910,6 +1918,9 @@ func (r *GatewayPluginOpenidConnectResource) Schema(ctx context.Context, req res
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -1921,6 +1932,9 @@ func (r *GatewayPluginOpenidConnectResource) Schema(ctx context.Context, req res
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginopentelemetry_data_source.go
+++ b/internal/provider/gatewaypluginopentelemetry_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginOpentelemetryDataSource struct {
 // GatewayPluginOpentelemetryDataSourceModel describes the data model.
 type GatewayPluginOpentelemetryDataSourceModel struct {
 	Config         tfTypes.OpentelemetryPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer              `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer              `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer              `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer              `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                      `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                       `tfsdk:"created_at"`
 	Enabled        types.Bool                        `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginOpentelemetryDataSourceModel struct {
 	InstanceName   types.String                      `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering        `tfsdk:"ordering"`
 	Protocols      []types.String                    `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer              `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer              `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer              `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer              `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                    `tfsdk:"tags"`
 	UpdatedAt      types.Int64                       `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginopentelemetry_resource.go
+++ b/internal/provider/gatewaypluginopentelemetry_resource.go
@@ -10,9 +10,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -41,8 +43,8 @@ type GatewayPluginOpentelemetryResource struct {
 // GatewayPluginOpentelemetryResourceModel describes the resource data model.
 type GatewayPluginOpentelemetryResourceModel struct {
 	Config         tfTypes.OpentelemetryPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer              `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer              `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer              `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer              `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                      `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                       `tfsdk:"created_at"`
 	Enabled        types.Bool                        `tfsdk:"enabled"`
@@ -50,8 +52,8 @@ type GatewayPluginOpentelemetryResourceModel struct {
 	InstanceName   types.String                      `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering        `tfsdk:"ordering"`
 	Protocols      []types.String                    `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer              `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer              `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer              `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer              `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                    `tfsdk:"tags"`
 	UpdatedAt      types.Int64                       `tfsdk:"updated_at"`
 }
@@ -258,6 +260,9 @@ func (r *GatewayPluginOpentelemetryResource) Schema(ctx context.Context, req res
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -269,6 +274,9 @@ func (r *GatewayPluginOpentelemetryResource) Schema(ctx context.Context, req res
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -337,6 +345,9 @@ func (r *GatewayPluginOpentelemetryResource) Schema(ctx context.Context, req res
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -348,6 +359,9 @@ func (r *GatewayPluginOpentelemetryResource) Schema(ctx context.Context, req res
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginpostfunction_data_source.go
+++ b/internal/provider/gatewaypluginpostfunction_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginPostFunctionDataSource struct {
 // GatewayPluginPostFunctionDataSourceModel describes the data model.
 type GatewayPluginPostFunctionDataSourceModel struct {
 	Config         tfTypes.PostFunctionPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer             `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer             `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer             `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer             `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                     `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                      `tfsdk:"created_at"`
 	Enabled        types.Bool                       `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginPostFunctionDataSourceModel struct {
 	InstanceName   types.String                     `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering       `tfsdk:"ordering"`
 	Protocols      []types.String                   `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer             `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer             `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer             `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer             `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                   `tfsdk:"tags"`
 	UpdatedAt      types.Int64                      `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginpostfunction_resource.go
+++ b/internal/provider/gatewaypluginpostfunction_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -35,8 +37,8 @@ type GatewayPluginPostFunctionResource struct {
 // GatewayPluginPostFunctionResourceModel describes the resource data model.
 type GatewayPluginPostFunctionResourceModel struct {
 	Config         tfTypes.PostFunctionPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer             `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer             `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer             `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer             `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                     `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                      `tfsdk:"created_at"`
 	Enabled        types.Bool                       `tfsdk:"enabled"`
@@ -44,8 +46,8 @@ type GatewayPluginPostFunctionResourceModel struct {
 	InstanceName   types.String                     `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering       `tfsdk:"ordering"`
 	Protocols      []types.String                   `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer             `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer             `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer             `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer             `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                   `tfsdk:"tags"`
 	UpdatedAt      types.Int64                      `tfsdk:"updated_at"`
 }
@@ -116,6 +118,9 @@ func (r *GatewayPluginPostFunctionResource) Schema(ctx context.Context, req reso
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -127,6 +132,9 @@ func (r *GatewayPluginPostFunctionResource) Schema(ctx context.Context, req reso
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -195,6 +203,9 @@ func (r *GatewayPluginPostFunctionResource) Schema(ctx context.Context, req reso
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -206,6 +217,9 @@ func (r *GatewayPluginPostFunctionResource) Schema(ctx context.Context, req reso
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginprefunction_data_source.go
+++ b/internal/provider/gatewaypluginprefunction_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginPreFunctionDataSource struct {
 // GatewayPluginPreFunctionDataSourceModel describes the data model.
 type GatewayPluginPreFunctionDataSourceModel struct {
 	Config         tfTypes.PostFunctionPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer             `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer             `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer             `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer             `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                     `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                      `tfsdk:"created_at"`
 	Enabled        types.Bool                       `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginPreFunctionDataSourceModel struct {
 	InstanceName   types.String                     `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering       `tfsdk:"ordering"`
 	Protocols      []types.String                   `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer             `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer             `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer             `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer             `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                   `tfsdk:"tags"`
 	UpdatedAt      types.Int64                      `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginprefunction_resource.go
+++ b/internal/provider/gatewaypluginprefunction_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -35,8 +37,8 @@ type GatewayPluginPreFunctionResource struct {
 // GatewayPluginPreFunctionResourceModel describes the resource data model.
 type GatewayPluginPreFunctionResourceModel struct {
 	Config         tfTypes.PostFunctionPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer             `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer             `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer             `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer             `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                     `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                      `tfsdk:"created_at"`
 	Enabled        types.Bool                       `tfsdk:"enabled"`
@@ -44,8 +46,8 @@ type GatewayPluginPreFunctionResourceModel struct {
 	InstanceName   types.String                     `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering       `tfsdk:"ordering"`
 	Protocols      []types.String                   `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer             `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer             `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer             `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer             `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                   `tfsdk:"tags"`
 	UpdatedAt      types.Int64                      `tfsdk:"updated_at"`
 }
@@ -116,6 +118,9 @@ func (r *GatewayPluginPreFunctionResource) Schema(ctx context.Context, req resou
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -127,6 +132,9 @@ func (r *GatewayPluginPreFunctionResource) Schema(ctx context.Context, req resou
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -195,6 +203,9 @@ func (r *GatewayPluginPreFunctionResource) Schema(ctx context.Context, req resou
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -206,6 +217,9 @@ func (r *GatewayPluginPreFunctionResource) Schema(ctx context.Context, req resou
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginprometheus_data_source.go
+++ b/internal/provider/gatewaypluginprometheus_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginPrometheusDataSource struct {
 // GatewayPluginPrometheusDataSourceModel describes the data model.
 type GatewayPluginPrometheusDataSourceModel struct {
 	Config         tfTypes.PrometheusPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer           `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer           `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer           `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer           `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                   `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                    `tfsdk:"created_at"`
 	Enabled        types.Bool                     `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginPrometheusDataSourceModel struct {
 	InstanceName   types.String                   `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering     `tfsdk:"ordering"`
 	Protocols      []types.String                 `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer           `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer           `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer           `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer           `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                 `tfsdk:"tags"`
 	UpdatedAt      types.Int64                    `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginprometheus_resource.go
+++ b/internal/provider/gatewaypluginprometheus_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -35,8 +37,8 @@ type GatewayPluginPrometheusResource struct {
 // GatewayPluginPrometheusResourceModel describes the resource data model.
 type GatewayPluginPrometheusResourceModel struct {
 	Config         tfTypes.PrometheusPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer           `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer           `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer           `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer           `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                   `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                    `tfsdk:"created_at"`
 	Enabled        types.Bool                     `tfsdk:"enabled"`
@@ -44,8 +46,8 @@ type GatewayPluginPrometheusResourceModel struct {
 	InstanceName   types.String                   `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering     `tfsdk:"ordering"`
 	Protocols      []types.String                 `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer           `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer           `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer           `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer           `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                 `tfsdk:"tags"`
 	UpdatedAt      types.Int64                    `tfsdk:"updated_at"`
 }
@@ -96,6 +98,9 @@ func (r *GatewayPluginPrometheusResource) Schema(ctx context.Context, req resour
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -107,6 +112,9 @@ func (r *GatewayPluginPrometheusResource) Schema(ctx context.Context, req resour
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -175,6 +183,9 @@ func (r *GatewayPluginPrometheusResource) Schema(ctx context.Context, req resour
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -186,6 +197,9 @@ func (r *GatewayPluginPrometheusResource) Schema(ctx context.Context, req resour
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginproxycache_data_source.go
+++ b/internal/provider/gatewaypluginproxycache_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginProxyCacheDataSource struct {
 // GatewayPluginProxyCacheDataSourceModel describes the data model.
 type GatewayPluginProxyCacheDataSourceModel struct {
 	Config         tfTypes.ProxyCachePluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer           `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer           `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer           `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer           `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                   `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                    `tfsdk:"created_at"`
 	Enabled        types.Bool                     `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginProxyCacheDataSourceModel struct {
 	InstanceName   types.String                   `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering     `tfsdk:"ordering"`
 	Protocols      []types.String                 `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer           `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer           `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer           `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer           `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                 `tfsdk:"tags"`
 	UpdatedAt      types.Int64                    `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginproxycache_resource.go
+++ b/internal/provider/gatewaypluginproxycache_resource.go
@@ -8,9 +8,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -37,8 +39,8 @@ type GatewayPluginProxyCacheResource struct {
 // GatewayPluginProxyCacheResourceModel describes the resource data model.
 type GatewayPluginProxyCacheResourceModel struct {
 	Config         tfTypes.ProxyCachePluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer           `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer           `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer           `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer           `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                   `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                    `tfsdk:"created_at"`
 	Enabled        types.Bool                     `tfsdk:"enabled"`
@@ -46,8 +48,8 @@ type GatewayPluginProxyCacheResourceModel struct {
 	InstanceName   types.String                   `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering     `tfsdk:"ordering"`
 	Protocols      []types.String                 `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer           `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer           `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer           `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer           `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                 `tfsdk:"tags"`
 	UpdatedAt      types.Int64                    `tfsdk:"updated_at"`
 }
@@ -155,6 +157,9 @@ func (r *GatewayPluginProxyCacheResource) Schema(ctx context.Context, req resour
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -166,6 +171,9 @@ func (r *GatewayPluginProxyCacheResource) Schema(ctx context.Context, req resour
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -234,6 +242,9 @@ func (r *GatewayPluginProxyCacheResource) Schema(ctx context.Context, req resour
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -245,6 +256,9 @@ func (r *GatewayPluginProxyCacheResource) Schema(ctx context.Context, req resour
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginproxycacheadvanced_data_source.go
+++ b/internal/provider/gatewaypluginproxycacheadvanced_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginProxyCacheAdvancedDataSource struct {
 // GatewayPluginProxyCacheAdvancedDataSourceModel describes the data model.
 type GatewayPluginProxyCacheAdvancedDataSourceModel struct {
 	Config         tfTypes.ProxyCacheAdvancedPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                   `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                   `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                   `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                   `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                           `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                            `tfsdk:"created_at"`
 	Enabled        types.Bool                             `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginProxyCacheAdvancedDataSourceModel struct {
 	InstanceName   types.String                           `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering             `tfsdk:"ordering"`
 	Protocols      []types.String                         `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                   `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                   `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                   `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                   `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                         `tfsdk:"tags"`
 	UpdatedAt      types.Int64                            `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginproxycacheadvanced_resource.go
+++ b/internal/provider/gatewaypluginproxycacheadvanced_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -39,8 +41,8 @@ type GatewayPluginProxyCacheAdvancedResource struct {
 // GatewayPluginProxyCacheAdvancedResourceModel describes the resource data model.
 type GatewayPluginProxyCacheAdvancedResourceModel struct {
 	Config         tfTypes.ProxyCacheAdvancedPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                   `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                   `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                   `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                   `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                           `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                            `tfsdk:"created_at"`
 	Enabled        types.Bool                             `tfsdk:"enabled"`
@@ -48,8 +50,8 @@ type GatewayPluginProxyCacheAdvancedResourceModel struct {
 	InstanceName   types.String                           `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering             `tfsdk:"ordering"`
 	Protocols      []types.String                         `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                   `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                   `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                   `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                   `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                         `tfsdk:"tags"`
 	UpdatedAt      types.Int64                            `tfsdk:"updated_at"`
 }
@@ -342,6 +344,9 @@ func (r *GatewayPluginProxyCacheAdvancedResource) Schema(ctx context.Context, re
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -353,6 +358,9 @@ func (r *GatewayPluginProxyCacheAdvancedResource) Schema(ctx context.Context, re
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -421,6 +429,9 @@ func (r *GatewayPluginProxyCacheAdvancedResource) Schema(ctx context.Context, re
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -432,6 +443,9 @@ func (r *GatewayPluginProxyCacheAdvancedResource) Schema(ctx context.Context, re
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginratelimiting_data_source.go
+++ b/internal/provider/gatewaypluginratelimiting_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginRateLimitingDataSource struct {
 // GatewayPluginRateLimitingDataSourceModel describes the data model.
 type GatewayPluginRateLimitingDataSourceModel struct {
 	Config         tfTypes.RateLimitingPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer             `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer             `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer             `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer             `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                     `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                      `tfsdk:"created_at"`
 	Enabled        types.Bool                       `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginRateLimitingDataSourceModel struct {
 	InstanceName   types.String                     `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering       `tfsdk:"ordering"`
 	Protocols      []types.String                   `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer             `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer             `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer             `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer             `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                   `tfsdk:"tags"`
 	UpdatedAt      types.Int64                      `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginratelimiting_resource.go
+++ b/internal/provider/gatewaypluginratelimiting_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -38,8 +40,8 @@ type GatewayPluginRateLimitingResource struct {
 // GatewayPluginRateLimitingResourceModel describes the resource data model.
 type GatewayPluginRateLimitingResourceModel struct {
 	Config         tfTypes.RateLimitingPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer             `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer             `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer             `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer             `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                     `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                      `tfsdk:"created_at"`
 	Enabled        types.Bool                       `tfsdk:"enabled"`
@@ -47,8 +49,8 @@ type GatewayPluginRateLimitingResourceModel struct {
 	InstanceName   types.String                     `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering       `tfsdk:"ordering"`
 	Protocols      []types.String                   `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer             `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer             `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer             `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer             `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                   `tfsdk:"tags"`
 	UpdatedAt      types.Int64                      `tfsdk:"updated_at"`
 }
@@ -220,6 +222,9 @@ func (r *GatewayPluginRateLimitingResource) Schema(ctx context.Context, req reso
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -231,6 +236,9 @@ func (r *GatewayPluginRateLimitingResource) Schema(ctx context.Context, req reso
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -299,6 +307,9 @@ func (r *GatewayPluginRateLimitingResource) Schema(ctx context.Context, req reso
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -310,6 +321,9 @@ func (r *GatewayPluginRateLimitingResource) Schema(ctx context.Context, req reso
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginratelimitingadvanced_data_source.go
+++ b/internal/provider/gatewaypluginratelimitingadvanced_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginRateLimitingAdvancedDataSource struct {
 // GatewayPluginRateLimitingAdvancedDataSourceModel describes the data model.
 type GatewayPluginRateLimitingAdvancedDataSourceModel struct {
 	Config         tfTypes.RateLimitingAdvancedPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                     `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                     `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                     `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                     `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                             `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                              `tfsdk:"created_at"`
 	Enabled        types.Bool                               `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginRateLimitingAdvancedDataSourceModel struct {
 	InstanceName   types.String                             `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering               `tfsdk:"ordering"`
 	Protocols      []types.String                           `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                     `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                     `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                     `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                     `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                           `tfsdk:"tags"`
 	UpdatedAt      types.Int64                              `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginratelimitingadvanced_resource.go
+++ b/internal/provider/gatewaypluginratelimitingadvanced_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -39,8 +41,8 @@ type GatewayPluginRateLimitingAdvancedResource struct {
 // GatewayPluginRateLimitingAdvancedResourceModel describes the resource data model.
 type GatewayPluginRateLimitingAdvancedResourceModel struct {
 	Config         tfTypes.RateLimitingAdvancedPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                     `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                     `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                     `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                     `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                             `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                              `tfsdk:"created_at"`
 	Enabled        types.Bool                               `tfsdk:"enabled"`
@@ -48,8 +50,8 @@ type GatewayPluginRateLimitingAdvancedResourceModel struct {
 	InstanceName   types.String                             `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering               `tfsdk:"ordering"`
 	Protocols      []types.String                           `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                     `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                     `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                     `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                     `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                           `tfsdk:"tags"`
 	UpdatedAt      types.Int64                              `tfsdk:"updated_at"`
 }
@@ -358,6 +360,9 @@ func (r *GatewayPluginRateLimitingAdvancedResource) Schema(ctx context.Context, 
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -369,6 +374,9 @@ func (r *GatewayPluginRateLimitingAdvancedResource) Schema(ctx context.Context, 
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -437,6 +445,9 @@ func (r *GatewayPluginRateLimitingAdvancedResource) Schema(ctx context.Context, 
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -448,6 +459,9 @@ func (r *GatewayPluginRateLimitingAdvancedResource) Schema(ctx context.Context, 
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginrequestsizelimiting_data_source.go
+++ b/internal/provider/gatewaypluginrequestsizelimiting_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginRequestSizeLimitingDataSource struct {
 // GatewayPluginRequestSizeLimitingDataSourceModel describes the data model.
 type GatewayPluginRequestSizeLimitingDataSourceModel struct {
 	Config         tfTypes.RequestSizeLimitingPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                    `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                    `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                    `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                    `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                            `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                             `tfsdk:"created_at"`
 	Enabled        types.Bool                              `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginRequestSizeLimitingDataSourceModel struct {
 	InstanceName   types.String                            `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering              `tfsdk:"ordering"`
 	Protocols      []types.String                          `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                    `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                    `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                    `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                    `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                          `tfsdk:"tags"`
 	UpdatedAt      types.Int64                             `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginrequestsizelimiting_resource.go
+++ b/internal/provider/gatewaypluginrequestsizelimiting_resource.go
@@ -8,9 +8,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -37,8 +39,8 @@ type GatewayPluginRequestSizeLimitingResource struct {
 // GatewayPluginRequestSizeLimitingResourceModel describes the resource data model.
 type GatewayPluginRequestSizeLimitingResourceModel struct {
 	Config         tfTypes.RequestSizeLimitingPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                    `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                    `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                    `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                    `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                            `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                             `tfsdk:"created_at"`
 	Enabled        types.Bool                              `tfsdk:"enabled"`
@@ -46,8 +48,8 @@ type GatewayPluginRequestSizeLimitingResourceModel struct {
 	InstanceName   types.String                            `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering              `tfsdk:"ordering"`
 	Protocols      []types.String                          `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                    `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                    `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                    `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                    `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                          `tfsdk:"tags"`
 	UpdatedAt      types.Int64                             `tfsdk:"updated_at"`
 }
@@ -90,6 +92,9 @@ func (r *GatewayPluginRequestSizeLimitingResource) Schema(ctx context.Context, r
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -101,6 +106,9 @@ func (r *GatewayPluginRequestSizeLimitingResource) Schema(ctx context.Context, r
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -169,6 +177,9 @@ func (r *GatewayPluginRequestSizeLimitingResource) Schema(ctx context.Context, r
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -180,6 +191,9 @@ func (r *GatewayPluginRequestSizeLimitingResource) Schema(ctx context.Context, r
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginrequesttermination_data_source.go
+++ b/internal/provider/gatewaypluginrequesttermination_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginRequestTerminationDataSource struct {
 // GatewayPluginRequestTerminationDataSourceModel describes the data model.
 type GatewayPluginRequestTerminationDataSourceModel struct {
 	Config         tfTypes.RequestTerminationPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                   `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                   `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                   `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                   `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                           `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                            `tfsdk:"created_at"`
 	Enabled        types.Bool                             `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginRequestTerminationDataSourceModel struct {
 	InstanceName   types.String                           `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering             `tfsdk:"ordering"`
 	Protocols      []types.String                         `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                   `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                   `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                   `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                   `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                         `tfsdk:"tags"`
 	UpdatedAt      types.Int64                            `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginrequesttermination_resource.go
+++ b/internal/provider/gatewaypluginrequesttermination_resource.go
@@ -8,9 +8,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -37,8 +39,8 @@ type GatewayPluginRequestTerminationResource struct {
 // GatewayPluginRequestTerminationResourceModel describes the resource data model.
 type GatewayPluginRequestTerminationResourceModel struct {
 	Config         tfTypes.RequestTerminationPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                   `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                   `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                   `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                   `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                           `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                            `tfsdk:"created_at"`
 	Enabled        types.Bool                             `tfsdk:"enabled"`
@@ -46,8 +48,8 @@ type GatewayPluginRequestTerminationResourceModel struct {
 	InstanceName   types.String                           `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering             `tfsdk:"ordering"`
 	Protocols      []types.String                         `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                   `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                   `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                   `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                   `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                         `tfsdk:"tags"`
 	UpdatedAt      types.Int64                            `tfsdk:"updated_at"`
 }
@@ -101,6 +103,9 @@ func (r *GatewayPluginRequestTerminationResource) Schema(ctx context.Context, re
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -112,6 +117,9 @@ func (r *GatewayPluginRequestTerminationResource) Schema(ctx context.Context, re
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -180,6 +188,9 @@ func (r *GatewayPluginRequestTerminationResource) Schema(ctx context.Context, re
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -191,6 +202,9 @@ func (r *GatewayPluginRequestTerminationResource) Schema(ctx context.Context, re
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginrequesttransformer_data_source.go
+++ b/internal/provider/gatewaypluginrequesttransformer_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginRequestTransformerDataSource struct {
 // GatewayPluginRequestTransformerDataSourceModel describes the data model.
 type GatewayPluginRequestTransformerDataSourceModel struct {
 	Config         tfTypes.RequestTransformerPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                   `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                   `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                   `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                   `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                           `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                            `tfsdk:"created_at"`
 	Enabled        types.Bool                             `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginRequestTransformerDataSourceModel struct {
 	InstanceName   types.String                           `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering             `tfsdk:"ordering"`
 	Protocols      []types.String                         `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                   `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                   `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                   `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                   `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                         `tfsdk:"tags"`
 	UpdatedAt      types.Int64                            `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginrequesttransformer_resource.go
+++ b/internal/provider/gatewaypluginrequesttransformer_resource.go
@@ -8,9 +8,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -38,8 +40,8 @@ type GatewayPluginRequestTransformerResource struct {
 // GatewayPluginRequestTransformerResourceModel describes the resource data model.
 type GatewayPluginRequestTransformerResourceModel struct {
 	Config         tfTypes.RequestTransformerPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                   `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                   `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                   `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                   `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                           `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                            `tfsdk:"created_at"`
 	Enabled        types.Bool                             `tfsdk:"enabled"`
@@ -47,8 +49,8 @@ type GatewayPluginRequestTransformerResourceModel struct {
 	InstanceName   types.String                           `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering             `tfsdk:"ordering"`
 	Protocols      []types.String                         `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                   `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                   `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                   `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                   `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                         `tfsdk:"tags"`
 	UpdatedAt      types.Int64                            `tfsdk:"updated_at"`
 }
@@ -186,6 +188,9 @@ func (r *GatewayPluginRequestTransformerResource) Schema(ctx context.Context, re
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -197,6 +202,9 @@ func (r *GatewayPluginRequestTransformerResource) Schema(ctx context.Context, re
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -265,6 +273,9 @@ func (r *GatewayPluginRequestTransformerResource) Schema(ctx context.Context, re
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -276,6 +287,9 @@ func (r *GatewayPluginRequestTransformerResource) Schema(ctx context.Context, re
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginrequesttransformeradvanced_data_source.go
+++ b/internal/provider/gatewaypluginrequesttransformeradvanced_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginRequestTransformerAdvancedDataSource struct {
 // GatewayPluginRequestTransformerAdvancedDataSourceModel describes the data model.
 type GatewayPluginRequestTransformerAdvancedDataSourceModel struct {
 	Config         tfTypes.RequestTransformerAdvancedPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                           `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                           `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                           `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                           `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                                   `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                                    `tfsdk:"created_at"`
 	Enabled        types.Bool                                     `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginRequestTransformerAdvancedDataSourceModel struct {
 	InstanceName   types.String                                   `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering                     `tfsdk:"ordering"`
 	Protocols      []types.String                                 `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                           `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                           `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                           `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                           `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                                 `tfsdk:"tags"`
 	UpdatedAt      types.Int64                                    `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginrequesttransformeradvanced_resource.go
+++ b/internal/provider/gatewaypluginrequesttransformeradvanced_resource.go
@@ -8,9 +8,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -38,8 +40,8 @@ type GatewayPluginRequestTransformerAdvancedResource struct {
 // GatewayPluginRequestTransformerAdvancedResourceModel describes the resource data model.
 type GatewayPluginRequestTransformerAdvancedResourceModel struct {
 	Config         tfTypes.RequestTransformerAdvancedPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                           `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                           `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                           `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                           `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                                   `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                                    `tfsdk:"created_at"`
 	Enabled        types.Bool                                     `tfsdk:"enabled"`
@@ -47,8 +49,8 @@ type GatewayPluginRequestTransformerAdvancedResourceModel struct {
 	InstanceName   types.String                                   `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering                     `tfsdk:"ordering"`
 	Protocols      []types.String                                 `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                           `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                           `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                           `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                           `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                                 `tfsdk:"tags"`
 	UpdatedAt      types.Int64                                    `tfsdk:"updated_at"`
 }
@@ -217,6 +219,9 @@ func (r *GatewayPluginRequestTransformerAdvancedResource) Schema(ctx context.Con
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -228,6 +233,9 @@ func (r *GatewayPluginRequestTransformerAdvancedResource) Schema(ctx context.Con
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -296,6 +304,9 @@ func (r *GatewayPluginRequestTransformerAdvancedResource) Schema(ctx context.Con
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -307,6 +318,9 @@ func (r *GatewayPluginRequestTransformerAdvancedResource) Schema(ctx context.Con
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginrequestvalidator_data_source.go
+++ b/internal/provider/gatewaypluginrequestvalidator_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginRequestValidatorDataSource struct {
 // GatewayPluginRequestValidatorDataSourceModel describes the data model.
 type GatewayPluginRequestValidatorDataSourceModel struct {
 	Config         tfTypes.RequestValidatorPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                 `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                 `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                 `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                 `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                         `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                          `tfsdk:"created_at"`
 	Enabled        types.Bool                           `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginRequestValidatorDataSourceModel struct {
 	InstanceName   types.String                         `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering           `tfsdk:"ordering"`
 	Protocols      []types.String                       `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                 `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                 `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                 `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                 `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                       `tfsdk:"tags"`
 	UpdatedAt      types.Int64                          `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginrequestvalidator_resource.go
+++ b/internal/provider/gatewaypluginrequestvalidator_resource.go
@@ -8,9 +8,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -40,8 +42,8 @@ type GatewayPluginRequestValidatorResource struct {
 // GatewayPluginRequestValidatorResourceModel describes the resource data model.
 type GatewayPluginRequestValidatorResourceModel struct {
 	Config         tfTypes.RequestValidatorPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                 `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                 `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                 `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                 `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                         `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                          `tfsdk:"created_at"`
 	Enabled        types.Bool                           `tfsdk:"enabled"`
@@ -49,8 +51,8 @@ type GatewayPluginRequestValidatorResourceModel struct {
 	InstanceName   types.String                         `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering           `tfsdk:"ordering"`
 	Protocols      []types.String                       `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                 `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                 `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                 `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                 `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                       `tfsdk:"tags"`
 	UpdatedAt      types.Int64                          `tfsdk:"updated_at"`
 }
@@ -170,6 +172,9 @@ func (r *GatewayPluginRequestValidatorResource) Schema(ctx context.Context, req 
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -181,6 +186,9 @@ func (r *GatewayPluginRequestValidatorResource) Schema(ctx context.Context, req 
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -249,6 +257,9 @@ func (r *GatewayPluginRequestValidatorResource) Schema(ctx context.Context, req 
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -260,6 +271,9 @@ func (r *GatewayPluginRequestValidatorResource) Schema(ctx context.Context, req 
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginresponseratelimiting_data_source.go
+++ b/internal/provider/gatewaypluginresponseratelimiting_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginResponseRatelimitingDataSource struct {
 // GatewayPluginResponseRatelimitingDataSourceModel describes the data model.
 type GatewayPluginResponseRatelimitingDataSourceModel struct {
 	Config         tfTypes.ResponseRatelimitingPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                     `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                     `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                     `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                     `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                             `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                              `tfsdk:"created_at"`
 	Enabled        types.Bool                               `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginResponseRatelimitingDataSourceModel struct {
 	InstanceName   types.String                             `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering               `tfsdk:"ordering"`
 	Protocols      []types.String                           `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                     `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                     `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                     `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                     `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                           `tfsdk:"tags"`
 	UpdatedAt      types.Int64                              `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginresponseratelimiting_resource.go
+++ b/internal/provider/gatewaypluginresponseratelimiting_resource.go
@@ -10,9 +10,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -40,8 +42,8 @@ type GatewayPluginResponseRatelimitingResource struct {
 // GatewayPluginResponseRatelimitingResourceModel describes the resource data model.
 type GatewayPluginResponseRatelimitingResourceModel struct {
 	Config         tfTypes.ResponseRatelimitingPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                     `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                     `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                     `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                     `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                             `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                              `tfsdk:"created_at"`
 	Enabled        types.Bool                               `tfsdk:"enabled"`
@@ -49,8 +51,8 @@ type GatewayPluginResponseRatelimitingResourceModel struct {
 	InstanceName   types.String                             `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering               `tfsdk:"ordering"`
 	Protocols      []types.String                           `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                     `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                     `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                     `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                     `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                           `tfsdk:"tags"`
 	UpdatedAt      types.Int64                              `tfsdk:"updated_at"`
 }
@@ -182,6 +184,9 @@ func (r *GatewayPluginResponseRatelimitingResource) Schema(ctx context.Context, 
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -193,6 +198,9 @@ func (r *GatewayPluginResponseRatelimitingResource) Schema(ctx context.Context, 
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -261,6 +269,9 @@ func (r *GatewayPluginResponseRatelimitingResource) Schema(ctx context.Context, 
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -272,6 +283,9 @@ func (r *GatewayPluginResponseRatelimitingResource) Schema(ctx context.Context, 
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginresponsetransformer_data_source.go
+++ b/internal/provider/gatewaypluginresponsetransformer_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginResponseTransformerDataSource struct {
 // GatewayPluginResponseTransformerDataSourceModel describes the data model.
 type GatewayPluginResponseTransformerDataSourceModel struct {
 	Config         tfTypes.ResponseTransformerPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                    `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                    `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                    `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                    `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                            `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                             `tfsdk:"created_at"`
 	Enabled        types.Bool                              `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginResponseTransformerDataSourceModel struct {
 	InstanceName   types.String                            `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering              `tfsdk:"ordering"`
 	Protocols      []types.String                          `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                    `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                    `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                    `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                    `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                          `tfsdk:"tags"`
 	UpdatedAt      types.Int64                             `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginresponsetransformer_resource.go
+++ b/internal/provider/gatewaypluginresponsetransformer_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -35,8 +37,8 @@ type GatewayPluginResponseTransformerResource struct {
 // GatewayPluginResponseTransformerResourceModel describes the resource data model.
 type GatewayPluginResponseTransformerResourceModel struct {
 	Config         tfTypes.ResponseTransformerPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                    `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                    `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                    `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                    `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                            `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                             `tfsdk:"created_at"`
 	Enabled        types.Bool                              `tfsdk:"enabled"`
@@ -44,8 +46,8 @@ type GatewayPluginResponseTransformerResourceModel struct {
 	InstanceName   types.String                            `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering              `tfsdk:"ordering"`
 	Protocols      []types.String                          `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                    `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                    `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                    `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                    `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                          `tfsdk:"tags"`
 	UpdatedAt      types.Int64                             `tfsdk:"updated_at"`
 }
@@ -167,6 +169,9 @@ func (r *GatewayPluginResponseTransformerResource) Schema(ctx context.Context, r
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -178,6 +183,9 @@ func (r *GatewayPluginResponseTransformerResource) Schema(ctx context.Context, r
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -246,6 +254,9 @@ func (r *GatewayPluginResponseTransformerResource) Schema(ctx context.Context, r
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -257,6 +268,9 @@ func (r *GatewayPluginResponseTransformerResource) Schema(ctx context.Context, r
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginresponsetransformeradvanced_data_source.go
+++ b/internal/provider/gatewaypluginresponsetransformeradvanced_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginResponseTransformerAdvancedDataSource struct {
 // GatewayPluginResponseTransformerAdvancedDataSourceModel describes the data model.
 type GatewayPluginResponseTransformerAdvancedDataSourceModel struct {
 	Config         tfTypes.ResponseTransformerAdvancedPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                            `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                            `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                            `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                            `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                                    `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                                     `tfsdk:"created_at"`
 	Enabled        types.Bool                                      `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginResponseTransformerAdvancedDataSourceModel struct {
 	InstanceName   types.String                                    `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering                      `tfsdk:"ordering"`
 	Protocols      []types.String                                  `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                            `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                            `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                            `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                            `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                                  `tfsdk:"tags"`
 	UpdatedAt      types.Int64                                     `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginresponsetransformeradvanced_resource.go
+++ b/internal/provider/gatewaypluginresponsetransformeradvanced_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -35,8 +37,8 @@ type GatewayPluginResponseTransformerAdvancedResource struct {
 // GatewayPluginResponseTransformerAdvancedResourceModel describes the resource data model.
 type GatewayPluginResponseTransformerAdvancedResourceModel struct {
 	Config         tfTypes.ResponseTransformerAdvancedPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                            `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                            `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                            `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                            `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                                    `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                                     `tfsdk:"created_at"`
 	Enabled        types.Bool                                      `tfsdk:"enabled"`
@@ -44,8 +46,8 @@ type GatewayPluginResponseTransformerAdvancedResourceModel struct {
 	InstanceName   types.String                                    `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering                      `tfsdk:"ordering"`
 	Protocols      []types.String                                  `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                            `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                            `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                            `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                            `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                                  `tfsdk:"tags"`
 	UpdatedAt      types.Int64                                     `tfsdk:"updated_at"`
 }
@@ -223,6 +225,9 @@ func (r *GatewayPluginResponseTransformerAdvancedResource) Schema(ctx context.Co
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -234,6 +239,9 @@ func (r *GatewayPluginResponseTransformerAdvancedResource) Schema(ctx context.Co
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -302,6 +310,9 @@ func (r *GatewayPluginResponseTransformerAdvancedResource) Schema(ctx context.Co
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -313,6 +324,9 @@ func (r *GatewayPluginResponseTransformerAdvancedResource) Schema(ctx context.Co
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginroutebyheader_data_source.go
+++ b/internal/provider/gatewaypluginroutebyheader_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginRouteByHeaderDataSource struct {
 // GatewayPluginRouteByHeaderDataSourceModel describes the data model.
 type GatewayPluginRouteByHeaderDataSourceModel struct {
 	Config         tfTypes.RouteByHeaderPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer              `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer              `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer              `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer              `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                      `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                       `tfsdk:"created_at"`
 	Enabled        types.Bool                        `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginRouteByHeaderDataSourceModel struct {
 	InstanceName   types.String                      `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering        `tfsdk:"ordering"`
 	Protocols      []types.String                    `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer              `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer              `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer              `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer              `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                    `tfsdk:"tags"`
 	UpdatedAt      types.Int64                       `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginroutebyheader_resource.go
+++ b/internal/provider/gatewaypluginroutebyheader_resource.go
@@ -8,9 +8,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -41,8 +43,8 @@ type GatewayPluginRouteByHeaderResource struct {
 // GatewayPluginRouteByHeaderResourceModel describes the resource data model.
 type GatewayPluginRouteByHeaderResourceModel struct {
 	Config         tfTypes.RouteByHeaderPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer              `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer              `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer              `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer              `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                      `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                       `tfsdk:"created_at"`
 	Enabled        types.Bool                        `tfsdk:"enabled"`
@@ -50,8 +52,8 @@ type GatewayPluginRouteByHeaderResourceModel struct {
 	InstanceName   types.String                      `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering        `tfsdk:"ordering"`
 	Protocols      []types.String                    `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer              `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer              `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer              `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer              `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                    `tfsdk:"tags"`
 	UpdatedAt      types.Int64                       `tfsdk:"updated_at"`
 }
@@ -102,6 +104,9 @@ func (r *GatewayPluginRouteByHeaderResource) Schema(ctx context.Context, req res
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -113,6 +118,9 @@ func (r *GatewayPluginRouteByHeaderResource) Schema(ctx context.Context, req res
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -181,6 +189,9 @@ func (r *GatewayPluginRouteByHeaderResource) Schema(ctx context.Context, req res
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -192,6 +203,9 @@ func (r *GatewayPluginRouteByHeaderResource) Schema(ctx context.Context, req res
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginroutetransformeradvanced_data_source.go
+++ b/internal/provider/gatewaypluginroutetransformeradvanced_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginRouteTransformerAdvancedDataSource struct {
 // GatewayPluginRouteTransformerAdvancedDataSourceModel describes the data model.
 type GatewayPluginRouteTransformerAdvancedDataSourceModel struct {
 	Config         tfTypes.RouteTransformerAdvancedPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                         `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                         `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                         `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                         `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                                 `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                                  `tfsdk:"created_at"`
 	Enabled        types.Bool                                   `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginRouteTransformerAdvancedDataSourceModel struct {
 	InstanceName   types.String                                 `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering                   `tfsdk:"ordering"`
 	Protocols      []types.String                               `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                         `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                         `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                         `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                         `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                               `tfsdk:"tags"`
 	UpdatedAt      types.Int64                                  `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginroutetransformeradvanced_resource.go
+++ b/internal/provider/gatewaypluginroutetransformeradvanced_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -35,8 +37,8 @@ type GatewayPluginRouteTransformerAdvancedResource struct {
 // GatewayPluginRouteTransformerAdvancedResourceModel describes the resource data model.
 type GatewayPluginRouteTransformerAdvancedResourceModel struct {
 	Config         tfTypes.RouteTransformerAdvancedPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                         `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                         `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                         `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                         `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                                 `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                                  `tfsdk:"created_at"`
 	Enabled        types.Bool                                   `tfsdk:"enabled"`
@@ -44,8 +46,8 @@ type GatewayPluginRouteTransformerAdvancedResourceModel struct {
 	InstanceName   types.String                                 `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering                   `tfsdk:"ordering"`
 	Protocols      []types.String                               `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                         `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                         `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                         `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                         `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                               `tfsdk:"tags"`
 	UpdatedAt      types.Int64                                  `tfsdk:"updated_at"`
 }
@@ -82,6 +84,9 @@ func (r *GatewayPluginRouteTransformerAdvancedResource) Schema(ctx context.Conte
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -93,6 +98,9 @@ func (r *GatewayPluginRouteTransformerAdvancedResource) Schema(ctx context.Conte
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -161,6 +169,9 @@ func (r *GatewayPluginRouteTransformerAdvancedResource) Schema(ctx context.Conte
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -172,6 +183,9 @@ func (r *GatewayPluginRouteTransformerAdvancedResource) Schema(ctx context.Conte
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginsaml_data_source.go
+++ b/internal/provider/gatewaypluginsaml_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginSamlDataSource struct {
 // GatewayPluginSamlDataSourceModel describes the data model.
 type GatewayPluginSamlDataSourceModel struct {
 	Config         tfTypes.SamlPluginConfig   `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String               `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                `tfsdk:"created_at"`
 	Enabled        types.Bool                 `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginSamlDataSourceModel struct {
 	InstanceName   types.String               `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering `tfsdk:"ordering"`
 	Protocols      []types.String             `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer       `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer       `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer       `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer       `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String             `tfsdk:"tags"`
 	UpdatedAt      types.Int64                `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginsaml_resource.go
+++ b/internal/provider/gatewaypluginsaml_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -40,8 +42,8 @@ type GatewayPluginSamlResource struct {
 // GatewayPluginSamlResourceModel describes the resource data model.
 type GatewayPluginSamlResourceModel struct {
 	Config         tfTypes.SamlPluginConfig   `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String               `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                `tfsdk:"created_at"`
 	Enabled        types.Bool                 `tfsdk:"enabled"`
@@ -49,8 +51,8 @@ type GatewayPluginSamlResourceModel struct {
 	InstanceName   types.String               `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering `tfsdk:"ordering"`
 	Protocols      []types.String             `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer       `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer       `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer       `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer       `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String             `tfsdk:"tags"`
 	UpdatedAt      types.Int64                `tfsdk:"updated_at"`
 }
@@ -514,6 +516,9 @@ func (r *GatewayPluginSamlResource) Schema(ctx context.Context, req resource.Sch
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -525,6 +530,9 @@ func (r *GatewayPluginSamlResource) Schema(ctx context.Context, req resource.Sch
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -593,6 +601,9 @@ func (r *GatewayPluginSamlResource) Schema(ctx context.Context, req resource.Sch
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -604,6 +615,9 @@ func (r *GatewayPluginSamlResource) Schema(ctx context.Context, req resource.Sch
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginsession_data_source.go
+++ b/internal/provider/gatewaypluginsession_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginSessionDataSource struct {
 // GatewayPluginSessionDataSourceModel describes the data model.
 type GatewayPluginSessionDataSourceModel struct {
 	Config         tfTypes.SessionPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer        `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer        `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer        `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer        `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                 `tfsdk:"created_at"`
 	Enabled        types.Bool                  `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginSessionDataSourceModel struct {
 	InstanceName   types.String                `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering  `tfsdk:"ordering"`
 	Protocols      []types.String              `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer        `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer        `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer        `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer        `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String              `tfsdk:"tags"`
 	UpdatedAt      types.Int64                 `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginsession_resource.go
+++ b/internal/provider/gatewaypluginsession_resource.go
@@ -8,9 +8,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -37,8 +39,8 @@ type GatewayPluginSessionResource struct {
 // GatewayPluginSessionResourceModel describes the resource data model.
 type GatewayPluginSessionResourceModel struct {
 	Config         tfTypes.SessionPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer        `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer        `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer        `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer        `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                 `tfsdk:"created_at"`
 	Enabled        types.Bool                  `tfsdk:"enabled"`
@@ -46,8 +48,8 @@ type GatewayPluginSessionResourceModel struct {
 	InstanceName   types.String                `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering  `tfsdk:"ordering"`
 	Protocols      []types.String              `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer        `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer        `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer        `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer        `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String              `tfsdk:"tags"`
 	UpdatedAt      types.Int64                 `tfsdk:"updated_at"`
 }
@@ -199,6 +201,9 @@ func (r *GatewayPluginSessionResource) Schema(ctx context.Context, req resource.
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -210,6 +215,9 @@ func (r *GatewayPluginSessionResource) Schema(ctx context.Context, req resource.
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -278,6 +286,9 @@ func (r *GatewayPluginSessionResource) Schema(ctx context.Context, req resource.
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -289,6 +300,9 @@ func (r *GatewayPluginSessionResource) Schema(ctx context.Context, req resource.
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginstatsd_data_source.go
+++ b/internal/provider/gatewaypluginstatsd_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginStatsdDataSource struct {
 // GatewayPluginStatsdDataSourceModel describes the data model.
 type GatewayPluginStatsdDataSourceModel struct {
 	Config         tfTypes.StatsdPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String               `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                `tfsdk:"created_at"`
 	Enabled        types.Bool                 `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginStatsdDataSourceModel struct {
 	InstanceName   types.String               `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering `tfsdk:"ordering"`
 	Protocols      []types.String             `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer       `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer       `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer       `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer       `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String             `tfsdk:"tags"`
 	UpdatedAt      types.Int64                `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginstatsd_resource.go
+++ b/internal/provider/gatewaypluginstatsd_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -40,8 +42,8 @@ type GatewayPluginStatsdResource struct {
 // GatewayPluginStatsdResourceModel describes the resource data model.
 type GatewayPluginStatsdResourceModel struct {
 	Config         tfTypes.StatsdPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String               `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                `tfsdk:"created_at"`
 	Enabled        types.Bool                 `tfsdk:"enabled"`
@@ -49,8 +51,8 @@ type GatewayPluginStatsdResourceModel struct {
 	InstanceName   types.String               `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering `tfsdk:"ordering"`
 	Protocols      []types.String             `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer       `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer       `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer       `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer       `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String             `tfsdk:"tags"`
 	UpdatedAt      types.Int64                `tfsdk:"updated_at"`
 }
@@ -317,6 +319,9 @@ func (r *GatewayPluginStatsdResource) Schema(ctx context.Context, req resource.S
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -328,6 +333,9 @@ func (r *GatewayPluginStatsdResource) Schema(ctx context.Context, req resource.S
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -396,6 +404,9 @@ func (r *GatewayPluginStatsdResource) Schema(ctx context.Context, req resource.S
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -407,6 +418,9 @@ func (r *GatewayPluginStatsdResource) Schema(ctx context.Context, req resource.S
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginstatsdadvanced_data_source.go
+++ b/internal/provider/gatewaypluginstatsdadvanced_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginStatsdAdvancedDataSource struct {
 // GatewayPluginStatsdAdvancedDataSourceModel describes the data model.
 type GatewayPluginStatsdAdvancedDataSourceModel struct {
 	Config         tfTypes.StatsdAdvancedPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer               `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer               `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer               `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer               `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                       `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                        `tfsdk:"created_at"`
 	Enabled        types.Bool                         `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginStatsdAdvancedDataSourceModel struct {
 	InstanceName   types.String                       `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering         `tfsdk:"ordering"`
 	Protocols      []types.String                     `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer               `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer               `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer               `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer               `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                     `tfsdk:"tags"`
 	UpdatedAt      types.Int64                        `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginstatsdadvanced_resource.go
+++ b/internal/provider/gatewaypluginstatsdadvanced_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -40,8 +42,8 @@ type GatewayPluginStatsdAdvancedResource struct {
 // GatewayPluginStatsdAdvancedResourceModel describes the resource data model.
 type GatewayPluginStatsdAdvancedResourceModel struct {
 	Config         tfTypes.StatsdAdvancedPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer               `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer               `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer               `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer               `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                       `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                        `tfsdk:"created_at"`
 	Enabled        types.Bool                         `tfsdk:"enabled"`
@@ -49,8 +51,8 @@ type GatewayPluginStatsdAdvancedResourceModel struct {
 	InstanceName   types.String                       `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering         `tfsdk:"ordering"`
 	Protocols      []types.String                     `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer               `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer               `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer               `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer               `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                     `tfsdk:"tags"`
 	UpdatedAt      types.Int64                        `tfsdk:"updated_at"`
 }
@@ -294,6 +296,9 @@ func (r *GatewayPluginStatsdAdvancedResource) Schema(ctx context.Context, req re
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -305,6 +310,9 @@ func (r *GatewayPluginStatsdAdvancedResource) Schema(ctx context.Context, req re
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -373,6 +381,9 @@ func (r *GatewayPluginStatsdAdvancedResource) Schema(ctx context.Context, req re
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -384,6 +395,9 @@ func (r *GatewayPluginStatsdAdvancedResource) Schema(ctx context.Context, req re
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginsyslog_data_source.go
+++ b/internal/provider/gatewaypluginsyslog_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginSyslogDataSource struct {
 // GatewayPluginSyslogDataSourceModel describes the data model.
 type GatewayPluginSyslogDataSourceModel struct {
 	Config         tfTypes.SyslogPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String               `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                `tfsdk:"created_at"`
 	Enabled        types.Bool                 `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginSyslogDataSourceModel struct {
 	InstanceName   types.String               `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering `tfsdk:"ordering"`
 	Protocols      []types.String             `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer       `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer       `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer       `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer       `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String             `tfsdk:"tags"`
 	UpdatedAt      types.Int64                `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginsyslog_resource.go
+++ b/internal/provider/gatewaypluginsyslog_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -39,8 +41,8 @@ type GatewayPluginSyslogResource struct {
 // GatewayPluginSyslogResourceModel describes the resource data model.
 type GatewayPluginSyslogResourceModel struct {
 	Config         tfTypes.SyslogPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String               `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                `tfsdk:"created_at"`
 	Enabled        types.Bool                 `tfsdk:"enabled"`
@@ -48,8 +50,8 @@ type GatewayPluginSyslogResourceModel struct {
 	InstanceName   types.String               `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering `tfsdk:"ordering"`
 	Protocols      []types.String             `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer       `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer       `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer       `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer       `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String             `tfsdk:"tags"`
 	UpdatedAt      types.Int64                `tfsdk:"updated_at"`
 }
@@ -176,6 +178,9 @@ func (r *GatewayPluginSyslogResource) Schema(ctx context.Context, req resource.S
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -187,6 +192,9 @@ func (r *GatewayPluginSyslogResource) Schema(ctx context.Context, req resource.S
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -255,6 +263,9 @@ func (r *GatewayPluginSyslogResource) Schema(ctx context.Context, req resource.S
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -266,6 +277,9 @@ func (r *GatewayPluginSyslogResource) Schema(ctx context.Context, req resource.S
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewayplugintcplog_data_source.go
+++ b/internal/provider/gatewayplugintcplog_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginTCPLogDataSource struct {
 // GatewayPluginTCPLogDataSourceModel describes the data model.
 type GatewayPluginTCPLogDataSourceModel struct {
 	Config         tfTypes.TCPLogPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String               `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                `tfsdk:"created_at"`
 	Enabled        types.Bool                 `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginTCPLogDataSourceModel struct {
 	InstanceName   types.String               `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering `tfsdk:"ordering"`
 	Protocols      []types.String             `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer       `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer       `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer       `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer       `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String             `tfsdk:"tags"`
 	UpdatedAt      types.Int64                `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewayplugintcplog_resource.go
+++ b/internal/provider/gatewayplugintcplog_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -39,8 +41,8 @@ type GatewayPluginTCPLogResource struct {
 // GatewayPluginTCPLogResourceModel describes the resource data model.
 type GatewayPluginTCPLogResourceModel struct {
 	Config         tfTypes.TCPLogPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String               `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                `tfsdk:"created_at"`
 	Enabled        types.Bool                 `tfsdk:"enabled"`
@@ -48,8 +50,8 @@ type GatewayPluginTCPLogResourceModel struct {
 	InstanceName   types.String               `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering `tfsdk:"ordering"`
 	Protocols      []types.String             `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer       `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer       `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer       `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer       `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String             `tfsdk:"tags"`
 	UpdatedAt      types.Int64                `tfsdk:"updated_at"`
 }
@@ -112,6 +114,9 @@ func (r *GatewayPluginTCPLogResource) Schema(ctx context.Context, req resource.S
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -123,6 +128,9 @@ func (r *GatewayPluginTCPLogResource) Schema(ctx context.Context, req resource.S
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -191,6 +199,9 @@ func (r *GatewayPluginTCPLogResource) Schema(ctx context.Context, req resource.S
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -202,6 +213,9 @@ func (r *GatewayPluginTCPLogResource) Schema(ctx context.Context, req resource.S
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewayplugintlshandshakemodifier_data_source.go
+++ b/internal/provider/gatewayplugintlshandshakemodifier_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginTLSHandshakeModifierDataSource struct {
 // GatewayPluginTLSHandshakeModifierDataSourceModel describes the data model.
 type GatewayPluginTLSHandshakeModifierDataSourceModel struct {
 	Config         tfTypes.TLSHandshakeModifierPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                     `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                     `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                     `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                     `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                             `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                              `tfsdk:"created_at"`
 	Enabled        types.Bool                               `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginTLSHandshakeModifierDataSourceModel struct {
 	InstanceName   types.String                             `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering               `tfsdk:"ordering"`
 	Protocols      []types.String                           `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                     `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                     `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                     `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                     `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                           `tfsdk:"tags"`
 	UpdatedAt      types.Int64                              `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewayplugintlshandshakemodifier_resource.go
+++ b/internal/provider/gatewayplugintlshandshakemodifier_resource.go
@@ -8,9 +8,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -37,8 +39,8 @@ type GatewayPluginTLSHandshakeModifierResource struct {
 // GatewayPluginTLSHandshakeModifierResourceModel describes the resource data model.
 type GatewayPluginTLSHandshakeModifierResourceModel struct {
 	Config         tfTypes.TLSHandshakeModifierPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                     `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                     `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                     `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                     `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                             `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                              `tfsdk:"created_at"`
 	Enabled        types.Bool                               `tfsdk:"enabled"`
@@ -46,8 +48,8 @@ type GatewayPluginTLSHandshakeModifierResourceModel struct {
 	InstanceName   types.String                             `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering               `tfsdk:"ordering"`
 	Protocols      []types.String                           `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                     `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                     `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                     `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                     `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                           `tfsdk:"tags"`
 	UpdatedAt      types.Int64                              `tfsdk:"updated_at"`
 }
@@ -76,6 +78,9 @@ func (r *GatewayPluginTLSHandshakeModifierResource) Schema(ctx context.Context, 
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -87,6 +92,9 @@ func (r *GatewayPluginTLSHandshakeModifierResource) Schema(ctx context.Context, 
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -155,6 +163,9 @@ func (r *GatewayPluginTLSHandshakeModifierResource) Schema(ctx context.Context, 
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -166,6 +177,9 @@ func (r *GatewayPluginTLSHandshakeModifierResource) Schema(ctx context.Context, 
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewayplugintlsmetadataheaders_data_source.go
+++ b/internal/provider/gatewayplugintlsmetadataheaders_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginTLSMetadataHeadersDataSource struct {
 // GatewayPluginTLSMetadataHeadersDataSourceModel describes the data model.
 type GatewayPluginTLSMetadataHeadersDataSourceModel struct {
 	Config         tfTypes.TLSMetadataHeadersPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                   `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                   `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                   `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                   `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                           `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                            `tfsdk:"created_at"`
 	Enabled        types.Bool                             `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginTLSMetadataHeadersDataSourceModel struct {
 	InstanceName   types.String                           `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering             `tfsdk:"ordering"`
 	Protocols      []types.String                         `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                   `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                   `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                   `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                   `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                         `tfsdk:"tags"`
 	UpdatedAt      types.Int64                            `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewayplugintlsmetadataheaders_resource.go
+++ b/internal/provider/gatewayplugintlsmetadataheaders_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -35,8 +37,8 @@ type GatewayPluginTLSMetadataHeadersResource struct {
 // GatewayPluginTLSMetadataHeadersResourceModel describes the resource data model.
 type GatewayPluginTLSMetadataHeadersResourceModel struct {
 	Config         tfTypes.TLSMetadataHeadersPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                   `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                   `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                   `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                   `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                           `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                            `tfsdk:"created_at"`
 	Enabled        types.Bool                             `tfsdk:"enabled"`
@@ -44,8 +46,8 @@ type GatewayPluginTLSMetadataHeadersResourceModel struct {
 	InstanceName   types.String                           `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering             `tfsdk:"ordering"`
 	Protocols      []types.String                         `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                   `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                   `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                   `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                   `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                         `tfsdk:"tags"`
 	UpdatedAt      types.Int64                            `tfsdk:"updated_at"`
 }
@@ -96,6 +98,9 @@ func (r *GatewayPluginTLSMetadataHeadersResource) Schema(ctx context.Context, re
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -107,6 +112,9 @@ func (r *GatewayPluginTLSMetadataHeadersResource) Schema(ctx context.Context, re
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -175,6 +183,9 @@ func (r *GatewayPluginTLSMetadataHeadersResource) Schema(ctx context.Context, re
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -186,6 +197,9 @@ func (r *GatewayPluginTLSMetadataHeadersResource) Schema(ctx context.Context, re
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginudplog_data_source.go
+++ b/internal/provider/gatewaypluginudplog_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginUDPLogDataSource struct {
 // GatewayPluginUDPLogDataSourceModel describes the data model.
 type GatewayPluginUDPLogDataSourceModel struct {
 	Config         tfTypes.UDPLogPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String               `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                `tfsdk:"created_at"`
 	Enabled        types.Bool                 `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginUDPLogDataSourceModel struct {
 	InstanceName   types.String               `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering `tfsdk:"ordering"`
 	Protocols      []types.String             `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer       `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer       `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer       `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer       `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String             `tfsdk:"tags"`
 	UpdatedAt      types.Int64                `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginudplog_resource.go
+++ b/internal/provider/gatewaypluginudplog_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -39,8 +41,8 @@ type GatewayPluginUDPLogResource struct {
 // GatewayPluginUDPLogResourceModel describes the resource data model.
 type GatewayPluginUDPLogResourceModel struct {
 	Config         tfTypes.UDPLogPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String               `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                `tfsdk:"created_at"`
 	Enabled        types.Bool                 `tfsdk:"enabled"`
@@ -48,8 +50,8 @@ type GatewayPluginUDPLogResourceModel struct {
 	InstanceName   types.String               `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering `tfsdk:"ordering"`
 	Protocols      []types.String             `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer       `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer       `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer       `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer       `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String             `tfsdk:"tags"`
 	UpdatedAt      types.Int64                `tfsdk:"updated_at"`
 }
@@ -97,6 +99,9 @@ func (r *GatewayPluginUDPLogResource) Schema(ctx context.Context, req resource.S
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -108,6 +113,9 @@ func (r *GatewayPluginUDPLogResource) Schema(ctx context.Context, req resource.S
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -176,6 +184,9 @@ func (r *GatewayPluginUDPLogResource) Schema(ctx context.Context, req resource.S
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -187,6 +198,9 @@ func (r *GatewayPluginUDPLogResource) Schema(ctx context.Context, req resource.S
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginupstreamtimeout_data_source.go
+++ b/internal/provider/gatewaypluginupstreamtimeout_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginUpstreamTimeoutDataSource struct {
 // GatewayPluginUpstreamTimeoutDataSourceModel describes the data model.
 type GatewayPluginUpstreamTimeoutDataSourceModel struct {
 	Config         tfTypes.UpstreamTimeoutPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                        `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                         `tfsdk:"created_at"`
 	Enabled        types.Bool                          `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginUpstreamTimeoutDataSourceModel struct {
 	InstanceName   types.String                        `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering          `tfsdk:"ordering"`
 	Protocols      []types.String                      `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                      `tfsdk:"tags"`
 	UpdatedAt      types.Int64                         `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginupstreamtimeout_resource.go
+++ b/internal/provider/gatewaypluginupstreamtimeout_resource.go
@@ -8,9 +8,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -37,8 +39,8 @@ type GatewayPluginUpstreamTimeoutResource struct {
 // GatewayPluginUpstreamTimeoutResourceModel describes the resource data model.
 type GatewayPluginUpstreamTimeoutResourceModel struct {
 	Config         tfTypes.UpstreamTimeoutPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                        `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                         `tfsdk:"created_at"`
 	Enabled        types.Bool                          `tfsdk:"enabled"`
@@ -46,8 +48,8 @@ type GatewayPluginUpstreamTimeoutResourceModel struct {
 	InstanceName   types.String                        `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering          `tfsdk:"ordering"`
 	Protocols      []types.String                      `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                      `tfsdk:"tags"`
 	UpdatedAt      types.Int64                         `tfsdk:"updated_at"`
 }
@@ -92,6 +94,9 @@ func (r *GatewayPluginUpstreamTimeoutResource) Schema(ctx context.Context, req r
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -103,6 +108,9 @@ func (r *GatewayPluginUpstreamTimeoutResource) Schema(ctx context.Context, req r
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -171,6 +179,9 @@ func (r *GatewayPluginUpstreamTimeoutResource) Schema(ctx context.Context, req r
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -182,6 +193,9 @@ func (r *GatewayPluginUpstreamTimeoutResource) Schema(ctx context.Context, req r
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginvaultauth_data_source.go
+++ b/internal/provider/gatewaypluginvaultauth_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginVaultAuthDataSource struct {
 // GatewayPluginVaultAuthDataSourceModel describes the data model.
 type GatewayPluginVaultAuthDataSourceModel struct {
 	Config         tfTypes.VaultAuthPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer          `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer          `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer          `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer          `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                  `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                   `tfsdk:"created_at"`
 	Enabled        types.Bool                    `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginVaultAuthDataSourceModel struct {
 	InstanceName   types.String                  `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering    `tfsdk:"ordering"`
 	Protocols      []types.String                `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer          `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer          `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer          `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer          `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                `tfsdk:"tags"`
 	UpdatedAt      types.Int64                   `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginvaultauth_resource.go
+++ b/internal/provider/gatewaypluginvaultauth_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -35,8 +37,8 @@ type GatewayPluginVaultAuthResource struct {
 // GatewayPluginVaultAuthResourceModel describes the resource data model.
 type GatewayPluginVaultAuthResourceModel struct {
 	Config         tfTypes.VaultAuthPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer          `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer          `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer          `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer          `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                  `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                   `tfsdk:"created_at"`
 	Enabled        types.Bool                    `tfsdk:"enabled"`
@@ -44,8 +46,8 @@ type GatewayPluginVaultAuthResourceModel struct {
 	InstanceName   types.String                  `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering    `tfsdk:"ordering"`
 	Protocols      []types.String                `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer          `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer          `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer          `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer          `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                `tfsdk:"tags"`
 	UpdatedAt      types.Int64                   `tfsdk:"updated_at"`
 }
@@ -101,6 +103,9 @@ func (r *GatewayPluginVaultAuthResource) Schema(ctx context.Context, req resourc
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -112,6 +117,9 @@ func (r *GatewayPluginVaultAuthResource) Schema(ctx context.Context, req resourc
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -180,6 +188,9 @@ func (r *GatewayPluginVaultAuthResource) Schema(ctx context.Context, req resourc
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -191,6 +202,9 @@ func (r *GatewayPluginVaultAuthResource) Schema(ctx context.Context, req resourc
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginwebsocketsizelimit_data_source.go
+++ b/internal/provider/gatewaypluginwebsocketsizelimit_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginWebsocketSizeLimitDataSource struct {
 // GatewayPluginWebsocketSizeLimitDataSourceModel describes the data model.
 type GatewayPluginWebsocketSizeLimitDataSourceModel struct {
 	Config         tfTypes.WebsocketSizeLimitPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                   `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                   `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                   `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                   `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                           `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                            `tfsdk:"created_at"`
 	Enabled        types.Bool                             `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginWebsocketSizeLimitDataSourceModel struct {
 	InstanceName   types.String                           `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering             `tfsdk:"ordering"`
 	Protocols      []types.String                         `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                   `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                   `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                   `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                   `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                         `tfsdk:"tags"`
 	UpdatedAt      types.Int64                            `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginwebsocketsizelimit_resource.go
+++ b/internal/provider/gatewaypluginwebsocketsizelimit_resource.go
@@ -8,9 +8,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -37,8 +39,8 @@ type GatewayPluginWebsocketSizeLimitResource struct {
 // GatewayPluginWebsocketSizeLimitResourceModel describes the resource data model.
 type GatewayPluginWebsocketSizeLimitResourceModel struct {
 	Config         tfTypes.WebsocketSizeLimitPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                   `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                   `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                   `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                   `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                           `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                            `tfsdk:"created_at"`
 	Enabled        types.Bool                             `tfsdk:"enabled"`
@@ -46,8 +48,8 @@ type GatewayPluginWebsocketSizeLimitResourceModel struct {
 	InstanceName   types.String                           `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering             `tfsdk:"ordering"`
 	Protocols      []types.String                         `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                   `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                   `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                   `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                   `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                         `tfsdk:"tags"`
 	UpdatedAt      types.Int64                            `tfsdk:"updated_at"`
 }
@@ -82,6 +84,9 @@ func (r *GatewayPluginWebsocketSizeLimitResource) Schema(ctx context.Context, re
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -93,6 +98,9 @@ func (r *GatewayPluginWebsocketSizeLimitResource) Schema(ctx context.Context, re
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -161,6 +169,9 @@ func (r *GatewayPluginWebsocketSizeLimitResource) Schema(ctx context.Context, re
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -172,6 +183,9 @@ func (r *GatewayPluginWebsocketSizeLimitResource) Schema(ctx context.Context, re
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginwebsocketvalidator_data_source.go
+++ b/internal/provider/gatewaypluginwebsocketvalidator_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginWebsocketValidatorDataSource struct {
 // GatewayPluginWebsocketValidatorDataSourceModel describes the data model.
 type GatewayPluginWebsocketValidatorDataSourceModel struct {
 	Config         tfTypes.WebsocketValidatorPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                   `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                   `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                   `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                   `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                           `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                            `tfsdk:"created_at"`
 	Enabled        types.Bool                             `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginWebsocketValidatorDataSourceModel struct {
 	InstanceName   types.String                           `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering             `tfsdk:"ordering"`
 	Protocols      []types.String                         `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                   `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                   `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                   `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                   `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                         `tfsdk:"tags"`
 	UpdatedAt      types.Int64                            `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginwebsocketvalidator_resource.go
+++ b/internal/provider/gatewaypluginwebsocketvalidator_resource.go
@@ -8,9 +8,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -38,8 +40,8 @@ type GatewayPluginWebsocketValidatorResource struct {
 // GatewayPluginWebsocketValidatorResourceModel describes the resource data model.
 type GatewayPluginWebsocketValidatorResourceModel struct {
 	Config         tfTypes.WebsocketValidatorPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                   `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                   `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                   `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                   `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                           `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                            `tfsdk:"created_at"`
 	Enabled        types.Bool                             `tfsdk:"enabled"`
@@ -47,8 +49,8 @@ type GatewayPluginWebsocketValidatorResourceModel struct {
 	InstanceName   types.String                           `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering             `tfsdk:"ordering"`
 	Protocols      []types.String                         `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                   `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                   `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                   `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                   `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                         `tfsdk:"tags"`
 	UpdatedAt      types.Int64                            `tfsdk:"updated_at"`
 }
@@ -173,6 +175,9 @@ func (r *GatewayPluginWebsocketValidatorResource) Schema(ctx context.Context, re
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -184,6 +189,9 @@ func (r *GatewayPluginWebsocketValidatorResource) Schema(ctx context.Context, re
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -252,6 +260,9 @@ func (r *GatewayPluginWebsocketValidatorResource) Schema(ctx context.Context, re
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -263,6 +274,9 @@ func (r *GatewayPluginWebsocketValidatorResource) Schema(ctx context.Context, re
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginxmlthreatprotection_data_source.go
+++ b/internal/provider/gatewaypluginxmlthreatprotection_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginXMLThreatProtectionDataSource struct {
 // GatewayPluginXMLThreatProtectionDataSourceModel describes the data model.
 type GatewayPluginXMLThreatProtectionDataSourceModel struct {
 	Config         tfTypes.XMLThreatProtectionPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                    `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                    `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                    `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                    `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                            `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                             `tfsdk:"created_at"`
 	Enabled        types.Bool                              `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginXMLThreatProtectionDataSourceModel struct {
 	InstanceName   types.String                            `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering              `tfsdk:"ordering"`
 	Protocols      []types.String                          `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                    `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                    `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                    `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                    `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                          `tfsdk:"tags"`
 	UpdatedAt      types.Int64                             `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginxmlthreatprotection_resource.go
+++ b/internal/provider/gatewaypluginxmlthreatprotection_resource.go
@@ -8,9 +8,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -37,8 +39,8 @@ type GatewayPluginXMLThreatProtectionResource struct {
 // GatewayPluginXMLThreatProtectionResourceModel describes the resource data model.
 type GatewayPluginXMLThreatProtectionResourceModel struct {
 	Config         tfTypes.XMLThreatProtectionPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer                    `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer                    `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer                    `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer                    `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String                            `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                             `tfsdk:"created_at"`
 	Enabled        types.Bool                              `tfsdk:"enabled"`
@@ -46,8 +48,8 @@ type GatewayPluginXMLThreatProtectionResourceModel struct {
 	InstanceName   types.String                            `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering              `tfsdk:"ordering"`
 	Protocols      []types.String                          `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer                    `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer                    `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer                    `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer                    `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String                          `tfsdk:"tags"`
 	UpdatedAt      types.Int64                             `tfsdk:"updated_at"`
 }
@@ -188,6 +190,9 @@ func (r *GatewayPluginXMLThreatProtectionResource) Schema(ctx context.Context, r
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -199,6 +204,9 @@ func (r *GatewayPluginXMLThreatProtectionResource) Schema(ctx context.Context, r
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -267,6 +275,9 @@ func (r *GatewayPluginXMLThreatProtectionResource) Schema(ctx context.Context, r
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -278,6 +289,9 @@ func (r *GatewayPluginXMLThreatProtectionResource) Schema(ctx context.Context, r
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginzipkin_data_source.go
+++ b/internal/provider/gatewaypluginzipkin_data_source.go
@@ -30,8 +30,8 @@ type GatewayPluginZipkinDataSource struct {
 // GatewayPluginZipkinDataSourceModel describes the data model.
 type GatewayPluginZipkinDataSourceModel struct {
 	Config         tfTypes.ZipkinPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String               `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                `tfsdk:"created_at"`
 	Enabled        types.Bool                 `tfsdk:"enabled"`
@@ -39,8 +39,8 @@ type GatewayPluginZipkinDataSourceModel struct {
 	InstanceName   types.String               `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering `tfsdk:"ordering"`
 	Protocols      []types.String             `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer       `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer       `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer       `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer       `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String             `tfsdk:"tags"`
 	UpdatedAt      types.Int64                `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaypluginzipkin_resource.go
+++ b/internal/provider/gatewaypluginzipkin_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -40,8 +42,8 @@ type GatewayPluginZipkinResource struct {
 // GatewayPluginZipkinResourceModel describes the resource data model.
 type GatewayPluginZipkinResourceModel struct {
 	Config         tfTypes.ZipkinPluginConfig `tfsdk:"config"`
-	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer"`
-	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group"`
+	Consumer       *tfTypes.ACLConsumer       `tfsdk:"consumer" tfPlanOnly:"true"`
+	ConsumerGroup  *tfTypes.ACLConsumer       `tfsdk:"consumer_group" tfPlanOnly:"true"`
 	ControlPlaneID types.String               `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                `tfsdk:"created_at"`
 	Enabled        types.Bool                 `tfsdk:"enabled"`
@@ -49,8 +51,8 @@ type GatewayPluginZipkinResourceModel struct {
 	InstanceName   types.String               `tfsdk:"instance_name"`
 	Ordering       *tfTypes.ACLPluginOrdering `tfsdk:"ordering"`
 	Protocols      []types.String             `tfsdk:"protocols"`
-	Route          *tfTypes.ACLConsumer       `tfsdk:"route"`
-	Service        *tfTypes.ACLConsumer       `tfsdk:"service"`
+	Route          *tfTypes.ACLConsumer       `tfsdk:"route" tfPlanOnly:"true"`
+	Service        *tfTypes.ACLConsumer       `tfsdk:"service" tfPlanOnly:"true"`
 	Tags           []types.String             `tfsdk:"tags"`
 	UpdatedAt      types.Int64                `tfsdk:"updated_at"`
 }
@@ -320,6 +322,9 @@ func (r *GatewayPluginZipkinResource) Schema(ctx context.Context, req resource.S
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -331,6 +336,9 @@ func (r *GatewayPluginZipkinResource) Schema(ctx context.Context, req resource.S
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -399,6 +407,9 @@ func (r *GatewayPluginZipkinResource) Schema(ctx context.Context, req resource.S
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -410,6 +421,9 @@ func (r *GatewayPluginZipkinResource) Schema(ctx context.Context, req resource.S
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewayroute_data_source.go
+++ b/internal/provider/gatewayroute_data_source.go
@@ -45,7 +45,7 @@ type GatewayRouteDataSourceModel struct {
 	RegexPriority           types.Int64             `tfsdk:"regex_priority"`
 	RequestBuffering        types.Bool              `tfsdk:"request_buffering"`
 	ResponseBuffering       types.Bool              `tfsdk:"response_buffering"`
-	Service                 *tfTypes.ACLConsumer    `tfsdk:"service"`
+	Service                 *tfTypes.ACLConsumer    `tfsdk:"service" tfPlanOnly:"true"`
 	Snis                    []types.String          `tfsdk:"snis"`
 	Sources                 []tfTypes.ClusterNodes  `tfsdk:"sources"`
 	StripPath               types.Bool              `tfsdk:"strip_path"`

--- a/internal/provider/gatewayroute_resource.go
+++ b/internal/provider/gatewayroute_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -54,7 +56,7 @@ type GatewayRouteResourceModel struct {
 	RegexPriority           types.Int64             `tfsdk:"regex_priority"`
 	RequestBuffering        types.Bool              `tfsdk:"request_buffering"`
 	ResponseBuffering       types.Bool              `tfsdk:"response_buffering"`
-	Service                 *tfTypes.ACLConsumer    `tfsdk:"service"`
+	Service                 *tfTypes.ACLConsumer    `tfsdk:"service" tfPlanOnly:"true"`
 	Snis                    []types.String          `tfsdk:"snis"`
 	Sources                 []tfTypes.ClusterNodes  `tfsdk:"sources"`
 	StripPath               types.Bool              `tfsdk:"strip_path"`
@@ -185,6 +187,9 @@ func (r *GatewayRouteResource) Schema(ctx context.Context, req resource.SchemaRe
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewayservice_data_source.go
+++ b/internal/provider/gatewayservice_data_source.go
@@ -30,7 +30,7 @@ type GatewayServiceDataSource struct {
 // GatewayServiceDataSourceModel describes the data model.
 type GatewayServiceDataSourceModel struct {
 	CaCertificates    []types.String       `tfsdk:"ca_certificates"`
-	ClientCertificate *tfTypes.ACLConsumer `tfsdk:"client_certificate"`
+	ClientCertificate *tfTypes.ACLConsumer `tfsdk:"client_certificate" tfPlanOnly:"true"`
 	ConnectTimeout    types.Int64          `tfsdk:"connect_timeout"`
 	ControlPlaneID    types.String         `tfsdk:"control_plane_id"`
 	CreatedAt         types.Int64          `tfsdk:"created_at"`

--- a/internal/provider/gatewayservice_resource.go
+++ b/internal/provider/gatewayservice_resource.go
@@ -8,9 +8,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -37,7 +39,7 @@ type GatewayServiceResource struct {
 // GatewayServiceResourceModel describes the resource data model.
 type GatewayServiceResourceModel struct {
 	CaCertificates    []types.String       `tfsdk:"ca_certificates"`
-	ClientCertificate *tfTypes.ACLConsumer `tfsdk:"client_certificate"`
+	ClientCertificate *tfTypes.ACLConsumer `tfsdk:"client_certificate" tfPlanOnly:"true"`
 	ConnectTimeout    types.Int64          `tfsdk:"connect_timeout"`
 	ControlPlaneID    types.String         `tfsdk:"control_plane_id"`
 	CreatedAt         types.Int64          `tfsdk:"created_at"`
@@ -74,6 +76,9 @@ func (r *GatewayServiceResource) Schema(ctx context.Context, req resource.Schema
 			"client_certificate": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaysni_data_source.go
+++ b/internal/provider/gatewaysni_data_source.go
@@ -29,13 +29,13 @@ type GatewaySNIDataSource struct {
 
 // GatewaySNIDataSourceModel describes the data model.
 type GatewaySNIDataSourceModel struct {
-	Certificate    tfTypes.ACLConsumer `tfsdk:"certificate"`
-	ControlPlaneID types.String        `tfsdk:"control_plane_id"`
-	CreatedAt      types.Int64         `tfsdk:"created_at"`
-	ID             types.String        `tfsdk:"id"`
-	Name           types.String        `tfsdk:"name"`
-	Tags           []types.String      `tfsdk:"tags"`
-	UpdatedAt      types.Int64         `tfsdk:"updated_at"`
+	Certificate    *tfTypes.ACLConsumer `tfsdk:"certificate" tfPlanOnly:"true"`
+	ControlPlaneID types.String         `tfsdk:"control_plane_id"`
+	CreatedAt      types.Int64          `tfsdk:"created_at"`
+	ID             types.String         `tfsdk:"id"`
+	Name           types.String         `tfsdk:"name"`
+	Tags           []types.String       `tfsdk:"tags"`
+	UpdatedAt      types.Int64          `tfsdk:"updated_at"`
 }
 
 // Metadata returns the data source type name.

--- a/internal/provider/gatewaysni_data_source_sdk.go
+++ b/internal/provider/gatewaysni_data_source_sdk.go
@@ -4,12 +4,18 @@ package provider
 
 import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	tfTypes "github.com/kong/terraform-provider-konnect/v2/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect/v2/internal/sdk/models/shared"
 )
 
 func (r *GatewaySNIDataSourceModel) RefreshFromSharedSni(resp *shared.Sni) {
 	if resp != nil {
-		r.Certificate.ID = types.StringPointerValue(resp.Certificate.ID)
+		if resp.Certificate == nil {
+			r.Certificate = nil
+		} else {
+			r.Certificate = &tfTypes.ACLConsumer{}
+			r.Certificate.ID = types.StringPointerValue(resp.Certificate.ID)
+		}
 		r.CreatedAt = types.Int64PointerValue(resp.CreatedAt)
 		r.ID = types.StringPointerValue(resp.ID)
 		r.Name = types.StringValue(resp.Name)

--- a/internal/provider/gatewaysni_resource.go
+++ b/internal/provider/gatewaysni_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -34,13 +36,13 @@ type GatewaySNIResource struct {
 
 // GatewaySNIResourceModel describes the resource data model.
 type GatewaySNIResourceModel struct {
-	Certificate    tfTypes.ACLConsumer `tfsdk:"certificate"`
-	ControlPlaneID types.String        `tfsdk:"control_plane_id"`
-	CreatedAt      types.Int64         `tfsdk:"created_at"`
-	ID             types.String        `tfsdk:"id"`
-	Name           types.String        `tfsdk:"name"`
-	Tags           []types.String      `tfsdk:"tags"`
-	UpdatedAt      types.Int64         `tfsdk:"updated_at"`
+	Certificate    *tfTypes.ACLConsumer `tfsdk:"certificate" tfPlanOnly:"true"`
+	ControlPlaneID types.String         `tfsdk:"control_plane_id"`
+	CreatedAt      types.Int64          `tfsdk:"created_at"`
+	ID             types.String         `tfsdk:"id"`
+	Name           types.String         `tfsdk:"name"`
+	Tags           []types.String       `tfsdk:"tags"`
+	UpdatedAt      types.Int64          `tfsdk:"updated_at"`
 }
 
 func (r *GatewaySNIResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -52,7 +54,11 @@ func (r *GatewaySNIResource) Schema(ctx context.Context, req resource.SchemaRequ
 		MarkdownDescription: "GatewaySNI Resource",
 		Attributes: map[string]schema.Attribute{
 			"certificate": schema.SingleNestedAttribute{
-				Required: true,
+				Computed: true,
+				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaysni_resource_sdk.go
+++ b/internal/provider/gatewaysni_resource_sdk.go
@@ -4,18 +4,22 @@ package provider
 
 import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	tfTypes "github.com/kong/terraform-provider-konnect/v2/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect/v2/internal/sdk/models/shared"
 )
 
 func (r *GatewaySNIResourceModel) ToSharedSNIInput() *shared.SNIInput {
-	id := new(string)
-	if !r.Certificate.ID.IsUnknown() && !r.Certificate.ID.IsNull() {
-		*id = r.Certificate.ID.ValueString()
-	} else {
-		id = nil
-	}
-	certificate := shared.SNICertificate{
-		ID: id,
+	var certificate *shared.SNICertificate
+	if r.Certificate != nil {
+		id := new(string)
+		if !r.Certificate.ID.IsUnknown() && !r.Certificate.ID.IsNull() {
+			*id = r.Certificate.ID.ValueString()
+		} else {
+			id = nil
+		}
+		certificate = &shared.SNICertificate{
+			ID: id,
+		}
 	}
 	id1 := new(string)
 	if !r.ID.IsUnknown() && !r.ID.IsNull() {
@@ -41,7 +45,12 @@ func (r *GatewaySNIResourceModel) ToSharedSNIInput() *shared.SNIInput {
 
 func (r *GatewaySNIResourceModel) RefreshFromSharedSni(resp *shared.Sni) {
 	if resp != nil {
-		r.Certificate.ID = types.StringPointerValue(resp.Certificate.ID)
+		if resp.Certificate == nil {
+			r.Certificate = nil
+		} else {
+			r.Certificate = &tfTypes.ACLConsumer{}
+			r.Certificate.ID = types.StringPointerValue(resp.Certificate.ID)
+		}
 		r.CreatedAt = types.Int64PointerValue(resp.CreatedAt)
 		r.ID = types.StringPointerValue(resp.ID)
 		r.Name = types.StringValue(resp.Name)

--- a/internal/provider/gatewaytarget_data_source.go
+++ b/internal/provider/gatewaytarget_data_source.go
@@ -35,7 +35,7 @@ type GatewayTargetDataSourceModel struct {
 	Tags           []types.String       `tfsdk:"tags"`
 	Target         types.String         `tfsdk:"target"`
 	UpdatedAt      types.Number         `tfsdk:"updated_at"`
-	Upstream       *tfTypes.ACLConsumer `tfsdk:"upstream"`
+	Upstream       *tfTypes.ACLConsumer `tfsdk:"upstream" tfPlanOnly:"true"`
 	UpstreamID     types.String         `tfsdk:"upstream_id"`
 	Weight         types.Int64          `tfsdk:"weight"`
 }

--- a/internal/provider/gatewaytarget_resource.go
+++ b/internal/provider/gatewaytarget_resource.go
@@ -7,11 +7,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/int64planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -45,7 +47,7 @@ type GatewayTargetResourceModel struct {
 	Tags           []types.String       `tfsdk:"tags"`
 	Target         types.String         `tfsdk:"target"`
 	UpdatedAt      types.Number         `tfsdk:"updated_at"`
-	Upstream       *tfTypes.ACLConsumer `tfsdk:"upstream"`
+	Upstream       *tfTypes.ACLConsumer `tfsdk:"upstream" tfPlanOnly:"true"`
 	UpstreamID     types.String         `tfsdk:"upstream_id"`
 	Weight         types.Int64          `tfsdk:"weight"`
 }
@@ -103,6 +105,9 @@ func (r *GatewayTargetResource) Schema(ctx context.Context, req resource.SchemaR
 			},
 			"upstream": schema.SingleNestedAttribute{
 				Computed: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewayupstream_data_source.go
+++ b/internal/provider/gatewayupstream_data_source.go
@@ -30,7 +30,7 @@ type GatewayUpstreamDataSource struct {
 // GatewayUpstreamDataSourceModel describes the data model.
 type GatewayUpstreamDataSourceModel struct {
 	Algorithm              types.String          `tfsdk:"algorithm"`
-	ClientCertificate      *tfTypes.ACLConsumer  `tfsdk:"client_certificate"`
+	ClientCertificate      *tfTypes.ACLConsumer  `tfsdk:"client_certificate" tfPlanOnly:"true"`
 	ControlPlaneID         types.String          `tfsdk:"control_plane_id"`
 	CreatedAt              types.Int64           `tfsdk:"created_at"`
 	HashFallback           types.String          `tfsdk:"hash_fallback"`

--- a/internal/provider/gatewayupstream_resource.go
+++ b/internal/provider/gatewayupstream_resource.go
@@ -8,9 +8,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -37,7 +39,7 @@ type GatewayUpstreamResource struct {
 // GatewayUpstreamResourceModel describes the resource data model.
 type GatewayUpstreamResourceModel struct {
 	Algorithm              types.String          `tfsdk:"algorithm"`
-	ClientCertificate      *tfTypes.ACLConsumer  `tfsdk:"client_certificate"`
+	ClientCertificate      *tfTypes.ACLConsumer  `tfsdk:"client_certificate" tfPlanOnly:"true"`
 	ControlPlaneID         types.String          `tfsdk:"control_plane_id"`
 	CreatedAt              types.Int64           `tfsdk:"created_at"`
 	HashFallback           types.String          `tfsdk:"hash_fallback"`
@@ -84,6 +86,9 @@ func (r *GatewayUpstreamResource) Schema(ctx context.Context, req resource.Schem
 			"client_certificate": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -113,10 +113,13 @@ func (p *KonnectProvider) Configure(ctx context.Context, req provider.ConfigureR
 		KonnectAccessToken:       konnectAccessToken,
 	}
 
+	httpClient := http.DefaultClient
+	httpClient.Transport = NewLoggingHTTPTransport(http.DefaultTransport)
+
 	opts := []sdk.SDKOption{
 		sdk.WithServerURL(ServerURL),
 		sdk.WithSecurity(security),
-		sdk.WithClient(http.DefaultClient),
+		sdk.WithClient(httpClient),
 	}
 	client := sdk.New(opts...)
 

--- a/internal/provider/utils.go
+++ b/internal/provider/utils.go
@@ -3,17 +3,25 @@
 package provider
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-log/tflog"
 	tfReflect "github.com/kong/terraform-provider-konnect/v2/internal/provider/reflect"
+	"io"
 	"net/http"
 	"net/http/httputil"
+	"net/textproto"
 	"reflect"
+	"strings"
 )
 
 func debugResponse(response *http.Response) string {
@@ -90,4 +98,178 @@ func refreshPlan(ctx context.Context, plan types.Object, target interface{}, dia
 		UnhandledUnknownAsEmpty: true,
 		SourceType:              tfReflect.SourceTypePlan,
 	}, path.Empty())...)
+}
+
+// Note: this is taken as a more minimal/specific version of https://github.com/hashicorp/terraform-plugin-sdk/blob/main/helper/logging/logging_http_transport.go
+func NewLoggingHTTPTransport(t http.RoundTripper) *loggingHttpTransport {
+	return &loggingHttpTransport{t}
+}
+
+const (
+	FieldHttpOperationType        = "tf_http_op_type"
+	OperationHttpRequest          = "request"
+	OperationHttpResponse         = "response"
+	FieldHttpRequestMethod        = "tf_http_req_method"
+	FieldHttpRequestUri           = "tf_http_req_uri"
+	FieldHttpRequestProtoVersion  = "tf_http_req_version"
+	FieldHttpRequestBody          = "tf_http_req_body"
+	FieldHttpResponseProtoVersion = "tf_http_res_version"
+	FieldHttpResponseStatusCode   = "tf_http_res_status_code"
+	FieldHttpResponseStatusReason = "tf_http_res_status_reason"
+	FieldHttpResponseBody         = "tf_http_res_body"
+	FieldHttpTransactionId        = "tf_http_trans_id"
+)
+
+type loggingHttpTransport struct {
+	transport http.RoundTripper
+}
+
+func (t *loggingHttpTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	ctx := req.Context()
+	ctx = t.addTransactionIdField(ctx)
+
+	// Decompose the request bytes in a message (HTTP body) and fields (HTTP headers), then log it
+	fields, err := decomposeRequestForLogging(req)
+	if err != nil {
+		tflog.Error(ctx, "Failed to parse request bytes for logging", []map[string]interface{}{map[string]interface{}{
+			"error": err,
+		}}...)
+	} else {
+		tflog.Debug(ctx, "Sending HTTP Request", []map[string]interface{}{fields}...)
+	}
+
+	// Invoke the wrapped RoundTrip now
+	res, err := t.transport.RoundTrip(req)
+	if err != nil {
+		return res, err
+	}
+
+	// Decompose the response bytes in a message (HTTP body) and fields (HTTP headers), then log it
+	fields, err = decomposeResponseForLogging(res)
+	if err != nil {
+		tflog.Error(ctx, "Failed to parse response bytes for logging", []map[string]interface{}{map[string]interface{}{
+			"error": err,
+		}}...)
+	} else {
+		tflog.Debug(ctx, "Received HTTP Response", []map[string]interface{}{fields}...)
+	}
+
+	return res, nil
+}
+
+func (t *loggingHttpTransport) addTransactionIdField(ctx context.Context) context.Context {
+	tId, err := uuid.GenerateUUID()
+
+	if err != nil {
+		tId = "Unable to assign Transaction ID: " + err.Error()
+	}
+
+	return tflog.SetField(ctx, FieldHttpTransactionId, tId)
+}
+
+func decomposeRequestForLogging(req *http.Request) (map[string]interface{}, error) {
+	fields := make(map[string]interface{}, len(req.Header)+4)
+	fields[FieldHttpOperationType] = OperationHttpRequest
+
+	fields[FieldHttpRequestMethod] = req.Method
+	fields[FieldHttpRequestUri] = req.URL.RequestURI()
+	fields[FieldHttpRequestProtoVersion] = req.Proto
+
+	// Get the full body of the request, including headers appended by http.Transport:
+	// this is necessary because the http.Request at this stage doesn't contain
+	// all the headers that will be eventually sent.
+	// We rely on `httputil.DumpRequestOut` to obtain the actual bytes that will be sent out.
+	reqBytes, err := httputil.DumpRequestOut(req, true)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a reader around the request full body
+	reqReader := textproto.NewReader(bufio.NewReader(bytes.NewReader(reqBytes)))
+
+	err = fieldHeadersFromRequestReader(reqReader, fields)
+	if err != nil {
+		return nil, err
+	}
+
+	// Read the rest of the body content
+	fields[FieldHttpRequestBody] = bodyFromRestOfRequestReader(reqReader)
+	return fields, nil
+}
+
+func fieldHeadersFromRequestReader(reader *textproto.Reader, fields map[string]interface{}) error {
+	// Ignore the first line: it contains non-header content
+	// that we have already captured.
+	// Skipping this step, would cause the following call to `ReadMIMEHeader()`
+	// to fail as it cannot parse the first line.
+	_, err := reader.ReadLine()
+	if err != nil {
+		return err
+	}
+
+	// Read the MIME-style headers
+	mimeHeader, err := reader.ReadMIMEHeader()
+	if err != nil {
+		return err
+	}
+
+	// Set the headers as fields to log
+	for k, v := range mimeHeader {
+		if len(v) == 1 {
+			fields[k] = v[0]
+		} else {
+			fields[k] = v
+		}
+	}
+	if _, ok := fields["Authorization"]; ok {
+		fields["Authorization"] = "(sensitive)"
+	}
+
+	return nil
+}
+
+func bodyFromRestOfRequestReader(reader *textproto.Reader) string {
+	var builder strings.Builder
+	for {
+		line, err := reader.ReadContinuedLine()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		builder.WriteString(line)
+	}
+
+	return builder.String()
+}
+
+func decomposeResponseForLogging(res *http.Response) (map[string]interface{}, error) {
+	fields := make(map[string]interface{}, len(res.Header)+4)
+	fields[FieldHttpOperationType] = OperationHttpResponse
+
+	fields[FieldHttpResponseProtoVersion] = res.Proto
+	fields[FieldHttpResponseStatusCode] = res.StatusCode
+	fields[FieldHttpResponseStatusReason] = res.Status
+
+	// Set the headers as fields to log
+	for k, v := range res.Header {
+		if len(v) == 1 {
+			fields[k] = v[0]
+		} else {
+			fields[k] = v
+		}
+	}
+
+	// Read the whole response body
+	resBody, err := io.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	// Wrap the bytes from the response body, back into an io.ReadCloser,
+	// to respect the interface of http.Response, as expected by users of the
+	// http.Client
+	res.Body = io.NopCloser(bytes.NewBuffer(resBody))
+
+	fields[FieldHttpResponseBody] = string(resBody)
+
+	return fields, nil
 }

--- a/internal/sdk/konnect.go
+++ b/internal/sdk/konnect.go
@@ -290,8 +290,8 @@ func New(opts ...SDKOption) *Konnect {
 			Language:          "go",
 			OpenAPIDocVersion: "2.0.0",
 			SDKVersion:        "0.0.1",
-			GenVersion:        "2.449.0",
-			UserAgent:         "speakeasy-sdk/go 0.0.1 2.449.0 2.0.0 github.com/kong/terraform-provider-konnect/v2/internal/sdk",
+			GenVersion:        "2.457.2",
+			UserAgent:         "speakeasy-sdk/go 0.0.1 2.457.2 2.0.0 github.com/kong/terraform-provider-konnect/v2/internal/sdk",
 			Hooks:             hooks.New(),
 		},
 	}

--- a/internal/sdk/models/shared/acl.go
+++ b/internal/sdk/models/shared/acl.go
@@ -14,7 +14,7 @@ func (o *ACLConsumer) GetID() *string {
 }
 
 type ACL struct {
-	Consumer *ACLConsumer `json:"consumer,omitempty"`
+	Consumer *ACLConsumer `json:"consumer"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64   `json:"created_at,omitempty"`
 	Group     *string  `json:"group,omitempty"`

--- a/internal/sdk/models/shared/aclplugin.go
+++ b/internal/sdk/models/shared/aclplugin.go
@@ -197,8 +197,8 @@ func (o *ACLPluginService) GetID() *string {
 type ACLPlugin struct {
 	Config ACLPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *ACLPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *ACLPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *ACLPluginConsumer      `json:"consumer"`
+	ConsumerGroup *ACLPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -210,9 +210,9 @@ type ACLPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []ACLPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *ACLPluginRoute `json:"route,omitempty"`
+	Route *ACLPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *ACLPluginService `json:"service,omitempty"`
+	Service *ACLPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -329,8 +329,8 @@ func (o *ACLPlugin) GetUpdatedAt() *int64 {
 type ACLPluginInput struct {
 	Config ACLPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *ACLPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *ACLPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *ACLPluginConsumer      `json:"consumer"`
+	ConsumerGroup *ACLPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool              `json:"enabled,omitempty"`
 	ID           *string            `json:"id,omitempty"`
@@ -340,9 +340,9 @@ type ACLPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []ACLPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *ACLPluginRoute `json:"route,omitempty"`
+	Route *ACLPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *ACLPluginService `json:"service,omitempty"`
+	Service *ACLPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/acmeplugin.go
+++ b/internal/sdk/models/shared/acmeplugin.go
@@ -777,8 +777,8 @@ func (o *AcmePluginService) GetID() *string {
 type AcmePlugin struct {
 	Config AcmePluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *AcmePluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *AcmePluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *AcmePluginConsumer      `json:"consumer"`
+	ConsumerGroup *AcmePluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -790,9 +790,9 @@ type AcmePlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []AcmePluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *AcmePluginRoute `json:"route,omitempty"`
+	Route *AcmePluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *AcmePluginService `json:"service,omitempty"`
+	Service *AcmePluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -909,8 +909,8 @@ func (o *AcmePlugin) GetUpdatedAt() *int64 {
 type AcmePluginInput struct {
 	Config AcmePluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *AcmePluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *AcmePluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *AcmePluginConsumer      `json:"consumer"`
+	ConsumerGroup *AcmePluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool               `json:"enabled,omitempty"`
 	ID           *string             `json:"id,omitempty"`
@@ -920,9 +920,9 @@ type AcmePluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []AcmePluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *AcmePluginRoute `json:"route,omitempty"`
+	Route *AcmePluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *AcmePluginService `json:"service,omitempty"`
+	Service *AcmePluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/aipromptdecoratorplugin.go
+++ b/internal/sdk/models/shared/aipromptdecoratorplugin.go
@@ -287,8 +287,8 @@ func (o *AiPromptDecoratorPluginService) GetID() *string {
 type AiPromptDecoratorPlugin struct {
 	Config AiPromptDecoratorPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *AiPromptDecoratorPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *AiPromptDecoratorPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *AiPromptDecoratorPluginConsumer      `json:"consumer"`
+	ConsumerGroup *AiPromptDecoratorPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -300,9 +300,9 @@ type AiPromptDecoratorPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []AiPromptDecoratorPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *AiPromptDecoratorPluginRoute `json:"route,omitempty"`
+	Route *AiPromptDecoratorPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *AiPromptDecoratorPluginService `json:"service,omitempty"`
+	Service *AiPromptDecoratorPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -419,8 +419,8 @@ func (o *AiPromptDecoratorPlugin) GetUpdatedAt() *int64 {
 type AiPromptDecoratorPluginInput struct {
 	Config AiPromptDecoratorPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *AiPromptDecoratorPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *AiPromptDecoratorPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *AiPromptDecoratorPluginConsumer      `json:"consumer"`
+	ConsumerGroup *AiPromptDecoratorPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                            `json:"enabled,omitempty"`
 	ID           *string                          `json:"id,omitempty"`
@@ -430,9 +430,9 @@ type AiPromptDecoratorPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []AiPromptDecoratorPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *AiPromptDecoratorPluginRoute `json:"route,omitempty"`
+	Route *AiPromptDecoratorPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *AiPromptDecoratorPluginService `json:"service,omitempty"`
+	Service *AiPromptDecoratorPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/aipromptguardplugin.go
+++ b/internal/sdk/models/shared/aipromptguardplugin.go
@@ -198,8 +198,8 @@ func (o *AiPromptGuardPluginService) GetID() *string {
 type AiPromptGuardPlugin struct {
 	Config AiPromptGuardPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *AiPromptGuardPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *AiPromptGuardPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *AiPromptGuardPluginConsumer      `json:"consumer"`
+	ConsumerGroup *AiPromptGuardPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -211,9 +211,9 @@ type AiPromptGuardPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []AiPromptGuardPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *AiPromptGuardPluginRoute `json:"route,omitempty"`
+	Route *AiPromptGuardPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *AiPromptGuardPluginService `json:"service,omitempty"`
+	Service *AiPromptGuardPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -330,8 +330,8 @@ func (o *AiPromptGuardPlugin) GetUpdatedAt() *int64 {
 type AiPromptGuardPluginInput struct {
 	Config AiPromptGuardPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *AiPromptGuardPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *AiPromptGuardPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *AiPromptGuardPluginConsumer      `json:"consumer"`
+	ConsumerGroup *AiPromptGuardPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                        `json:"enabled,omitempty"`
 	ID           *string                      `json:"id,omitempty"`
@@ -341,9 +341,9 @@ type AiPromptGuardPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []AiPromptGuardPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *AiPromptGuardPluginRoute `json:"route,omitempty"`
+	Route *AiPromptGuardPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *AiPromptGuardPluginService `json:"service,omitempty"`
+	Service *AiPromptGuardPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/aiprompttemplateplugin.go
+++ b/internal/sdk/models/shared/aiprompttemplateplugin.go
@@ -210,8 +210,8 @@ func (o *AiPromptTemplatePluginService) GetID() *string {
 type AiPromptTemplatePlugin struct {
 	Config AiPromptTemplatePluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *AiPromptTemplatePluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *AiPromptTemplatePluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *AiPromptTemplatePluginConsumer      `json:"consumer"`
+	ConsumerGroup *AiPromptTemplatePluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -223,9 +223,9 @@ type AiPromptTemplatePlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []AiPromptTemplatePluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *AiPromptTemplatePluginRoute `json:"route,omitempty"`
+	Route *AiPromptTemplatePluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *AiPromptTemplatePluginService `json:"service,omitempty"`
+	Service *AiPromptTemplatePluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -342,8 +342,8 @@ func (o *AiPromptTemplatePlugin) GetUpdatedAt() *int64 {
 type AiPromptTemplatePluginInput struct {
 	Config AiPromptTemplatePluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *AiPromptTemplatePluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *AiPromptTemplatePluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *AiPromptTemplatePluginConsumer      `json:"consumer"`
+	ConsumerGroup *AiPromptTemplatePluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                           `json:"enabled,omitempty"`
 	ID           *string                         `json:"id,omitempty"`
@@ -353,9 +353,9 @@ type AiPromptTemplatePluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []AiPromptTemplatePluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *AiPromptTemplatePluginRoute `json:"route,omitempty"`
+	Route *AiPromptTemplatePluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *AiPromptTemplatePluginService `json:"service,omitempty"`
+	Service *AiPromptTemplatePluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/aiproxyplugin.go
+++ b/internal/sdk/models/shared/aiproxyplugin.go
@@ -770,8 +770,8 @@ func (o *AiProxyPluginService) GetID() *string {
 type AiProxyPlugin struct {
 	Config AiProxyPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *AiProxyPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *AiProxyPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *AiProxyPluginConsumer      `json:"consumer"`
+	ConsumerGroup *AiProxyPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -783,9 +783,9 @@ type AiProxyPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []AiProxyPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *AiProxyPluginRoute `json:"route,omitempty"`
+	Route *AiProxyPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *AiProxyPluginService `json:"service,omitempty"`
+	Service *AiProxyPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -902,8 +902,8 @@ func (o *AiProxyPlugin) GetUpdatedAt() *int64 {
 type AiProxyPluginInput struct {
 	Config AiProxyPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *AiProxyPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *AiProxyPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *AiProxyPluginConsumer      `json:"consumer"`
+	ConsumerGroup *AiProxyPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                  `json:"enabled,omitempty"`
 	ID           *string                `json:"id,omitempty"`
@@ -913,9 +913,9 @@ type AiProxyPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []AiProxyPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *AiProxyPluginRoute `json:"route,omitempty"`
+	Route *AiProxyPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *AiProxyPluginService `json:"service,omitempty"`
+	Service *AiProxyPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/airequesttransformerplugin.go
+++ b/internal/sdk/models/shared/airequesttransformerplugin.go
@@ -805,8 +805,8 @@ func (o *AiRequestTransformerPluginService) GetID() *string {
 type AiRequestTransformerPlugin struct {
 	Config AiRequestTransformerPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *AiRequestTransformerPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *AiRequestTransformerPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *AiRequestTransformerPluginConsumer      `json:"consumer"`
+	ConsumerGroup *AiRequestTransformerPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -818,9 +818,9 @@ type AiRequestTransformerPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []AiRequestTransformerPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *AiRequestTransformerPluginRoute `json:"route,omitempty"`
+	Route *AiRequestTransformerPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *AiRequestTransformerPluginService `json:"service,omitempty"`
+	Service *AiRequestTransformerPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -937,8 +937,8 @@ func (o *AiRequestTransformerPlugin) GetUpdatedAt() *int64 {
 type AiRequestTransformerPluginInput struct {
 	Config AiRequestTransformerPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *AiRequestTransformerPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *AiRequestTransformerPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *AiRequestTransformerPluginConsumer      `json:"consumer"`
+	ConsumerGroup *AiRequestTransformerPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                               `json:"enabled,omitempty"`
 	ID           *string                             `json:"id,omitempty"`
@@ -948,9 +948,9 @@ type AiRequestTransformerPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []AiRequestTransformerPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *AiRequestTransformerPluginRoute `json:"route,omitempty"`
+	Route *AiRequestTransformerPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *AiRequestTransformerPluginService `json:"service,omitempty"`
+	Service *AiRequestTransformerPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/airesponsetransformerplugin.go
+++ b/internal/sdk/models/shared/airesponsetransformerplugin.go
@@ -814,8 +814,8 @@ func (o *AiResponseTransformerPluginService) GetID() *string {
 type AiResponseTransformerPlugin struct {
 	Config AiResponseTransformerPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *AiResponseTransformerPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *AiResponseTransformerPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *AiResponseTransformerPluginConsumer      `json:"consumer"`
+	ConsumerGroup *AiResponseTransformerPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -827,9 +827,9 @@ type AiResponseTransformerPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []AiResponseTransformerPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *AiResponseTransformerPluginRoute `json:"route,omitempty"`
+	Route *AiResponseTransformerPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *AiResponseTransformerPluginService `json:"service,omitempty"`
+	Service *AiResponseTransformerPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -946,8 +946,8 @@ func (o *AiResponseTransformerPlugin) GetUpdatedAt() *int64 {
 type AiResponseTransformerPluginInput struct {
 	Config AiResponseTransformerPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *AiResponseTransformerPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *AiResponseTransformerPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *AiResponseTransformerPluginConsumer      `json:"consumer"`
+	ConsumerGroup *AiResponseTransformerPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                                `json:"enabled,omitempty"`
 	ID           *string                              `json:"id,omitempty"`
@@ -957,9 +957,9 @@ type AiResponseTransformerPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []AiResponseTransformerPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *AiResponseTransformerPluginRoute `json:"route,omitempty"`
+	Route *AiResponseTransformerPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *AiResponseTransformerPluginService `json:"service,omitempty"`
+	Service *AiResponseTransformerPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/awslambdaplugin.go
+++ b/internal/sdk/models/shared/awslambdaplugin.go
@@ -506,8 +506,8 @@ func (o *AwsLambdaPluginService) GetID() *string {
 type AwsLambdaPlugin struct {
 	Config AwsLambdaPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *AwsLambdaPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *AwsLambdaPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *AwsLambdaPluginConsumer      `json:"consumer"`
+	ConsumerGroup *AwsLambdaPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -519,9 +519,9 @@ type AwsLambdaPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []AwsLambdaPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *AwsLambdaPluginRoute `json:"route,omitempty"`
+	Route *AwsLambdaPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *AwsLambdaPluginService `json:"service,omitempty"`
+	Service *AwsLambdaPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -638,8 +638,8 @@ func (o *AwsLambdaPlugin) GetUpdatedAt() *int64 {
 type AwsLambdaPluginInput struct {
 	Config AwsLambdaPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *AwsLambdaPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *AwsLambdaPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *AwsLambdaPluginConsumer      `json:"consumer"`
+	ConsumerGroup *AwsLambdaPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                    `json:"enabled,omitempty"`
 	ID           *string                  `json:"id,omitempty"`
@@ -649,9 +649,9 @@ type AwsLambdaPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []AwsLambdaPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *AwsLambdaPluginRoute `json:"route,omitempty"`
+	Route *AwsLambdaPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *AwsLambdaPluginService `json:"service,omitempty"`
+	Service *AwsLambdaPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/azurefunctionsplugin.go
+++ b/internal/sdk/models/shared/azurefunctionsplugin.go
@@ -243,8 +243,8 @@ func (o *AzureFunctionsPluginService) GetID() *string {
 type AzureFunctionsPlugin struct {
 	Config AzureFunctionsPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *AzureFunctionsPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *AzureFunctionsPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *AzureFunctionsPluginConsumer      `json:"consumer"`
+	ConsumerGroup *AzureFunctionsPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -256,9 +256,9 @@ type AzureFunctionsPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []AzureFunctionsPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *AzureFunctionsPluginRoute `json:"route,omitempty"`
+	Route *AzureFunctionsPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *AzureFunctionsPluginService `json:"service,omitempty"`
+	Service *AzureFunctionsPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -375,8 +375,8 @@ func (o *AzureFunctionsPlugin) GetUpdatedAt() *int64 {
 type AzureFunctionsPluginInput struct {
 	Config AzureFunctionsPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *AzureFunctionsPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *AzureFunctionsPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *AzureFunctionsPluginConsumer      `json:"consumer"`
+	ConsumerGroup *AzureFunctionsPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                         `json:"enabled,omitempty"`
 	ID           *string                       `json:"id,omitempty"`
@@ -386,9 +386,9 @@ type AzureFunctionsPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []AzureFunctionsPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *AzureFunctionsPluginRoute `json:"route,omitempty"`
+	Route *AzureFunctionsPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *AzureFunctionsPluginService `json:"service,omitempty"`
+	Service *AzureFunctionsPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/basicauth.go
+++ b/internal/sdk/models/shared/basicauth.go
@@ -14,7 +14,7 @@ func (o *BasicAuthConsumer) GetID() *string {
 }
 
 type BasicAuth struct {
-	Consumer *BasicAuthConsumer `json:"consumer,omitempty"`
+	Consumer *BasicAuthConsumer `json:"consumer"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64   `json:"created_at,omitempty"`
 	ID        *string  `json:"id,omitempty"`

--- a/internal/sdk/models/shared/basicauthplugin.go
+++ b/internal/sdk/models/shared/basicauthplugin.go
@@ -180,8 +180,8 @@ func (o *BasicAuthPluginService) GetID() *string {
 type BasicAuthPlugin struct {
 	Config BasicAuthPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *BasicAuthPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *BasicAuthPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *BasicAuthPluginConsumer      `json:"consumer"`
+	ConsumerGroup *BasicAuthPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -193,9 +193,9 @@ type BasicAuthPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []BasicAuthPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *BasicAuthPluginRoute `json:"route,omitempty"`
+	Route *BasicAuthPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *BasicAuthPluginService `json:"service,omitempty"`
+	Service *BasicAuthPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -312,8 +312,8 @@ func (o *BasicAuthPlugin) GetUpdatedAt() *int64 {
 type BasicAuthPluginInput struct {
 	Config BasicAuthPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *BasicAuthPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *BasicAuthPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *BasicAuthPluginConsumer      `json:"consumer"`
+	ConsumerGroup *BasicAuthPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                    `json:"enabled,omitempty"`
 	ID           *string                  `json:"id,omitempty"`
@@ -323,9 +323,9 @@ type BasicAuthPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []BasicAuthPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *BasicAuthPluginRoute `json:"route,omitempty"`
+	Route *BasicAuthPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *BasicAuthPluginService `json:"service,omitempty"`
+	Service *BasicAuthPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/botdetectionplugin.go
+++ b/internal/sdk/models/shared/botdetectionplugin.go
@@ -171,8 +171,8 @@ func (o *BotDetectionPluginService) GetID() *string {
 type BotDetectionPlugin struct {
 	Config BotDetectionPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *BotDetectionPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *BotDetectionPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *BotDetectionPluginConsumer      `json:"consumer"`
+	ConsumerGroup *BotDetectionPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -184,9 +184,9 @@ type BotDetectionPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []BotDetectionPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *BotDetectionPluginRoute `json:"route,omitempty"`
+	Route *BotDetectionPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *BotDetectionPluginService `json:"service,omitempty"`
+	Service *BotDetectionPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -303,8 +303,8 @@ func (o *BotDetectionPlugin) GetUpdatedAt() *int64 {
 type BotDetectionPluginInput struct {
 	Config BotDetectionPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *BotDetectionPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *BotDetectionPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *BotDetectionPluginConsumer      `json:"consumer"`
+	ConsumerGroup *BotDetectionPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                       `json:"enabled,omitempty"`
 	ID           *string                     `json:"id,omitempty"`
@@ -314,9 +314,9 @@ type BotDetectionPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []BotDetectionPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *BotDetectionPluginRoute `json:"route,omitempty"`
+	Route *BotDetectionPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *BotDetectionPluginService `json:"service,omitempty"`
+	Service *BotDetectionPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/canaryplugin.go
+++ b/internal/sdk/models/shared/canaryplugin.go
@@ -314,8 +314,8 @@ func (o *CanaryPluginService) GetID() *string {
 type CanaryPlugin struct {
 	Config CanaryPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *CanaryPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *CanaryPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *CanaryPluginConsumer      `json:"consumer"`
+	ConsumerGroup *CanaryPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -327,9 +327,9 @@ type CanaryPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []CanaryPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *CanaryPluginRoute `json:"route,omitempty"`
+	Route *CanaryPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *CanaryPluginService `json:"service,omitempty"`
+	Service *CanaryPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -446,8 +446,8 @@ func (o *CanaryPlugin) GetUpdatedAt() *int64 {
 type CanaryPluginInput struct {
 	Config CanaryPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *CanaryPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *CanaryPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *CanaryPluginConsumer      `json:"consumer"`
+	ConsumerGroup *CanaryPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                 `json:"enabled,omitempty"`
 	ID           *string               `json:"id,omitempty"`
@@ -457,9 +457,9 @@ type CanaryPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []CanaryPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *CanaryPluginRoute `json:"route,omitempty"`
+	Route *CanaryPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *CanaryPluginService `json:"service,omitempty"`
+	Service *CanaryPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/correlationidplugin.go
+++ b/internal/sdk/models/shared/correlationidplugin.go
@@ -210,8 +210,8 @@ func (o *CorrelationIDPluginService) GetID() *string {
 type CorrelationIDPlugin struct {
 	Config CorrelationIDPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *CorrelationIDPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *CorrelationIDPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *CorrelationIDPluginConsumer      `json:"consumer"`
+	ConsumerGroup *CorrelationIDPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -223,9 +223,9 @@ type CorrelationIDPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []CorrelationIDPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *CorrelationIDPluginRoute `json:"route,omitempty"`
+	Route *CorrelationIDPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *CorrelationIDPluginService `json:"service,omitempty"`
+	Service *CorrelationIDPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -342,8 +342,8 @@ func (o *CorrelationIDPlugin) GetUpdatedAt() *int64 {
 type CorrelationIDPluginInput struct {
 	Config CorrelationIDPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *CorrelationIDPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *CorrelationIDPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *CorrelationIDPluginConsumer      `json:"consumer"`
+	ConsumerGroup *CorrelationIDPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                        `json:"enabled,omitempty"`
 	ID           *string                      `json:"id,omitempty"`
@@ -353,9 +353,9 @@ type CorrelationIDPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []CorrelationIDPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *CorrelationIDPluginRoute `json:"route,omitempty"`
+	Route *CorrelationIDPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *CorrelationIDPluginService `json:"service,omitempty"`
+	Service *CorrelationIDPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/corsplugin.go
+++ b/internal/sdk/models/shared/corsplugin.go
@@ -272,8 +272,8 @@ func (o *CorsPluginService) GetID() *string {
 type CorsPlugin struct {
 	Config CorsPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *CorsPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *CorsPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *CorsPluginConsumer      `json:"consumer"`
+	ConsumerGroup *CorsPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -285,9 +285,9 @@ type CorsPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []CorsPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *CorsPluginRoute `json:"route,omitempty"`
+	Route *CorsPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *CorsPluginService `json:"service,omitempty"`
+	Service *CorsPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -404,8 +404,8 @@ func (o *CorsPlugin) GetUpdatedAt() *int64 {
 type CorsPluginInput struct {
 	Config CorsPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *CorsPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *CorsPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *CorsPluginConsumer      `json:"consumer"`
+	ConsumerGroup *CorsPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool               `json:"enabled,omitempty"`
 	ID           *string             `json:"id,omitempty"`
@@ -415,9 +415,9 @@ type CorsPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []CorsPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *CorsPluginRoute `json:"route,omitempty"`
+	Route *CorsPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *CorsPluginService `json:"service,omitempty"`
+	Service *CorsPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/datadogplugin.go
+++ b/internal/sdk/models/shared/datadogplugin.go
@@ -512,8 +512,8 @@ func (o *DatadogPluginService) GetID() *string {
 type DatadogPlugin struct {
 	Config DatadogPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *DatadogPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *DatadogPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *DatadogPluginConsumer      `json:"consumer"`
+	ConsumerGroup *DatadogPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -525,9 +525,9 @@ type DatadogPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []DatadogPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *DatadogPluginRoute `json:"route,omitempty"`
+	Route *DatadogPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *DatadogPluginService `json:"service,omitempty"`
+	Service *DatadogPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -644,8 +644,8 @@ func (o *DatadogPlugin) GetUpdatedAt() *int64 {
 type DatadogPluginInput struct {
 	Config DatadogPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *DatadogPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *DatadogPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *DatadogPluginConsumer      `json:"consumer"`
+	ConsumerGroup *DatadogPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                  `json:"enabled,omitempty"`
 	ID           *string                `json:"id,omitempty"`
@@ -655,9 +655,9 @@ type DatadogPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []DatadogPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *DatadogPluginRoute `json:"route,omitempty"`
+	Route *DatadogPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *DatadogPluginService `json:"service,omitempty"`
+	Service *DatadogPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/degraphqlplugin.go
+++ b/internal/sdk/models/shared/degraphqlplugin.go
@@ -162,8 +162,8 @@ func (o *DegraphqlPluginService) GetID() *string {
 type DegraphqlPlugin struct {
 	Config DegraphqlPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *DegraphqlPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *DegraphqlPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *DegraphqlPluginConsumer      `json:"consumer"`
+	ConsumerGroup *DegraphqlPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -175,9 +175,9 @@ type DegraphqlPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []DegraphqlPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *DegraphqlPluginRoute `json:"route,omitempty"`
+	Route *DegraphqlPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *DegraphqlPluginService `json:"service,omitempty"`
+	Service *DegraphqlPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -294,8 +294,8 @@ func (o *DegraphqlPlugin) GetUpdatedAt() *int64 {
 type DegraphqlPluginInput struct {
 	Config DegraphqlPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *DegraphqlPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *DegraphqlPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *DegraphqlPluginConsumer      `json:"consumer"`
+	ConsumerGroup *DegraphqlPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                    `json:"enabled,omitempty"`
 	ID           *string                  `json:"id,omitempty"`
@@ -305,9 +305,9 @@ type DegraphqlPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []DegraphqlPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *DegraphqlPluginRoute `json:"route,omitempty"`
+	Route *DegraphqlPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *DegraphqlPluginService `json:"service,omitempty"`
+	Service *DegraphqlPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/exittransformerplugin.go
+++ b/internal/sdk/models/shared/exittransformerplugin.go
@@ -179,8 +179,8 @@ func (o *ExitTransformerPluginService) GetID() *string {
 type ExitTransformerPlugin struct {
 	Config ExitTransformerPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *ExitTransformerPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *ExitTransformerPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *ExitTransformerPluginConsumer      `json:"consumer"`
+	ConsumerGroup *ExitTransformerPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -192,9 +192,9 @@ type ExitTransformerPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []ExitTransformerPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *ExitTransformerPluginRoute `json:"route,omitempty"`
+	Route *ExitTransformerPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *ExitTransformerPluginService `json:"service,omitempty"`
+	Service *ExitTransformerPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -311,8 +311,8 @@ func (o *ExitTransformerPlugin) GetUpdatedAt() *int64 {
 type ExitTransformerPluginInput struct {
 	Config ExitTransformerPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *ExitTransformerPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *ExitTransformerPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *ExitTransformerPluginConsumer      `json:"consumer"`
+	ConsumerGroup *ExitTransformerPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                          `json:"enabled,omitempty"`
 	ID           *string                        `json:"id,omitempty"`
@@ -322,9 +322,9 @@ type ExitTransformerPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []ExitTransformerPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *ExitTransformerPluginRoute `json:"route,omitempty"`
+	Route *ExitTransformerPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *ExitTransformerPluginService `json:"service,omitempty"`
+	Service *ExitTransformerPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/filelogplugin.go
+++ b/internal/sdk/models/shared/filelogplugin.go
@@ -180,8 +180,8 @@ func (o *FileLogPluginService) GetID() *string {
 type FileLogPlugin struct {
 	Config FileLogPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *FileLogPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *FileLogPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *FileLogPluginConsumer      `json:"consumer"`
+	ConsumerGroup *FileLogPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -193,9 +193,9 @@ type FileLogPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []FileLogPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *FileLogPluginRoute `json:"route,omitempty"`
+	Route *FileLogPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *FileLogPluginService `json:"service,omitempty"`
+	Service *FileLogPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -312,8 +312,8 @@ func (o *FileLogPlugin) GetUpdatedAt() *int64 {
 type FileLogPluginInput struct {
 	Config FileLogPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *FileLogPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *FileLogPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *FileLogPluginConsumer      `json:"consumer"`
+	ConsumerGroup *FileLogPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                  `json:"enabled,omitempty"`
 	ID           *string                `json:"id,omitempty"`
@@ -323,9 +323,9 @@ type FileLogPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []FileLogPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *FileLogPluginRoute `json:"route,omitempty"`
+	Route *FileLogPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *FileLogPluginService `json:"service,omitempty"`
+	Service *FileLogPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/forwardproxyplugin.go
+++ b/internal/sdk/models/shared/forwardproxyplugin.go
@@ -290,8 +290,8 @@ func (o *ForwardProxyPluginService) GetID() *string {
 type ForwardProxyPlugin struct {
 	Config ForwardProxyPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *ForwardProxyPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *ForwardProxyPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *ForwardProxyPluginConsumer      `json:"consumer"`
+	ConsumerGroup *ForwardProxyPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -303,9 +303,9 @@ type ForwardProxyPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []ForwardProxyPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *ForwardProxyPluginRoute `json:"route,omitempty"`
+	Route *ForwardProxyPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *ForwardProxyPluginService `json:"service,omitempty"`
+	Service *ForwardProxyPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -422,8 +422,8 @@ func (o *ForwardProxyPlugin) GetUpdatedAt() *int64 {
 type ForwardProxyPluginInput struct {
 	Config ForwardProxyPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *ForwardProxyPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *ForwardProxyPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *ForwardProxyPluginConsumer      `json:"consumer"`
+	ConsumerGroup *ForwardProxyPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                       `json:"enabled,omitempty"`
 	ID           *string                     `json:"id,omitempty"`
@@ -433,9 +433,9 @@ type ForwardProxyPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []ForwardProxyPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *ForwardProxyPluginRoute `json:"route,omitempty"`
+	Route *ForwardProxyPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *ForwardProxyPluginService `json:"service,omitempty"`
+	Service *ForwardProxyPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/graphqlproxycacheadvancedplugin.go
+++ b/internal/sdk/models/shared/graphqlproxycacheadvancedplugin.go
@@ -508,8 +508,8 @@ func (o *GraphqlProxyCacheAdvancedPluginService) GetID() *string {
 type GraphqlProxyCacheAdvancedPlugin struct {
 	Config GraphqlProxyCacheAdvancedPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *GraphqlProxyCacheAdvancedPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *GraphqlProxyCacheAdvancedPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *GraphqlProxyCacheAdvancedPluginConsumer      `json:"consumer"`
+	ConsumerGroup *GraphqlProxyCacheAdvancedPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -521,9 +521,9 @@ type GraphqlProxyCacheAdvancedPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []GraphqlProxyCacheAdvancedPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *GraphqlProxyCacheAdvancedPluginRoute `json:"route,omitempty"`
+	Route *GraphqlProxyCacheAdvancedPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *GraphqlProxyCacheAdvancedPluginService `json:"service,omitempty"`
+	Service *GraphqlProxyCacheAdvancedPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -640,8 +640,8 @@ func (o *GraphqlProxyCacheAdvancedPlugin) GetUpdatedAt() *int64 {
 type GraphqlProxyCacheAdvancedPluginInput struct {
 	Config GraphqlProxyCacheAdvancedPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *GraphqlProxyCacheAdvancedPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *GraphqlProxyCacheAdvancedPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *GraphqlProxyCacheAdvancedPluginConsumer      `json:"consumer"`
+	ConsumerGroup *GraphqlProxyCacheAdvancedPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                                    `json:"enabled,omitempty"`
 	ID           *string                                  `json:"id,omitempty"`
@@ -651,9 +651,9 @@ type GraphqlProxyCacheAdvancedPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []GraphqlProxyCacheAdvancedPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *GraphqlProxyCacheAdvancedPluginRoute `json:"route,omitempty"`
+	Route *GraphqlProxyCacheAdvancedPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *GraphqlProxyCacheAdvancedPluginService `json:"service,omitempty"`
+	Service *GraphqlProxyCacheAdvancedPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/graphqlratelimitingadvancedplugin.go
+++ b/internal/sdk/models/shared/graphqlratelimitingadvancedplugin.go
@@ -644,8 +644,8 @@ func (o *GraphqlRateLimitingAdvancedPluginService) GetID() *string {
 type GraphqlRateLimitingAdvancedPlugin struct {
 	Config GraphqlRateLimitingAdvancedPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *GraphqlRateLimitingAdvancedPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *GraphqlRateLimitingAdvancedPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *GraphqlRateLimitingAdvancedPluginConsumer      `json:"consumer"`
+	ConsumerGroup *GraphqlRateLimitingAdvancedPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -657,9 +657,9 @@ type GraphqlRateLimitingAdvancedPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []GraphqlRateLimitingAdvancedPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *GraphqlRateLimitingAdvancedPluginRoute `json:"route,omitempty"`
+	Route *GraphqlRateLimitingAdvancedPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *GraphqlRateLimitingAdvancedPluginService `json:"service,omitempty"`
+	Service *GraphqlRateLimitingAdvancedPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -776,8 +776,8 @@ func (o *GraphqlRateLimitingAdvancedPlugin) GetUpdatedAt() *int64 {
 type GraphqlRateLimitingAdvancedPluginInput struct {
 	Config GraphqlRateLimitingAdvancedPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *GraphqlRateLimitingAdvancedPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *GraphqlRateLimitingAdvancedPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *GraphqlRateLimitingAdvancedPluginConsumer      `json:"consumer"`
+	ConsumerGroup *GraphqlRateLimitingAdvancedPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                                      `json:"enabled,omitempty"`
 	ID           *string                                    `json:"id,omitempty"`
@@ -787,9 +787,9 @@ type GraphqlRateLimitingAdvancedPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []GraphqlRateLimitingAdvancedPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *GraphqlRateLimitingAdvancedPluginRoute `json:"route,omitempty"`
+	Route *GraphqlRateLimitingAdvancedPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *GraphqlRateLimitingAdvancedPluginService `json:"service,omitempty"`
+	Service *GraphqlRateLimitingAdvancedPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/grpcgatewayplugin.go
+++ b/internal/sdk/models/shared/grpcgatewayplugin.go
@@ -162,8 +162,8 @@ func (o *GrpcGatewayPluginService) GetID() *string {
 type GrpcGatewayPlugin struct {
 	Config GrpcGatewayPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *GrpcGatewayPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *GrpcGatewayPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *GrpcGatewayPluginConsumer      `json:"consumer"`
+	ConsumerGroup *GrpcGatewayPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -175,9 +175,9 @@ type GrpcGatewayPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []GrpcGatewayPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *GrpcGatewayPluginRoute `json:"route,omitempty"`
+	Route *GrpcGatewayPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *GrpcGatewayPluginService `json:"service,omitempty"`
+	Service *GrpcGatewayPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -294,8 +294,8 @@ func (o *GrpcGatewayPlugin) GetUpdatedAt() *int64 {
 type GrpcGatewayPluginInput struct {
 	Config GrpcGatewayPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *GrpcGatewayPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *GrpcGatewayPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *GrpcGatewayPluginConsumer      `json:"consumer"`
+	ConsumerGroup *GrpcGatewayPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                      `json:"enabled,omitempty"`
 	ID           *string                    `json:"id,omitempty"`
@@ -305,9 +305,9 @@ type GrpcGatewayPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []GrpcGatewayPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *GrpcGatewayPluginRoute `json:"route,omitempty"`
+	Route *GrpcGatewayPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *GrpcGatewayPluginService `json:"service,omitempty"`
+	Service *GrpcGatewayPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/grpcwebplugin.go
+++ b/internal/sdk/models/shared/grpcwebplugin.go
@@ -180,8 +180,8 @@ func (o *GrpcWebPluginService) GetID() *string {
 type GrpcWebPlugin struct {
 	Config GrpcWebPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *GrpcWebPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *GrpcWebPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *GrpcWebPluginConsumer      `json:"consumer"`
+	ConsumerGroup *GrpcWebPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -193,9 +193,9 @@ type GrpcWebPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []GrpcWebPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *GrpcWebPluginRoute `json:"route,omitempty"`
+	Route *GrpcWebPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *GrpcWebPluginService `json:"service,omitempty"`
+	Service *GrpcWebPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -312,8 +312,8 @@ func (o *GrpcWebPlugin) GetUpdatedAt() *int64 {
 type GrpcWebPluginInput struct {
 	Config GrpcWebPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *GrpcWebPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *GrpcWebPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *GrpcWebPluginConsumer      `json:"consumer"`
+	ConsumerGroup *GrpcWebPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                  `json:"enabled,omitempty"`
 	ID           *string                `json:"id,omitempty"`
@@ -323,9 +323,9 @@ type GrpcWebPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []GrpcWebPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *GrpcWebPluginRoute `json:"route,omitempty"`
+	Route *GrpcWebPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *GrpcWebPluginService `json:"service,omitempty"`
+	Service *GrpcWebPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/hmacauth.go
+++ b/internal/sdk/models/shared/hmacauth.go
@@ -14,7 +14,7 @@ func (o *HMACAuthConsumer) GetID() *string {
 }
 
 type HMACAuth struct {
-	Consumer *HMACAuthConsumer `json:"consumer,omitempty"`
+	Consumer *HMACAuthConsumer `json:"consumer"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64   `json:"created_at,omitempty"`
 	ID        *string  `json:"id,omitempty"`

--- a/internal/sdk/models/shared/hmacauthplugin.go
+++ b/internal/sdk/models/shared/hmacauthplugin.go
@@ -248,8 +248,8 @@ func (o *HmacAuthPluginService) GetID() *string {
 type HmacAuthPlugin struct {
 	Config HmacAuthPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *HmacAuthPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *HmacAuthPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *HmacAuthPluginConsumer      `json:"consumer"`
+	ConsumerGroup *HmacAuthPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -261,9 +261,9 @@ type HmacAuthPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []HmacAuthPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *HmacAuthPluginRoute `json:"route,omitempty"`
+	Route *HmacAuthPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *HmacAuthPluginService `json:"service,omitempty"`
+	Service *HmacAuthPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -380,8 +380,8 @@ func (o *HmacAuthPlugin) GetUpdatedAt() *int64 {
 type HmacAuthPluginInput struct {
 	Config HmacAuthPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *HmacAuthPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *HmacAuthPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *HmacAuthPluginConsumer      `json:"consumer"`
+	ConsumerGroup *HmacAuthPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                   `json:"enabled,omitempty"`
 	ID           *string                 `json:"id,omitempty"`
@@ -391,9 +391,9 @@ type HmacAuthPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []HmacAuthPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *HmacAuthPluginRoute `json:"route,omitempty"`
+	Route *HmacAuthPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *HmacAuthPluginService `json:"service,omitempty"`
+	Service *HmacAuthPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/httplogplugin.go
+++ b/internal/sdk/models/shared/httplogplugin.go
@@ -410,8 +410,8 @@ func (o *HTTPLogPluginService) GetID() *string {
 type HTTPLogPlugin struct {
 	Config HTTPLogPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *HTTPLogPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *HTTPLogPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *HTTPLogPluginConsumer      `json:"consumer"`
+	ConsumerGroup *HTTPLogPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -423,9 +423,9 @@ type HTTPLogPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []HTTPLogPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *HTTPLogPluginRoute `json:"route,omitempty"`
+	Route *HTTPLogPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *HTTPLogPluginService `json:"service,omitempty"`
+	Service *HTTPLogPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -542,8 +542,8 @@ func (o *HTTPLogPlugin) GetUpdatedAt() *int64 {
 type HTTPLogPluginInput struct {
 	Config HTTPLogPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *HTTPLogPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *HTTPLogPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *HTTPLogPluginConsumer      `json:"consumer"`
+	ConsumerGroup *HTTPLogPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                  `json:"enabled,omitempty"`
 	ID           *string                `json:"id,omitempty"`
@@ -553,9 +553,9 @@ type HTTPLogPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []HTTPLogPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *HTTPLogPluginRoute `json:"route,omitempty"`
+	Route *HTTPLogPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *HTTPLogPluginService `json:"service,omitempty"`
+	Service *HTTPLogPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/iprestrictionplugin.go
+++ b/internal/sdk/models/shared/iprestrictionplugin.go
@@ -189,8 +189,8 @@ func (o *IPRestrictionPluginService) GetID() *string {
 type IPRestrictionPlugin struct {
 	Config IPRestrictionPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *IPRestrictionPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *IPRestrictionPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *IPRestrictionPluginConsumer      `json:"consumer"`
+	ConsumerGroup *IPRestrictionPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -202,9 +202,9 @@ type IPRestrictionPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []IPRestrictionPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *IPRestrictionPluginRoute `json:"route,omitempty"`
+	Route *IPRestrictionPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *IPRestrictionPluginService `json:"service,omitempty"`
+	Service *IPRestrictionPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -321,8 +321,8 @@ func (o *IPRestrictionPlugin) GetUpdatedAt() *int64 {
 type IPRestrictionPluginInput struct {
 	Config IPRestrictionPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *IPRestrictionPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *IPRestrictionPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *IPRestrictionPluginConsumer      `json:"consumer"`
+	ConsumerGroup *IPRestrictionPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                        `json:"enabled,omitempty"`
 	ID           *string                      `json:"id,omitempty"`
@@ -332,9 +332,9 @@ type IPRestrictionPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []IPRestrictionPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *IPRestrictionPluginRoute `json:"route,omitempty"`
+	Route *IPRestrictionPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *IPRestrictionPluginService `json:"service,omitempty"`
+	Service *IPRestrictionPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/jqplugin.go
+++ b/internal/sdk/models/shared/jqplugin.go
@@ -295,8 +295,8 @@ func (o *JqPluginService) GetID() *string {
 type JqPlugin struct {
 	Config JqPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *JqPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *JqPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *JqPluginConsumer      `json:"consumer"`
+	ConsumerGroup *JqPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -308,9 +308,9 @@ type JqPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []JqPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *JqPluginRoute `json:"route,omitempty"`
+	Route *JqPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *JqPluginService `json:"service,omitempty"`
+	Service *JqPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -427,8 +427,8 @@ func (o *JqPlugin) GetUpdatedAt() *int64 {
 type JqPluginInput struct {
 	Config JqPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *JqPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *JqPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *JqPluginConsumer      `json:"consumer"`
+	ConsumerGroup *JqPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool             `json:"enabled,omitempty"`
 	ID           *string           `json:"id,omitempty"`
@@ -438,9 +438,9 @@ type JqPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []JqPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *JqPluginRoute `json:"route,omitempty"`
+	Route *JqPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *JqPluginService `json:"service,omitempty"`
+	Service *JqPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/jwedecryptplugin.go
+++ b/internal/sdk/models/shared/jwedecryptplugin.go
@@ -189,8 +189,8 @@ func (o *JweDecryptPluginService) GetID() *string {
 type JweDecryptPlugin struct {
 	Config JweDecryptPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *JweDecryptPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *JweDecryptPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *JweDecryptPluginConsumer      `json:"consumer"`
+	ConsumerGroup *JweDecryptPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -202,9 +202,9 @@ type JweDecryptPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []JweDecryptPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *JweDecryptPluginRoute `json:"route,omitempty"`
+	Route *JweDecryptPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *JweDecryptPluginService `json:"service,omitempty"`
+	Service *JweDecryptPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -321,8 +321,8 @@ func (o *JweDecryptPlugin) GetUpdatedAt() *int64 {
 type JweDecryptPluginInput struct {
 	Config JweDecryptPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *JweDecryptPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *JweDecryptPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *JweDecryptPluginConsumer      `json:"consumer"`
+	ConsumerGroup *JweDecryptPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                     `json:"enabled,omitempty"`
 	ID           *string                   `json:"id,omitempty"`
@@ -332,9 +332,9 @@ type JweDecryptPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []JweDecryptPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *JweDecryptPluginRoute `json:"route,omitempty"`
+	Route *JweDecryptPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *JweDecryptPluginService `json:"service,omitempty"`
+	Service *JweDecryptPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/jwt.go
+++ b/internal/sdk/models/shared/jwt.go
@@ -79,7 +79,7 @@ func (o *JWTConsumer) GetID() *string {
 
 type Jwt struct {
 	Algorithm *JWTAlgorithm `json:"algorithm,omitempty"`
-	Consumer  *JWTConsumer  `json:"consumer,omitempty"`
+	Consumer  *JWTConsumer  `json:"consumer"`
 	// Unix epoch when the resource was created.
 	CreatedAt    *int64   `json:"created_at,omitempty"`
 	ID           *string  `json:"id,omitempty"`

--- a/internal/sdk/models/shared/jwtplugin.go
+++ b/internal/sdk/models/shared/jwtplugin.go
@@ -269,8 +269,8 @@ func (o *JwtPluginService) GetID() *string {
 type JwtPlugin struct {
 	Config JwtPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *JwtPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *JwtPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *JwtPluginConsumer      `json:"consumer"`
+	ConsumerGroup *JwtPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -282,9 +282,9 @@ type JwtPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []JwtPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *JwtPluginRoute `json:"route,omitempty"`
+	Route *JwtPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *JwtPluginService `json:"service,omitempty"`
+	Service *JwtPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -401,8 +401,8 @@ func (o *JwtPlugin) GetUpdatedAt() *int64 {
 type JwtPluginInput struct {
 	Config JwtPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *JwtPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *JwtPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *JwtPluginConsumer      `json:"consumer"`
+	ConsumerGroup *JwtPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool              `json:"enabled,omitempty"`
 	ID           *string            `json:"id,omitempty"`
@@ -412,9 +412,9 @@ type JwtPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []JwtPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *JwtPluginRoute `json:"route,omitempty"`
+	Route *JwtPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *JwtPluginService `json:"service,omitempty"`
+	Service *JwtPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/jwtsignerplugin.go
+++ b/internal/sdk/models/shared/jwtsignerplugin.go
@@ -1219,8 +1219,8 @@ func (o *JwtSignerPluginService) GetID() *string {
 type JwtSignerPlugin struct {
 	Config JwtSignerPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *JwtSignerPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *JwtSignerPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *JwtSignerPluginConsumer      `json:"consumer"`
+	ConsumerGroup *JwtSignerPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -1232,9 +1232,9 @@ type JwtSignerPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []JwtSignerPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *JwtSignerPluginRoute `json:"route,omitempty"`
+	Route *JwtSignerPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *JwtSignerPluginService `json:"service,omitempty"`
+	Service *JwtSignerPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -1351,8 +1351,8 @@ func (o *JwtSignerPlugin) GetUpdatedAt() *int64 {
 type JwtSignerPluginInput struct {
 	Config JwtSignerPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *JwtSignerPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *JwtSignerPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *JwtSignerPluginConsumer      `json:"consumer"`
+	ConsumerGroup *JwtSignerPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                    `json:"enabled,omitempty"`
 	ID           *string                  `json:"id,omitempty"`
@@ -1362,9 +1362,9 @@ type JwtSignerPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []JwtSignerPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *JwtSignerPluginRoute `json:"route,omitempty"`
+	Route *JwtSignerPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *JwtSignerPluginService `json:"service,omitempty"`
+	Service *JwtSignerPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/kafkalogplugin.go
+++ b/internal/sdk/models/shared/kafkalogplugin.go
@@ -485,8 +485,8 @@ func (o *KafkaLogPluginService) GetID() *string {
 type KafkaLogPlugin struct {
 	Config KafkaLogPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *KafkaLogPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *KafkaLogPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *KafkaLogPluginConsumer      `json:"consumer"`
+	ConsumerGroup *KafkaLogPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -498,9 +498,9 @@ type KafkaLogPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []KafkaLogPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *KafkaLogPluginRoute `json:"route,omitempty"`
+	Route *KafkaLogPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *KafkaLogPluginService `json:"service,omitempty"`
+	Service *KafkaLogPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -617,8 +617,8 @@ func (o *KafkaLogPlugin) GetUpdatedAt() *int64 {
 type KafkaLogPluginInput struct {
 	Config KafkaLogPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *KafkaLogPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *KafkaLogPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *KafkaLogPluginConsumer      `json:"consumer"`
+	ConsumerGroup *KafkaLogPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                   `json:"enabled,omitempty"`
 	ID           *string                 `json:"id,omitempty"`
@@ -628,9 +628,9 @@ type KafkaLogPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []KafkaLogPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *KafkaLogPluginRoute `json:"route,omitempty"`
+	Route *KafkaLogPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *KafkaLogPluginService `json:"service,omitempty"`
+	Service *KafkaLogPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/kafkaupstreamplugin.go
+++ b/internal/sdk/models/shared/kafkaupstreamplugin.go
@@ -513,8 +513,8 @@ func (o *KafkaUpstreamPluginService) GetID() *string {
 type KafkaUpstreamPlugin struct {
 	Config KafkaUpstreamPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *KafkaUpstreamPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *KafkaUpstreamPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *KafkaUpstreamPluginConsumer      `json:"consumer"`
+	ConsumerGroup *KafkaUpstreamPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -526,9 +526,9 @@ type KafkaUpstreamPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []KafkaUpstreamPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *KafkaUpstreamPluginRoute `json:"route,omitempty"`
+	Route *KafkaUpstreamPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *KafkaUpstreamPluginService `json:"service,omitempty"`
+	Service *KafkaUpstreamPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -645,8 +645,8 @@ func (o *KafkaUpstreamPlugin) GetUpdatedAt() *int64 {
 type KafkaUpstreamPluginInput struct {
 	Config KafkaUpstreamPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *KafkaUpstreamPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *KafkaUpstreamPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *KafkaUpstreamPluginConsumer      `json:"consumer"`
+	ConsumerGroup *KafkaUpstreamPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                        `json:"enabled,omitempty"`
 	ID           *string                      `json:"id,omitempty"`
@@ -656,9 +656,9 @@ type KafkaUpstreamPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []KafkaUpstreamPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *KafkaUpstreamPluginRoute `json:"route,omitempty"`
+	Route *KafkaUpstreamPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *KafkaUpstreamPluginService `json:"service,omitempty"`
+	Service *KafkaUpstreamPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/key.go
+++ b/internal/sdk/models/shared/key.go
@@ -48,7 +48,7 @@ type Key struct {
 	// A keypair in PEM format.
 	Pem *Pem `json:"pem,omitempty"`
 	// The id (an UUID) of the key-set with which to associate the key.
-	Set *Set `json:"set,omitempty"`
+	Set *Set `json:"set"`
 	// An optional set of strings associated with the Key for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -130,7 +130,7 @@ type KeyInput struct {
 	// A keypair in PEM format.
 	Pem *Pem `json:"pem,omitempty"`
 	// The id (an UUID) of the key-set with which to associate the key.
-	Set *Set `json:"set,omitempty"`
+	Set *Set `json:"set"`
 	// An optional set of strings associated with the Key for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/keyauth.go
+++ b/internal/sdk/models/shared/keyauth.go
@@ -14,7 +14,7 @@ func (o *KeyAuthConsumer) GetID() *string {
 }
 
 type KeyAuth struct {
-	Consumer *KeyAuthConsumer `json:"consumer,omitempty"`
+	Consumer *KeyAuthConsumer `json:"consumer"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64   `json:"created_at,omitempty"`
 	ID        *string  `json:"id,omitempty"`

--- a/internal/sdk/models/shared/keyauthencplugin.go
+++ b/internal/sdk/models/shared/keyauthencplugin.go
@@ -225,8 +225,8 @@ func (o *KeyAuthEncPluginService) GetID() *string {
 type KeyAuthEncPlugin struct {
 	Config KeyAuthEncPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *KeyAuthEncPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *KeyAuthEncPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *KeyAuthEncPluginConsumer      `json:"consumer"`
+	ConsumerGroup *KeyAuthEncPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -238,9 +238,9 @@ type KeyAuthEncPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []KeyAuthEncPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *KeyAuthEncPluginRoute `json:"route,omitempty"`
+	Route *KeyAuthEncPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *KeyAuthEncPluginService `json:"service,omitempty"`
+	Service *KeyAuthEncPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -357,8 +357,8 @@ func (o *KeyAuthEncPlugin) GetUpdatedAt() *int64 {
 type KeyAuthEncPluginInput struct {
 	Config KeyAuthEncPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *KeyAuthEncPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *KeyAuthEncPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *KeyAuthEncPluginConsumer      `json:"consumer"`
+	ConsumerGroup *KeyAuthEncPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                     `json:"enabled,omitempty"`
 	ID           *string                   `json:"id,omitempty"`
@@ -368,9 +368,9 @@ type KeyAuthEncPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []KeyAuthEncPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *KeyAuthEncPluginRoute `json:"route,omitempty"`
+	Route *KeyAuthEncPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *KeyAuthEncPluginService `json:"service,omitempty"`
+	Service *KeyAuthEncPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/keyauthplugin.go
+++ b/internal/sdk/models/shared/keyauthplugin.go
@@ -225,8 +225,8 @@ func (o *KeyAuthPluginService) GetID() *string {
 type KeyAuthPlugin struct {
 	Config KeyAuthPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *KeyAuthPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *KeyAuthPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *KeyAuthPluginConsumer      `json:"consumer"`
+	ConsumerGroup *KeyAuthPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -238,9 +238,9 @@ type KeyAuthPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []KeyAuthPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *KeyAuthPluginRoute `json:"route,omitempty"`
+	Route *KeyAuthPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *KeyAuthPluginService `json:"service,omitempty"`
+	Service *KeyAuthPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -357,8 +357,8 @@ func (o *KeyAuthPlugin) GetUpdatedAt() *int64 {
 type KeyAuthPluginInput struct {
 	Config KeyAuthPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *KeyAuthPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *KeyAuthPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *KeyAuthPluginConsumer      `json:"consumer"`
+	ConsumerGroup *KeyAuthPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                  `json:"enabled,omitempty"`
 	ID           *string                `json:"id,omitempty"`
@@ -368,9 +368,9 @@ type KeyAuthPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []KeyAuthPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *KeyAuthPluginRoute `json:"route,omitempty"`
+	Route *KeyAuthPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *KeyAuthPluginService `json:"service,omitempty"`
+	Service *KeyAuthPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/konnectapplicationauthplugin.go
+++ b/internal/sdk/models/shared/konnectapplicationauthplugin.go
@@ -4174,8 +4174,8 @@ func (o *KonnectApplicationAuthPluginService) GetID() *string {
 type KonnectApplicationAuthPlugin struct {
 	Config KonnectApplicationAuthPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *KonnectApplicationAuthPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *KonnectApplicationAuthPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *KonnectApplicationAuthPluginConsumer      `json:"consumer"`
+	ConsumerGroup *KonnectApplicationAuthPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -4187,9 +4187,9 @@ type KonnectApplicationAuthPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []KonnectApplicationAuthPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *KonnectApplicationAuthPluginRoute `json:"route,omitempty"`
+	Route *KonnectApplicationAuthPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *KonnectApplicationAuthPluginService `json:"service,omitempty"`
+	Service *KonnectApplicationAuthPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -4306,8 +4306,8 @@ func (o *KonnectApplicationAuthPlugin) GetUpdatedAt() *int64 {
 type KonnectApplicationAuthPluginInput struct {
 	Config KonnectApplicationAuthPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *KonnectApplicationAuthPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *KonnectApplicationAuthPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *KonnectApplicationAuthPluginConsumer      `json:"consumer"`
+	ConsumerGroup *KonnectApplicationAuthPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                                 `json:"enabled,omitempty"`
 	ID           *string                               `json:"id,omitempty"`
@@ -4317,9 +4317,9 @@ type KonnectApplicationAuthPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []KonnectApplicationAuthPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *KonnectApplicationAuthPluginRoute `json:"route,omitempty"`
+	Route *KonnectApplicationAuthPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *KonnectApplicationAuthPluginService `json:"service,omitempty"`
+	Service *KonnectApplicationAuthPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/ldapauthadvancedplugin.go
+++ b/internal/sdk/models/shared/ldapauthadvancedplugin.go
@@ -386,8 +386,8 @@ func (o *LdapAuthAdvancedPluginService) GetID() *string {
 type LdapAuthAdvancedPlugin struct {
 	Config LdapAuthAdvancedPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *LdapAuthAdvancedPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *LdapAuthAdvancedPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *LdapAuthAdvancedPluginConsumer      `json:"consumer"`
+	ConsumerGroup *LdapAuthAdvancedPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -399,9 +399,9 @@ type LdapAuthAdvancedPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []LdapAuthAdvancedPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *LdapAuthAdvancedPluginRoute `json:"route,omitempty"`
+	Route *LdapAuthAdvancedPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *LdapAuthAdvancedPluginService `json:"service,omitempty"`
+	Service *LdapAuthAdvancedPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -518,8 +518,8 @@ func (o *LdapAuthAdvancedPlugin) GetUpdatedAt() *int64 {
 type LdapAuthAdvancedPluginInput struct {
 	Config LdapAuthAdvancedPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *LdapAuthAdvancedPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *LdapAuthAdvancedPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *LdapAuthAdvancedPluginConsumer      `json:"consumer"`
+	ConsumerGroup *LdapAuthAdvancedPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                           `json:"enabled,omitempty"`
 	ID           *string                         `json:"id,omitempty"`
@@ -529,9 +529,9 @@ type LdapAuthAdvancedPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []LdapAuthAdvancedPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *LdapAuthAdvancedPluginRoute `json:"route,omitempty"`
+	Route *LdapAuthAdvancedPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *LdapAuthAdvancedPluginService `json:"service,omitempty"`
+	Service *LdapAuthAdvancedPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/ldapauthplugin.go
+++ b/internal/sdk/models/shared/ldapauthplugin.go
@@ -279,8 +279,8 @@ func (o *LdapAuthPluginService) GetID() *string {
 type LdapAuthPlugin struct {
 	Config LdapAuthPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *LdapAuthPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *LdapAuthPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *LdapAuthPluginConsumer      `json:"consumer"`
+	ConsumerGroup *LdapAuthPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -292,9 +292,9 @@ type LdapAuthPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []LdapAuthPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *LdapAuthPluginRoute `json:"route,omitempty"`
+	Route *LdapAuthPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *LdapAuthPluginService `json:"service,omitempty"`
+	Service *LdapAuthPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -411,8 +411,8 @@ func (o *LdapAuthPlugin) GetUpdatedAt() *int64 {
 type LdapAuthPluginInput struct {
 	Config LdapAuthPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *LdapAuthPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *LdapAuthPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *LdapAuthPluginConsumer      `json:"consumer"`
+	ConsumerGroup *LdapAuthPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                   `json:"enabled,omitempty"`
 	ID           *string                 `json:"id,omitempty"`
@@ -422,9 +422,9 @@ type LdapAuthPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []LdapAuthPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *LdapAuthPluginRoute `json:"route,omitempty"`
+	Route *LdapAuthPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *LdapAuthPluginService `json:"service,omitempty"`
+	Service *LdapAuthPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/logglyplugin.go
+++ b/internal/sdk/models/shared/logglyplugin.go
@@ -412,8 +412,8 @@ func (o *LogglyPluginService) GetID() *string {
 type LogglyPlugin struct {
 	Config LogglyPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *LogglyPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *LogglyPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *LogglyPluginConsumer      `json:"consumer"`
+	ConsumerGroup *LogglyPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -425,9 +425,9 @@ type LogglyPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []LogglyPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *LogglyPluginRoute `json:"route,omitempty"`
+	Route *LogglyPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *LogglyPluginService `json:"service,omitempty"`
+	Service *LogglyPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -544,8 +544,8 @@ func (o *LogglyPlugin) GetUpdatedAt() *int64 {
 type LogglyPluginInput struct {
 	Config LogglyPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *LogglyPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *LogglyPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *LogglyPluginConsumer      `json:"consumer"`
+	ConsumerGroup *LogglyPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                 `json:"enabled,omitempty"`
 	ID           *string               `json:"id,omitempty"`
@@ -555,9 +555,9 @@ type LogglyPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []LogglyPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *LogglyPluginRoute `json:"route,omitempty"`
+	Route *LogglyPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *LogglyPluginService `json:"service,omitempty"`
+	Service *LogglyPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/mockingplugin.go
+++ b/internal/sdk/models/shared/mockingplugin.go
@@ -243,8 +243,8 @@ func (o *MockingPluginService) GetID() *string {
 type MockingPlugin struct {
 	Config MockingPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *MockingPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *MockingPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *MockingPluginConsumer      `json:"consumer"`
+	ConsumerGroup *MockingPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -256,9 +256,9 @@ type MockingPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []MockingPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *MockingPluginRoute `json:"route,omitempty"`
+	Route *MockingPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *MockingPluginService `json:"service,omitempty"`
+	Service *MockingPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -375,8 +375,8 @@ func (o *MockingPlugin) GetUpdatedAt() *int64 {
 type MockingPluginInput struct {
 	Config MockingPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *MockingPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *MockingPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *MockingPluginConsumer      `json:"consumer"`
+	ConsumerGroup *MockingPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                  `json:"enabled,omitempty"`
 	ID           *string                `json:"id,omitempty"`
@@ -386,9 +386,9 @@ type MockingPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []MockingPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *MockingPluginRoute `json:"route,omitempty"`
+	Route *MockingPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *MockingPluginService `json:"service,omitempty"`
+	Service *MockingPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/mtlsauthplugin.go
+++ b/internal/sdk/models/shared/mtlsauthplugin.go
@@ -380,8 +380,8 @@ func (o *MtlsAuthPluginService) GetID() *string {
 type MtlsAuthPlugin struct {
 	Config MtlsAuthPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *MtlsAuthPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *MtlsAuthPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *MtlsAuthPluginConsumer      `json:"consumer"`
+	ConsumerGroup *MtlsAuthPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -393,9 +393,9 @@ type MtlsAuthPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []MtlsAuthPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *MtlsAuthPluginRoute `json:"route,omitempty"`
+	Route *MtlsAuthPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *MtlsAuthPluginService `json:"service,omitempty"`
+	Service *MtlsAuthPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -512,8 +512,8 @@ func (o *MtlsAuthPlugin) GetUpdatedAt() *int64 {
 type MtlsAuthPluginInput struct {
 	Config MtlsAuthPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *MtlsAuthPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *MtlsAuthPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *MtlsAuthPluginConsumer      `json:"consumer"`
+	ConsumerGroup *MtlsAuthPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                   `json:"enabled,omitempty"`
 	ID           *string                 `json:"id,omitempty"`
@@ -523,9 +523,9 @@ type MtlsAuthPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []MtlsAuthPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *MtlsAuthPluginRoute `json:"route,omitempty"`
+	Route *MtlsAuthPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *MtlsAuthPluginService `json:"service,omitempty"`
+	Service *MtlsAuthPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/oasvalidationplugin.go
+++ b/internal/sdk/models/shared/oasvalidationplugin.go
@@ -288,8 +288,8 @@ func (o *OasValidationPluginService) GetID() *string {
 type OasValidationPlugin struct {
 	Config OasValidationPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *OasValidationPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *OasValidationPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *OasValidationPluginConsumer      `json:"consumer"`
+	ConsumerGroup *OasValidationPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -301,9 +301,9 @@ type OasValidationPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []OasValidationPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *OasValidationPluginRoute `json:"route,omitempty"`
+	Route *OasValidationPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *OasValidationPluginService `json:"service,omitempty"`
+	Service *OasValidationPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -420,8 +420,8 @@ func (o *OasValidationPlugin) GetUpdatedAt() *int64 {
 type OasValidationPluginInput struct {
 	Config OasValidationPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *OasValidationPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *OasValidationPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *OasValidationPluginConsumer      `json:"consumer"`
+	ConsumerGroup *OasValidationPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                        `json:"enabled,omitempty"`
 	ID           *string                      `json:"id,omitempty"`
@@ -431,9 +431,9 @@ type OasValidationPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []OasValidationPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *OasValidationPluginRoute `json:"route,omitempty"`
+	Route *OasValidationPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *OasValidationPluginService `json:"service,omitempty"`
+	Service *OasValidationPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/oauth2introspectionplugin.go
+++ b/internal/sdk/models/shared/oauth2introspectionplugin.go
@@ -297,8 +297,8 @@ func (o *Oauth2IntrospectionPluginService) GetID() *string {
 type Oauth2IntrospectionPlugin struct {
 	Config Oauth2IntrospectionPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *Oauth2IntrospectionPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *Oauth2IntrospectionPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *Oauth2IntrospectionPluginConsumer      `json:"consumer"`
+	ConsumerGroup *Oauth2IntrospectionPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -310,9 +310,9 @@ type Oauth2IntrospectionPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []Oauth2IntrospectionPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *Oauth2IntrospectionPluginRoute `json:"route,omitempty"`
+	Route *Oauth2IntrospectionPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *Oauth2IntrospectionPluginService `json:"service,omitempty"`
+	Service *Oauth2IntrospectionPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -429,8 +429,8 @@ func (o *Oauth2IntrospectionPlugin) GetUpdatedAt() *int64 {
 type Oauth2IntrospectionPluginInput struct {
 	Config Oauth2IntrospectionPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *Oauth2IntrospectionPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *Oauth2IntrospectionPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *Oauth2IntrospectionPluginConsumer      `json:"consumer"`
+	ConsumerGroup *Oauth2IntrospectionPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                              `json:"enabled,omitempty"`
 	ID           *string                            `json:"id,omitempty"`
@@ -440,9 +440,9 @@ type Oauth2IntrospectionPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []Oauth2IntrospectionPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *Oauth2IntrospectionPluginRoute `json:"route,omitempty"`
+	Route *Oauth2IntrospectionPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *Oauth2IntrospectionPluginService `json:"service,omitempty"`
+	Service *Oauth2IntrospectionPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/oauth2plugin.go
+++ b/internal/sdk/models/shared/oauth2plugin.go
@@ -344,8 +344,8 @@ func (o *Oauth2PluginService) GetID() *string {
 type Oauth2Plugin struct {
 	Config Oauth2PluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *Oauth2PluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *Oauth2PluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *Oauth2PluginConsumer      `json:"consumer"`
+	ConsumerGroup *Oauth2PluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -357,9 +357,9 @@ type Oauth2Plugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []Oauth2PluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *Oauth2PluginRoute `json:"route,omitempty"`
+	Route *Oauth2PluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *Oauth2PluginService `json:"service,omitempty"`
+	Service *Oauth2PluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -476,8 +476,8 @@ func (o *Oauth2Plugin) GetUpdatedAt() *int64 {
 type Oauth2PluginInput struct {
 	Config Oauth2PluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *Oauth2PluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *Oauth2PluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *Oauth2PluginConsumer      `json:"consumer"`
+	ConsumerGroup *Oauth2PluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                 `json:"enabled,omitempty"`
 	ID           *string               `json:"id,omitempty"`
@@ -487,9 +487,9 @@ type Oauth2PluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []Oauth2PluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *Oauth2PluginRoute `json:"route,omitempty"`
+	Route *Oauth2PluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *Oauth2PluginService `json:"service,omitempty"`
+	Service *Oauth2PluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/opaplugin.go
+++ b/internal/sdk/models/shared/opaplugin.go
@@ -278,8 +278,8 @@ func (o *OpaPluginService) GetID() *string {
 type OpaPlugin struct {
 	Config OpaPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *OpaPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *OpaPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *OpaPluginConsumer      `json:"consumer"`
+	ConsumerGroup *OpaPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -291,9 +291,9 @@ type OpaPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []OpaPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *OpaPluginRoute `json:"route,omitempty"`
+	Route *OpaPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *OpaPluginService `json:"service,omitempty"`
+	Service *OpaPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -410,8 +410,8 @@ func (o *OpaPlugin) GetUpdatedAt() *int64 {
 type OpaPluginInput struct {
 	Config OpaPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *OpaPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *OpaPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *OpaPluginConsumer      `json:"consumer"`
+	ConsumerGroup *OpaPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool              `json:"enabled,omitempty"`
 	ID           *string            `json:"id,omitempty"`
@@ -421,9 +421,9 @@ type OpaPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []OpaPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *OpaPluginRoute `json:"route,omitempty"`
+	Route *OpaPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *OpaPluginService `json:"service,omitempty"`
+	Service *OpaPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/openidconnectplugin.go
+++ b/internal/sdk/models/shared/openidconnectplugin.go
@@ -4029,8 +4029,8 @@ func (o *OpenidConnectPluginService) GetID() *string {
 type OpenidConnectPlugin struct {
 	Config OpenidConnectPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *OpenidConnectPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *OpenidConnectPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *OpenidConnectPluginConsumer      `json:"consumer"`
+	ConsumerGroup *OpenidConnectPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -4042,9 +4042,9 @@ type OpenidConnectPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []OpenidConnectPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *OpenidConnectPluginRoute `json:"route,omitempty"`
+	Route *OpenidConnectPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *OpenidConnectPluginService `json:"service,omitempty"`
+	Service *OpenidConnectPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -4161,8 +4161,8 @@ func (o *OpenidConnectPlugin) GetUpdatedAt() *int64 {
 type OpenidConnectPluginInput struct {
 	Config OpenidConnectPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *OpenidConnectPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *OpenidConnectPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *OpenidConnectPluginConsumer      `json:"consumer"`
+	ConsumerGroup *OpenidConnectPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                        `json:"enabled,omitempty"`
 	ID           *string                      `json:"id,omitempty"`
@@ -4172,9 +4172,9 @@ type OpenidConnectPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []OpenidConnectPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *OpenidConnectPluginRoute `json:"route,omitempty"`
+	Route *OpenidConnectPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *OpenidConnectPluginService `json:"service,omitempty"`
+	Service *OpenidConnectPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/opentelemetryplugin.go
+++ b/internal/sdk/models/shared/opentelemetryplugin.go
@@ -598,8 +598,8 @@ func (o *OpentelemetryPluginService) GetID() *string {
 type OpentelemetryPlugin struct {
 	Config OpentelemetryPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *OpentelemetryPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *OpentelemetryPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *OpentelemetryPluginConsumer      `json:"consumer"`
+	ConsumerGroup *OpentelemetryPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -611,9 +611,9 @@ type OpentelemetryPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []OpentelemetryPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *OpentelemetryPluginRoute `json:"route,omitempty"`
+	Route *OpentelemetryPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *OpentelemetryPluginService `json:"service,omitempty"`
+	Service *OpentelemetryPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -730,8 +730,8 @@ func (o *OpentelemetryPlugin) GetUpdatedAt() *int64 {
 type OpentelemetryPluginInput struct {
 	Config OpentelemetryPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *OpentelemetryPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *OpentelemetryPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *OpentelemetryPluginConsumer      `json:"consumer"`
+	ConsumerGroup *OpentelemetryPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                        `json:"enabled,omitempty"`
 	ID           *string                      `json:"id,omitempty"`
@@ -741,9 +741,9 @@ type OpentelemetryPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []OpentelemetryPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *OpentelemetryPluginRoute `json:"route,omitempty"`
+	Route *OpentelemetryPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *OpentelemetryPluginService `json:"service,omitempty"`
+	Service *OpentelemetryPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/plugin.go
+++ b/internal/sdk/models/shared/plugin.go
@@ -150,8 +150,8 @@ type Plugin struct {
 	// The configuration properties for the Plugin which can be found on the plugins documentation page in the [Kong Hub](https://docs.konghq.com/hub/).
 	Config map[string]any `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *PluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *PluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *PluginConsumer      `json:"consumer"`
+	ConsumerGroup *PluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -164,9 +164,9 @@ type Plugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []Protocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *PluginRoute `json:"route,omitempty"`
+	Route *PluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *PluginService `json:"service,omitempty"`
+	Service *PluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -276,8 +276,8 @@ type PluginInput struct {
 	// The configuration properties for the Plugin which can be found on the plugins documentation page in the [Kong Hub](https://docs.konghq.com/hub/).
 	Config map[string]any `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *PluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *PluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *PluginConsumer      `json:"consumer"`
+	ConsumerGroup *PluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool   `json:"enabled,omitempty"`
 	ID           *string `json:"id,omitempty"`
@@ -288,9 +288,9 @@ type PluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []Protocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *PluginRoute `json:"route,omitempty"`
+	Route *PluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *PluginService `json:"service,omitempty"`
+	Service *PluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/postfunctionplugin.go
+++ b/internal/sdk/models/shared/postfunctionplugin.go
@@ -233,8 +233,8 @@ func (o *PostFunctionPluginService) GetID() *string {
 type PostFunctionPlugin struct {
 	Config PostFunctionPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *PostFunctionPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *PostFunctionPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *PostFunctionPluginConsumer      `json:"consumer"`
+	ConsumerGroup *PostFunctionPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -246,9 +246,9 @@ type PostFunctionPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []PostFunctionPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *PostFunctionPluginRoute `json:"route,omitempty"`
+	Route *PostFunctionPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *PostFunctionPluginService `json:"service,omitempty"`
+	Service *PostFunctionPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -365,8 +365,8 @@ func (o *PostFunctionPlugin) GetUpdatedAt() *int64 {
 type PostFunctionPluginInput struct {
 	Config PostFunctionPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *PostFunctionPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *PostFunctionPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *PostFunctionPluginConsumer      `json:"consumer"`
+	ConsumerGroup *PostFunctionPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                       `json:"enabled,omitempty"`
 	ID           *string                     `json:"id,omitempty"`
@@ -376,9 +376,9 @@ type PostFunctionPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []PostFunctionPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *PostFunctionPluginRoute `json:"route,omitempty"`
+	Route *PostFunctionPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *PostFunctionPluginService `json:"service,omitempty"`
+	Service *PostFunctionPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/prefunctionplugin.go
+++ b/internal/sdk/models/shared/prefunctionplugin.go
@@ -233,8 +233,8 @@ func (o *PreFunctionPluginService) GetID() *string {
 type PreFunctionPlugin struct {
 	Config PreFunctionPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *PreFunctionPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *PreFunctionPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *PreFunctionPluginConsumer      `json:"consumer"`
+	ConsumerGroup *PreFunctionPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -246,9 +246,9 @@ type PreFunctionPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []PreFunctionPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *PreFunctionPluginRoute `json:"route,omitempty"`
+	Route *PreFunctionPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *PreFunctionPluginService `json:"service,omitempty"`
+	Service *PreFunctionPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -365,8 +365,8 @@ func (o *PreFunctionPlugin) GetUpdatedAt() *int64 {
 type PreFunctionPluginInput struct {
 	Config PreFunctionPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *PreFunctionPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *PreFunctionPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *PreFunctionPluginConsumer      `json:"consumer"`
+	ConsumerGroup *PreFunctionPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                      `json:"enabled,omitempty"`
 	ID           *string                    `json:"id,omitempty"`
@@ -376,9 +376,9 @@ type PreFunctionPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []PreFunctionPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *PreFunctionPluginRoute `json:"route,omitempty"`
+	Route *PreFunctionPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *PreFunctionPluginService `json:"service,omitempty"`
+	Service *PreFunctionPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/prometheusplugin.go
+++ b/internal/sdk/models/shared/prometheusplugin.go
@@ -207,8 +207,8 @@ func (o *PrometheusPluginService) GetID() *string {
 type PrometheusPlugin struct {
 	Config PrometheusPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *PrometheusPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *PrometheusPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *PrometheusPluginConsumer      `json:"consumer"`
+	ConsumerGroup *PrometheusPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -220,9 +220,9 @@ type PrometheusPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []PrometheusPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *PrometheusPluginRoute `json:"route,omitempty"`
+	Route *PrometheusPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *PrometheusPluginService `json:"service,omitempty"`
+	Service *PrometheusPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -339,8 +339,8 @@ func (o *PrometheusPlugin) GetUpdatedAt() *int64 {
 type PrometheusPluginInput struct {
 	Config PrometheusPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *PrometheusPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *PrometheusPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *PrometheusPluginConsumer      `json:"consumer"`
+	ConsumerGroup *PrometheusPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                     `json:"enabled,omitempty"`
 	ID           *string                   `json:"id,omitempty"`
@@ -350,9 +350,9 @@ type PrometheusPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []PrometheusPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *PrometheusPluginRoute `json:"route,omitempty"`
+	Route *PrometheusPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *PrometheusPluginService `json:"service,omitempty"`
+	Service *PrometheusPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/proxycacheadvancedplugin.go
+++ b/internal/sdk/models/shared/proxycacheadvancedplugin.go
@@ -643,8 +643,8 @@ func (o *ProxyCacheAdvancedPluginService) GetID() *string {
 type ProxyCacheAdvancedPlugin struct {
 	Config ProxyCacheAdvancedPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *ProxyCacheAdvancedPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *ProxyCacheAdvancedPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *ProxyCacheAdvancedPluginConsumer      `json:"consumer"`
+	ConsumerGroup *ProxyCacheAdvancedPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -656,9 +656,9 @@ type ProxyCacheAdvancedPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []ProxyCacheAdvancedPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *ProxyCacheAdvancedPluginRoute `json:"route,omitempty"`
+	Route *ProxyCacheAdvancedPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *ProxyCacheAdvancedPluginService `json:"service,omitempty"`
+	Service *ProxyCacheAdvancedPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -775,8 +775,8 @@ func (o *ProxyCacheAdvancedPlugin) GetUpdatedAt() *int64 {
 type ProxyCacheAdvancedPluginInput struct {
 	Config ProxyCacheAdvancedPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *ProxyCacheAdvancedPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *ProxyCacheAdvancedPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *ProxyCacheAdvancedPluginConsumer      `json:"consumer"`
+	ConsumerGroup *ProxyCacheAdvancedPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                             `json:"enabled,omitempty"`
 	ID           *string                           `json:"id,omitempty"`
@@ -786,9 +786,9 @@ type ProxyCacheAdvancedPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []ProxyCacheAdvancedPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *ProxyCacheAdvancedPluginRoute `json:"route,omitempty"`
+	Route *ProxyCacheAdvancedPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *ProxyCacheAdvancedPluginService `json:"service,omitempty"`
+	Service *ProxyCacheAdvancedPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/proxycacheplugin.go
+++ b/internal/sdk/models/shared/proxycacheplugin.go
@@ -358,8 +358,8 @@ func (o *ProxyCachePluginService) GetID() *string {
 type ProxyCachePlugin struct {
 	Config ProxyCachePluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *ProxyCachePluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *ProxyCachePluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *ProxyCachePluginConsumer      `json:"consumer"`
+	ConsumerGroup *ProxyCachePluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -371,9 +371,9 @@ type ProxyCachePlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []ProxyCachePluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *ProxyCachePluginRoute `json:"route,omitempty"`
+	Route *ProxyCachePluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *ProxyCachePluginService `json:"service,omitempty"`
+	Service *ProxyCachePluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -490,8 +490,8 @@ func (o *ProxyCachePlugin) GetUpdatedAt() *int64 {
 type ProxyCachePluginInput struct {
 	Config ProxyCachePluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *ProxyCachePluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *ProxyCachePluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *ProxyCachePluginConsumer      `json:"consumer"`
+	ConsumerGroup *ProxyCachePluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                     `json:"enabled,omitempty"`
 	ID           *string                   `json:"id,omitempty"`
@@ -501,9 +501,9 @@ type ProxyCachePluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []ProxyCachePluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *ProxyCachePluginRoute `json:"route,omitempty"`
+	Route *ProxyCachePluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *ProxyCachePluginService `json:"service,omitempty"`
+	Service *ProxyCachePluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/ratelimitingadvancedplugin.go
+++ b/internal/sdk/models/shared/ratelimitingadvancedplugin.go
@@ -677,8 +677,8 @@ func (o *RateLimitingAdvancedPluginService) GetID() *string {
 type RateLimitingAdvancedPlugin struct {
 	Config RateLimitingAdvancedPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *RateLimitingAdvancedPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *RateLimitingAdvancedPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *RateLimitingAdvancedPluginConsumer      `json:"consumer"`
+	ConsumerGroup *RateLimitingAdvancedPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -690,9 +690,9 @@ type RateLimitingAdvancedPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []RateLimitingAdvancedPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *RateLimitingAdvancedPluginRoute `json:"route,omitempty"`
+	Route *RateLimitingAdvancedPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *RateLimitingAdvancedPluginService `json:"service,omitempty"`
+	Service *RateLimitingAdvancedPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -809,8 +809,8 @@ func (o *RateLimitingAdvancedPlugin) GetUpdatedAt() *int64 {
 type RateLimitingAdvancedPluginInput struct {
 	Config RateLimitingAdvancedPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *RateLimitingAdvancedPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *RateLimitingAdvancedPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *RateLimitingAdvancedPluginConsumer      `json:"consumer"`
+	ConsumerGroup *RateLimitingAdvancedPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                               `json:"enabled,omitempty"`
 	ID           *string                             `json:"id,omitempty"`
@@ -820,9 +820,9 @@ type RateLimitingAdvancedPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []RateLimitingAdvancedPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *RateLimitingAdvancedPluginRoute `json:"route,omitempty"`
+	Route *RateLimitingAdvancedPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *RateLimitingAdvancedPluginService `json:"service,omitempty"`
+	Service *RateLimitingAdvancedPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/ratelimitingplugin.go
+++ b/internal/sdk/models/shared/ratelimitingplugin.go
@@ -454,8 +454,8 @@ func (o *RateLimitingPluginService) GetID() *string {
 type RateLimitingPlugin struct {
 	Config RateLimitingPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *RateLimitingPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *RateLimitingPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *RateLimitingPluginConsumer      `json:"consumer"`
+	ConsumerGroup *RateLimitingPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -467,9 +467,9 @@ type RateLimitingPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []RateLimitingPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *RateLimitingPluginRoute `json:"route,omitempty"`
+	Route *RateLimitingPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *RateLimitingPluginService `json:"service,omitempty"`
+	Service *RateLimitingPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -586,8 +586,8 @@ func (o *RateLimitingPlugin) GetUpdatedAt() *int64 {
 type RateLimitingPluginInput struct {
 	Config RateLimitingPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *RateLimitingPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *RateLimitingPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *RateLimitingPluginConsumer      `json:"consumer"`
+	ConsumerGroup *RateLimitingPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                       `json:"enabled,omitempty"`
 	ID           *string                     `json:"id,omitempty"`
@@ -597,9 +597,9 @@ type RateLimitingPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []RateLimitingPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *RateLimitingPluginRoute `json:"route,omitempty"`
+	Route *RateLimitingPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *RateLimitingPluginService `json:"service,omitempty"`
+	Service *RateLimitingPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/requestsizelimitingplugin.go
+++ b/internal/sdk/models/shared/requestsizelimitingplugin.go
@@ -210,8 +210,8 @@ func (o *RequestSizeLimitingPluginService) GetID() *string {
 type RequestSizeLimitingPlugin struct {
 	Config RequestSizeLimitingPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *RequestSizeLimitingPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *RequestSizeLimitingPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *RequestSizeLimitingPluginConsumer      `json:"consumer"`
+	ConsumerGroup *RequestSizeLimitingPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -223,9 +223,9 @@ type RequestSizeLimitingPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []RequestSizeLimitingPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *RequestSizeLimitingPluginRoute `json:"route,omitempty"`
+	Route *RequestSizeLimitingPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *RequestSizeLimitingPluginService `json:"service,omitempty"`
+	Service *RequestSizeLimitingPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -342,8 +342,8 @@ func (o *RequestSizeLimitingPlugin) GetUpdatedAt() *int64 {
 type RequestSizeLimitingPluginInput struct {
 	Config RequestSizeLimitingPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *RequestSizeLimitingPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *RequestSizeLimitingPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *RequestSizeLimitingPluginConsumer      `json:"consumer"`
+	ConsumerGroup *RequestSizeLimitingPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                              `json:"enabled,omitempty"`
 	ID           *string                            `json:"id,omitempty"`
@@ -353,9 +353,9 @@ type RequestSizeLimitingPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []RequestSizeLimitingPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *RequestSizeLimitingPluginRoute `json:"route,omitempty"`
+	Route *RequestSizeLimitingPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *RequestSizeLimitingPluginService `json:"service,omitempty"`
+	Service *RequestSizeLimitingPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/requestterminationplugin.go
+++ b/internal/sdk/models/shared/requestterminationplugin.go
@@ -207,8 +207,8 @@ func (o *RequestTerminationPluginService) GetID() *string {
 type RequestTerminationPlugin struct {
 	Config RequestTerminationPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *RequestTerminationPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *RequestTerminationPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *RequestTerminationPluginConsumer      `json:"consumer"`
+	ConsumerGroup *RequestTerminationPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -220,9 +220,9 @@ type RequestTerminationPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []RequestTerminationPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *RequestTerminationPluginRoute `json:"route,omitempty"`
+	Route *RequestTerminationPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *RequestTerminationPluginService `json:"service,omitempty"`
+	Service *RequestTerminationPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -339,8 +339,8 @@ func (o *RequestTerminationPlugin) GetUpdatedAt() *int64 {
 type RequestTerminationPluginInput struct {
 	Config RequestTerminationPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *RequestTerminationPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *RequestTerminationPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *RequestTerminationPluginConsumer      `json:"consumer"`
+	ConsumerGroup *RequestTerminationPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                             `json:"enabled,omitempty"`
 	ID           *string                           `json:"id,omitempty"`
@@ -350,9 +350,9 @@ type RequestTerminationPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []RequestTerminationPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *RequestTerminationPluginRoute `json:"route,omitempty"`
+	Route *RequestTerminationPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *RequestTerminationPluginService `json:"service,omitempty"`
+	Service *RequestTerminationPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/requesttransformeradvancedplugin.go
+++ b/internal/sdk/models/shared/requesttransformeradvancedplugin.go
@@ -484,8 +484,8 @@ func (o *RequestTransformerAdvancedPluginService) GetID() *string {
 type RequestTransformerAdvancedPlugin struct {
 	Config RequestTransformerAdvancedPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *RequestTransformerAdvancedPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *RequestTransformerAdvancedPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *RequestTransformerAdvancedPluginConsumer      `json:"consumer"`
+	ConsumerGroup *RequestTransformerAdvancedPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -497,9 +497,9 @@ type RequestTransformerAdvancedPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []RequestTransformerAdvancedPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *RequestTransformerAdvancedPluginRoute `json:"route,omitempty"`
+	Route *RequestTransformerAdvancedPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *RequestTransformerAdvancedPluginService `json:"service,omitempty"`
+	Service *RequestTransformerAdvancedPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -616,8 +616,8 @@ func (o *RequestTransformerAdvancedPlugin) GetUpdatedAt() *int64 {
 type RequestTransformerAdvancedPluginInput struct {
 	Config RequestTransformerAdvancedPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *RequestTransformerAdvancedPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *RequestTransformerAdvancedPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *RequestTransformerAdvancedPluginConsumer      `json:"consumer"`
+	ConsumerGroup *RequestTransformerAdvancedPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                                     `json:"enabled,omitempty"`
 	ID           *string                                   `json:"id,omitempty"`
@@ -627,9 +627,9 @@ type RequestTransformerAdvancedPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []RequestTransformerAdvancedPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *RequestTransformerAdvancedPluginRoute `json:"route,omitempty"`
+	Route *RequestTransformerAdvancedPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *RequestTransformerAdvancedPluginService `json:"service,omitempty"`
+	Service *RequestTransformerAdvancedPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/requesttransformerplugin.go
+++ b/internal/sdk/models/shared/requesttransformerplugin.go
@@ -345,8 +345,8 @@ func (o *RequestTransformerPluginService) GetID() *string {
 type RequestTransformerPlugin struct {
 	Config RequestTransformerPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *RequestTransformerPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *RequestTransformerPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *RequestTransformerPluginConsumer      `json:"consumer"`
+	ConsumerGroup *RequestTransformerPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -358,9 +358,9 @@ type RequestTransformerPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []RequestTransformerPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *RequestTransformerPluginRoute `json:"route,omitempty"`
+	Route *RequestTransformerPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *RequestTransformerPluginService `json:"service,omitempty"`
+	Service *RequestTransformerPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -477,8 +477,8 @@ func (o *RequestTransformerPlugin) GetUpdatedAt() *int64 {
 type RequestTransformerPluginInput struct {
 	Config RequestTransformerPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *RequestTransformerPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *RequestTransformerPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *RequestTransformerPluginConsumer      `json:"consumer"`
+	ConsumerGroup *RequestTransformerPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                             `json:"enabled,omitempty"`
 	ID           *string                           `json:"id,omitempty"`
@@ -488,9 +488,9 @@ type RequestTransformerPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []RequestTransformerPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *RequestTransformerPluginRoute `json:"route,omitempty"`
+	Route *RequestTransformerPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *RequestTransformerPluginService `json:"service,omitempty"`
+	Service *RequestTransformerPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/requestvalidatorplugin.go
+++ b/internal/sdk/models/shared/requestvalidatorplugin.go
@@ -363,8 +363,8 @@ func (o *RequestValidatorPluginService) GetID() *string {
 type RequestValidatorPlugin struct {
 	Config RequestValidatorPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *RequestValidatorPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *RequestValidatorPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *RequestValidatorPluginConsumer      `json:"consumer"`
+	ConsumerGroup *RequestValidatorPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -376,9 +376,9 @@ type RequestValidatorPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []RequestValidatorPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *RequestValidatorPluginRoute `json:"route,omitempty"`
+	Route *RequestValidatorPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *RequestValidatorPluginService `json:"service,omitempty"`
+	Service *RequestValidatorPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -495,8 +495,8 @@ func (o *RequestValidatorPlugin) GetUpdatedAt() *int64 {
 type RequestValidatorPluginInput struct {
 	Config RequestValidatorPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *RequestValidatorPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *RequestValidatorPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *RequestValidatorPluginConsumer      `json:"consumer"`
+	ConsumerGroup *RequestValidatorPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                           `json:"enabled,omitempty"`
 	ID           *string                         `json:"id,omitempty"`
@@ -506,9 +506,9 @@ type RequestValidatorPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []RequestValidatorPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *RequestValidatorPluginRoute `json:"route,omitempty"`
+	Route *RequestValidatorPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *RequestValidatorPluginService `json:"service,omitempty"`
+	Service *RequestValidatorPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/responseratelimitingplugin.go
+++ b/internal/sdk/models/shared/responseratelimitingplugin.go
@@ -370,8 +370,8 @@ func (o *ResponseRatelimitingPluginService) GetID() *string {
 type ResponseRatelimitingPlugin struct {
 	Config ResponseRatelimitingPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *ResponseRatelimitingPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *ResponseRatelimitingPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *ResponseRatelimitingPluginConsumer      `json:"consumer"`
+	ConsumerGroup *ResponseRatelimitingPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -383,9 +383,9 @@ type ResponseRatelimitingPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []ResponseRatelimitingPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *ResponseRatelimitingPluginRoute `json:"route,omitempty"`
+	Route *ResponseRatelimitingPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *ResponseRatelimitingPluginService `json:"service,omitempty"`
+	Service *ResponseRatelimitingPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -502,8 +502,8 @@ func (o *ResponseRatelimitingPlugin) GetUpdatedAt() *int64 {
 type ResponseRatelimitingPluginInput struct {
 	Config ResponseRatelimitingPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *ResponseRatelimitingPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *ResponseRatelimitingPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *ResponseRatelimitingPluginConsumer      `json:"consumer"`
+	ConsumerGroup *ResponseRatelimitingPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                               `json:"enabled,omitempty"`
 	ID           *string                             `json:"id,omitempty"`
@@ -513,9 +513,9 @@ type ResponseRatelimitingPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []ResponseRatelimitingPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *ResponseRatelimitingPluginRoute `json:"route,omitempty"`
+	Route *ResponseRatelimitingPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *ResponseRatelimitingPluginService `json:"service,omitempty"`
+	Service *ResponseRatelimitingPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/responsetransformeradvancedplugin.go
+++ b/internal/sdk/models/shared/responsetransformeradvancedplugin.go
@@ -503,8 +503,8 @@ func (o *ResponseTransformerAdvancedPluginService) GetID() *string {
 type ResponseTransformerAdvancedPlugin struct {
 	Config ResponseTransformerAdvancedPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *ResponseTransformerAdvancedPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *ResponseTransformerAdvancedPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *ResponseTransformerAdvancedPluginConsumer      `json:"consumer"`
+	ConsumerGroup *ResponseTransformerAdvancedPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -516,9 +516,9 @@ type ResponseTransformerAdvancedPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []ResponseTransformerAdvancedPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *ResponseTransformerAdvancedPluginRoute `json:"route,omitempty"`
+	Route *ResponseTransformerAdvancedPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *ResponseTransformerAdvancedPluginService `json:"service,omitempty"`
+	Service *ResponseTransformerAdvancedPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -635,8 +635,8 @@ func (o *ResponseTransformerAdvancedPlugin) GetUpdatedAt() *int64 {
 type ResponseTransformerAdvancedPluginInput struct {
 	Config ResponseTransformerAdvancedPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *ResponseTransformerAdvancedPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *ResponseTransformerAdvancedPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *ResponseTransformerAdvancedPluginConsumer      `json:"consumer"`
+	ConsumerGroup *ResponseTransformerAdvancedPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                                      `json:"enabled,omitempty"`
 	ID           *string                                    `json:"id,omitempty"`
@@ -646,9 +646,9 @@ type ResponseTransformerAdvancedPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []ResponseTransformerAdvancedPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *ResponseTransformerAdvancedPluginRoute `json:"route,omitempty"`
+	Route *ResponseTransformerAdvancedPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *ResponseTransformerAdvancedPluginService `json:"service,omitempty"`
+	Service *ResponseTransformerAdvancedPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/responsetransformerplugin.go
+++ b/internal/sdk/models/shared/responsetransformerplugin.go
@@ -405,8 +405,8 @@ func (o *ResponseTransformerPluginService) GetID() *string {
 type ResponseTransformerPlugin struct {
 	Config ResponseTransformerPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *ResponseTransformerPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *ResponseTransformerPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *ResponseTransformerPluginConsumer      `json:"consumer"`
+	ConsumerGroup *ResponseTransformerPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -418,9 +418,9 @@ type ResponseTransformerPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []ResponseTransformerPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *ResponseTransformerPluginRoute `json:"route,omitempty"`
+	Route *ResponseTransformerPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *ResponseTransformerPluginService `json:"service,omitempty"`
+	Service *ResponseTransformerPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -537,8 +537,8 @@ func (o *ResponseTransformerPlugin) GetUpdatedAt() *int64 {
 type ResponseTransformerPluginInput struct {
 	Config ResponseTransformerPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *ResponseTransformerPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *ResponseTransformerPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *ResponseTransformerPluginConsumer      `json:"consumer"`
+	ConsumerGroup *ResponseTransformerPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                              `json:"enabled,omitempty"`
 	ID           *string                            `json:"id,omitempty"`
@@ -548,9 +548,9 @@ type ResponseTransformerPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []ResponseTransformerPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *ResponseTransformerPluginRoute `json:"route,omitempty"`
+	Route *ResponseTransformerPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *ResponseTransformerPluginService `json:"service,omitempty"`
+	Service *ResponseTransformerPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/route.go
+++ b/internal/sdk/models/shared/route.go
@@ -202,7 +202,7 @@ type Route struct {
 	// Whether to enable response body buffering or not. With HTTP 1.1, it may make sense to turn this off on services that send data with chunked transfer encoding.
 	ResponseBuffering *bool `json:"response_buffering,omitempty"`
 	// The Service this Route is associated to. This is where the Route proxies traffic to.
-	Service *RouteService `json:"service,omitempty"`
+	Service *RouteService `json:"service"`
 	// A list of SNIs that match this Route when using stream routing.
 	Snis []string `json:"snis,omitempty"`
 	// A list of IP sources of incoming connections that match this Route when using stream routing. Each entry is an object with fields "ip" (optionally in CIDR range notation) and/or "port".
@@ -392,7 +392,7 @@ type RouteInput struct {
 	// Whether to enable response body buffering or not. With HTTP 1.1, it may make sense to turn this off on services that send data with chunked transfer encoding.
 	ResponseBuffering *bool `json:"response_buffering,omitempty"`
 	// The Service this Route is associated to. This is where the Route proxies traffic to.
-	Service *RouteService `json:"service,omitempty"`
+	Service *RouteService `json:"service"`
 	// A list of SNIs that match this Route when using stream routing.
 	Snis []string `json:"snis,omitempty"`
 	// A list of IP sources of incoming connections that match this Route when using stream routing. Each entry is an object with fields "ip" (optionally in CIDR range notation) and/or "port".

--- a/internal/sdk/models/shared/routebyheaderplugin.go
+++ b/internal/sdk/models/shared/routebyheaderplugin.go
@@ -181,8 +181,8 @@ func (o *RouteByHeaderPluginService) GetID() *string {
 type RouteByHeaderPlugin struct {
 	Config RouteByHeaderPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *RouteByHeaderPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *RouteByHeaderPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *RouteByHeaderPluginConsumer      `json:"consumer"`
+	ConsumerGroup *RouteByHeaderPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -194,9 +194,9 @@ type RouteByHeaderPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []RouteByHeaderPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *RouteByHeaderPluginRoute `json:"route,omitempty"`
+	Route *RouteByHeaderPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *RouteByHeaderPluginService `json:"service,omitempty"`
+	Service *RouteByHeaderPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -313,8 +313,8 @@ func (o *RouteByHeaderPlugin) GetUpdatedAt() *int64 {
 type RouteByHeaderPluginInput struct {
 	Config RouteByHeaderPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *RouteByHeaderPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *RouteByHeaderPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *RouteByHeaderPluginConsumer      `json:"consumer"`
+	ConsumerGroup *RouteByHeaderPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                        `json:"enabled,omitempty"`
 	ID           *string                      `json:"id,omitempty"`
@@ -324,9 +324,9 @@ type RouteByHeaderPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []RouteByHeaderPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *RouteByHeaderPluginRoute `json:"route,omitempty"`
+	Route *RouteByHeaderPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *RouteByHeaderPluginService `json:"service,omitempty"`
+	Service *RouteByHeaderPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/routetransformeradvancedplugin.go
+++ b/internal/sdk/models/shared/routetransformeradvancedplugin.go
@@ -185,8 +185,8 @@ func (o *RouteTransformerAdvancedPluginService) GetID() *string {
 type RouteTransformerAdvancedPlugin struct {
 	Config RouteTransformerAdvancedPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *RouteTransformerAdvancedPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *RouteTransformerAdvancedPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *RouteTransformerAdvancedPluginConsumer      `json:"consumer"`
+	ConsumerGroup *RouteTransformerAdvancedPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -198,9 +198,9 @@ type RouteTransformerAdvancedPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []RouteTransformerAdvancedPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *RouteTransformerAdvancedPluginRoute `json:"route,omitempty"`
+	Route *RouteTransformerAdvancedPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *RouteTransformerAdvancedPluginService `json:"service,omitempty"`
+	Service *RouteTransformerAdvancedPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -317,8 +317,8 @@ func (o *RouteTransformerAdvancedPlugin) GetUpdatedAt() *int64 {
 type RouteTransformerAdvancedPluginInput struct {
 	Config RouteTransformerAdvancedPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *RouteTransformerAdvancedPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *RouteTransformerAdvancedPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *RouteTransformerAdvancedPluginConsumer      `json:"consumer"`
+	ConsumerGroup *RouteTransformerAdvancedPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                                   `json:"enabled,omitempty"`
 	ID           *string                                 `json:"id,omitempty"`
@@ -328,9 +328,9 @@ type RouteTransformerAdvancedPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []RouteTransformerAdvancedPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *RouteTransformerAdvancedPluginRoute `json:"route,omitempty"`
+	Route *RouteTransformerAdvancedPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *RouteTransformerAdvancedPluginService `json:"service,omitempty"`
+	Service *RouteTransformerAdvancedPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/samlplugin.go
+++ b/internal/sdk/models/shared/samlplugin.go
@@ -1096,8 +1096,8 @@ func (o *SamlPluginService) GetID() *string {
 type SamlPlugin struct {
 	Config SamlPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *SamlPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *SamlPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *SamlPluginConsumer      `json:"consumer"`
+	ConsumerGroup *SamlPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -1109,9 +1109,9 @@ type SamlPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []SamlPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *SamlPluginRoute `json:"route,omitempty"`
+	Route *SamlPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *SamlPluginService `json:"service,omitempty"`
+	Service *SamlPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -1228,8 +1228,8 @@ func (o *SamlPlugin) GetUpdatedAt() *int64 {
 type SamlPluginInput struct {
 	Config SamlPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *SamlPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *SamlPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *SamlPluginConsumer      `json:"consumer"`
+	ConsumerGroup *SamlPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool               `json:"enabled,omitempty"`
 	ID           *string             `json:"id,omitempty"`
@@ -1239,9 +1239,9 @@ type SamlPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []SamlPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *SamlPluginRoute `json:"route,omitempty"`
+	Route *SamlPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *SamlPluginService `json:"service,omitempty"`
+	Service *SamlPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/service.go
+++ b/internal/sdk/models/shared/service.go
@@ -75,7 +75,7 @@ type Service struct {
 	// Array of `CA Certificate` object UUIDs that are used to build the trust store while verifying upstream server's TLS certificate. If set to `null` when Nginx default is respected. If default CA list in Nginx are not specified and TLS verification is enabled, then handshake with upstream server will always fail (because no CA are trusted).
 	CaCertificates []string `json:"ca_certificates,omitempty"`
 	// Certificate to be used as client certificate while TLS handshaking to the upstream server.
-	ClientCertificate *ClientCertificate `json:"client_certificate,omitempty"`
+	ClientCertificate *ClientCertificate `json:"client_certificate"`
 	// The timeout in milliseconds for establishing a connection to the upstream server.
 	ConnectTimeout *int64 `json:"connect_timeout,omitempty"`
 	// Unix epoch when the resource was created.
@@ -240,7 +240,7 @@ type ServiceInput struct {
 	// Array of `CA Certificate` object UUIDs that are used to build the trust store while verifying upstream server's TLS certificate. If set to `null` when Nginx default is respected. If default CA list in Nginx are not specified and TLS verification is enabled, then handshake with upstream server will always fail (because no CA are trusted).
 	CaCertificates []string `json:"ca_certificates,omitempty"`
 	// Certificate to be used as client certificate while TLS handshaking to the upstream server.
-	ClientCertificate *ClientCertificate `json:"client_certificate,omitempty"`
+	ClientCertificate *ClientCertificate `json:"client_certificate"`
 	// The timeout in milliseconds for establishing a connection to the upstream server.
 	ConnectTimeout *int64 `json:"connect_timeout,omitempty"`
 	// Whether the Service is active. If set to `false`, the proxy behavior will be as if any routes attached to it do not exist (404). Default: `true`.

--- a/internal/sdk/models/shared/sessionplugin.go
+++ b/internal/sdk/models/shared/sessionplugin.go
@@ -530,8 +530,8 @@ func (o *SessionPluginService) GetID() *string {
 type SessionPlugin struct {
 	Config SessionPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *SessionPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *SessionPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *SessionPluginConsumer      `json:"consumer"`
+	ConsumerGroup *SessionPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -543,9 +543,9 @@ type SessionPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []SessionPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *SessionPluginRoute `json:"route,omitempty"`
+	Route *SessionPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *SessionPluginService `json:"service,omitempty"`
+	Service *SessionPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -662,8 +662,8 @@ func (o *SessionPlugin) GetUpdatedAt() *int64 {
 type SessionPluginInput struct {
 	Config SessionPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *SessionPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *SessionPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *SessionPluginConsumer      `json:"consumer"`
+	ConsumerGroup *SessionPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                  `json:"enabled,omitempty"`
 	ID           *string                `json:"id,omitempty"`
@@ -673,9 +673,9 @@ type SessionPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []SessionPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *SessionPluginRoute `json:"route,omitempty"`
+	Route *SessionPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *SessionPluginService `json:"service,omitempty"`
+	Service *SessionPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/sni.go
+++ b/internal/sdk/models/shared/sni.go
@@ -17,7 +17,7 @@ func (o *SNICertificate) GetID() *string {
 // Sni - An SNI object represents a many-to-one mapping of hostnames to a certificate. That is, a certificate object can have many hostnames associated with it; when Kong receives an SSL request, it uses the SNI field in the Client Hello to lookup the certificate object based on the SNI associated with the certificate.
 type Sni struct {
 	// The id (a UUID) of the certificate with which to associate the SNI hostname. The Certificate must have a valid private key associated with it to be used by the SNI object.
-	Certificate SNICertificate `json:"certificate"`
+	Certificate *SNICertificate `json:"certificate"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64  `json:"created_at,omitempty"`
 	ID        *string `json:"id,omitempty"`
@@ -29,9 +29,9 @@ type Sni struct {
 	UpdatedAt *int64 `json:"updated_at,omitempty"`
 }
 
-func (o *Sni) GetCertificate() SNICertificate {
+func (o *Sni) GetCertificate() *SNICertificate {
 	if o == nil {
-		return SNICertificate{}
+		return nil
 	}
 	return o.Certificate
 }
@@ -74,17 +74,17 @@ func (o *Sni) GetUpdatedAt() *int64 {
 // SNIInput - An SNI object represents a many-to-one mapping of hostnames to a certificate. That is, a certificate object can have many hostnames associated with it; when Kong receives an SSL request, it uses the SNI field in the Client Hello to lookup the certificate object based on the SNI associated with the certificate.
 type SNIInput struct {
 	// The id (a UUID) of the certificate with which to associate the SNI hostname. The Certificate must have a valid private key associated with it to be used by the SNI object.
-	Certificate SNICertificate `json:"certificate"`
-	ID          *string        `json:"id,omitempty"`
+	Certificate *SNICertificate `json:"certificate"`
+	ID          *string         `json:"id,omitempty"`
 	// The SNI name to associate with the given certificate.
 	Name string `json:"name"`
 	// An optional set of strings associated with the SNIs for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }
 
-func (o *SNIInput) GetCertificate() SNICertificate {
+func (o *SNIInput) GetCertificate() *SNICertificate {
 	if o == nil {
-		return SNICertificate{}
+		return nil
 	}
 	return o.Certificate
 }

--- a/internal/sdk/models/shared/statsdadvancedplugin.go
+++ b/internal/sdk/models/shared/statsdadvancedplugin.go
@@ -693,8 +693,8 @@ func (o *StatsdAdvancedPluginService) GetID() *string {
 type StatsdAdvancedPlugin struct {
 	Config StatsdAdvancedPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *StatsdAdvancedPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *StatsdAdvancedPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *StatsdAdvancedPluginConsumer      `json:"consumer"`
+	ConsumerGroup *StatsdAdvancedPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -706,9 +706,9 @@ type StatsdAdvancedPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []StatsdAdvancedPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *StatsdAdvancedPluginRoute `json:"route,omitempty"`
+	Route *StatsdAdvancedPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *StatsdAdvancedPluginService `json:"service,omitempty"`
+	Service *StatsdAdvancedPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -825,8 +825,8 @@ func (o *StatsdAdvancedPlugin) GetUpdatedAt() *int64 {
 type StatsdAdvancedPluginInput struct {
 	Config StatsdAdvancedPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *StatsdAdvancedPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *StatsdAdvancedPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *StatsdAdvancedPluginConsumer      `json:"consumer"`
+	ConsumerGroup *StatsdAdvancedPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                         `json:"enabled,omitempty"`
 	ID           *string                       `json:"id,omitempty"`
@@ -836,9 +836,9 @@ type StatsdAdvancedPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []StatsdAdvancedPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *StatsdAdvancedPluginRoute `json:"route,omitempty"`
+	Route *StatsdAdvancedPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *StatsdAdvancedPluginService `json:"service,omitempty"`
+	Service *StatsdAdvancedPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/statsdplugin.go
+++ b/internal/sdk/models/shared/statsdplugin.go
@@ -759,8 +759,8 @@ func (o *StatsdPluginService) GetID() *string {
 type StatsdPlugin struct {
 	Config StatsdPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *StatsdPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *StatsdPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *StatsdPluginConsumer      `json:"consumer"`
+	ConsumerGroup *StatsdPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -772,9 +772,9 @@ type StatsdPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []StatsdPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *StatsdPluginRoute `json:"route,omitempty"`
+	Route *StatsdPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *StatsdPluginService `json:"service,omitempty"`
+	Service *StatsdPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -891,8 +891,8 @@ func (o *StatsdPlugin) GetUpdatedAt() *int64 {
 type StatsdPluginInput struct {
 	Config StatsdPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *StatsdPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *StatsdPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *StatsdPluginConsumer      `json:"consumer"`
+	ConsumerGroup *StatsdPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                 `json:"enabled,omitempty"`
 	ID           *string               `json:"id,omitempty"`
@@ -902,9 +902,9 @@ type StatsdPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []StatsdPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *StatsdPluginRoute `json:"route,omitempty"`
+	Route *StatsdPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *StatsdPluginService `json:"service,omitempty"`
+	Service *StatsdPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/syslogplugin.go
+++ b/internal/sdk/models/shared/syslogplugin.go
@@ -460,8 +460,8 @@ func (o *SyslogPluginService) GetID() *string {
 type SyslogPlugin struct {
 	Config SyslogPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *SyslogPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *SyslogPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *SyslogPluginConsumer      `json:"consumer"`
+	ConsumerGroup *SyslogPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -473,9 +473,9 @@ type SyslogPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []SyslogPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *SyslogPluginRoute `json:"route,omitempty"`
+	Route *SyslogPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *SyslogPluginService `json:"service,omitempty"`
+	Service *SyslogPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -592,8 +592,8 @@ func (o *SyslogPlugin) GetUpdatedAt() *int64 {
 type SyslogPluginInput struct {
 	Config SyslogPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *SyslogPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *SyslogPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *SyslogPluginConsumer      `json:"consumer"`
+	ConsumerGroup *SyslogPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                 `json:"enabled,omitempty"`
 	ID           *string               `json:"id,omitempty"`
@@ -603,9 +603,9 @@ type SyslogPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []SyslogPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *SyslogPluginRoute `json:"route,omitempty"`
+	Route *SyslogPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *SyslogPluginService `json:"service,omitempty"`
+	Service *SyslogPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/target.go
+++ b/internal/sdk/models/shared/target.go
@@ -24,7 +24,7 @@ type Target struct {
 	Target *string `json:"target,omitempty"`
 	// Unix epoch when the resource was last updated.
 	UpdatedAt *float64        `json:"updated_at,omitempty"`
-	Upstream  *TargetUpstream `json:"upstream,omitempty"`
+	Upstream  *TargetUpstream `json:"upstream"`
 	// The weight this target gets within the upstream loadbalancer (`0`-`65535`). If the hostname resolves to an SRV record, the `weight` value will be overridden by the value from the DNS record.
 	Weight *int64 `json:"weight,omitempty"`
 }

--- a/internal/sdk/models/shared/tcplogplugin.go
+++ b/internal/sdk/models/shared/tcplogplugin.go
@@ -216,8 +216,8 @@ func (o *TCPLogPluginService) GetID() *string {
 type TCPLogPlugin struct {
 	Config TCPLogPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *TCPLogPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *TCPLogPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *TCPLogPluginConsumer      `json:"consumer"`
+	ConsumerGroup *TCPLogPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -229,9 +229,9 @@ type TCPLogPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []TCPLogPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *TCPLogPluginRoute `json:"route,omitempty"`
+	Route *TCPLogPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *TCPLogPluginService `json:"service,omitempty"`
+	Service *TCPLogPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -348,8 +348,8 @@ func (o *TCPLogPlugin) GetUpdatedAt() *int64 {
 type TCPLogPluginInput struct {
 	Config TCPLogPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *TCPLogPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *TCPLogPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *TCPLogPluginConsumer      `json:"consumer"`
+	ConsumerGroup *TCPLogPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                 `json:"enabled,omitempty"`
 	ID           *string               `json:"id,omitempty"`
@@ -359,9 +359,9 @@ type TCPLogPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []TCPLogPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *TCPLogPluginRoute `json:"route,omitempty"`
+	Route *TCPLogPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *TCPLogPluginService `json:"service,omitempty"`
+	Service *TCPLogPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/tlshandshakemodifierplugin.go
+++ b/internal/sdk/models/shared/tlshandshakemodifierplugin.go
@@ -186,8 +186,8 @@ func (o *TLSHandshakeModifierPluginService) GetID() *string {
 type TLSHandshakeModifierPlugin struct {
 	Config TLSHandshakeModifierPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *TLSHandshakeModifierPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *TLSHandshakeModifierPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *TLSHandshakeModifierPluginConsumer      `json:"consumer"`
+	ConsumerGroup *TLSHandshakeModifierPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -199,9 +199,9 @@ type TLSHandshakeModifierPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []TLSHandshakeModifierPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *TLSHandshakeModifierPluginRoute `json:"route,omitempty"`
+	Route *TLSHandshakeModifierPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *TLSHandshakeModifierPluginService `json:"service,omitempty"`
+	Service *TLSHandshakeModifierPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -318,8 +318,8 @@ func (o *TLSHandshakeModifierPlugin) GetUpdatedAt() *int64 {
 type TLSHandshakeModifierPluginInput struct {
 	Config TLSHandshakeModifierPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *TLSHandshakeModifierPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *TLSHandshakeModifierPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *TLSHandshakeModifierPluginConsumer      `json:"consumer"`
+	ConsumerGroup *TLSHandshakeModifierPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                               `json:"enabled,omitempty"`
 	ID           *string                             `json:"id,omitempty"`
@@ -329,9 +329,9 @@ type TLSHandshakeModifierPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []TLSHandshakeModifierPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *TLSHandshakeModifierPluginRoute `json:"route,omitempty"`
+	Route *TLSHandshakeModifierPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *TLSHandshakeModifierPluginService `json:"service,omitempty"`
+	Service *TLSHandshakeModifierPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/tlsmetadataheadersplugin.go
+++ b/internal/sdk/models/shared/tlsmetadataheadersplugin.go
@@ -207,8 +207,8 @@ func (o *TLSMetadataHeadersPluginService) GetID() *string {
 type TLSMetadataHeadersPlugin struct {
 	Config TLSMetadataHeadersPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *TLSMetadataHeadersPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *TLSMetadataHeadersPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *TLSMetadataHeadersPluginConsumer      `json:"consumer"`
+	ConsumerGroup *TLSMetadataHeadersPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -220,9 +220,9 @@ type TLSMetadataHeadersPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []TLSMetadataHeadersPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *TLSMetadataHeadersPluginRoute `json:"route,omitempty"`
+	Route *TLSMetadataHeadersPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *TLSMetadataHeadersPluginService `json:"service,omitempty"`
+	Service *TLSMetadataHeadersPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -339,8 +339,8 @@ func (o *TLSMetadataHeadersPlugin) GetUpdatedAt() *int64 {
 type TLSMetadataHeadersPluginInput struct {
 	Config TLSMetadataHeadersPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *TLSMetadataHeadersPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *TLSMetadataHeadersPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *TLSMetadataHeadersPluginConsumer      `json:"consumer"`
+	ConsumerGroup *TLSMetadataHeadersPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                             `json:"enabled,omitempty"`
 	ID           *string                           `json:"id,omitempty"`
@@ -350,9 +350,9 @@ type TLSMetadataHeadersPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []TLSMetadataHeadersPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *TLSMetadataHeadersPluginRoute `json:"route,omitempty"`
+	Route *TLSMetadataHeadersPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *TLSMetadataHeadersPluginService `json:"service,omitempty"`
+	Service *TLSMetadataHeadersPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/udplogplugin.go
+++ b/internal/sdk/models/shared/udplogplugin.go
@@ -189,8 +189,8 @@ func (o *UDPLogPluginService) GetID() *string {
 type UDPLogPlugin struct {
 	Config UDPLogPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *UDPLogPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *UDPLogPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *UDPLogPluginConsumer      `json:"consumer"`
+	ConsumerGroup *UDPLogPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -202,9 +202,9 @@ type UDPLogPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []UDPLogPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *UDPLogPluginRoute `json:"route,omitempty"`
+	Route *UDPLogPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *UDPLogPluginService `json:"service,omitempty"`
+	Service *UDPLogPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -321,8 +321,8 @@ func (o *UDPLogPlugin) GetUpdatedAt() *int64 {
 type UDPLogPluginInput struct {
 	Config UDPLogPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *UDPLogPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *UDPLogPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *UDPLogPluginConsumer      `json:"consumer"`
+	ConsumerGroup *UDPLogPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                 `json:"enabled,omitempty"`
 	ID           *string               `json:"id,omitempty"`
@@ -332,9 +332,9 @@ type UDPLogPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []UDPLogPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *UDPLogPluginRoute `json:"route,omitempty"`
+	Route *UDPLogPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *UDPLogPluginService `json:"service,omitempty"`
+	Service *UDPLogPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/upstream.go
+++ b/internal/sdk/models/shared/upstream.go
@@ -470,7 +470,7 @@ type Upstream struct {
 	// Which load balancing algorithm to use.
 	Algorithm *UpstreamAlgorithm `json:"algorithm,omitempty"`
 	// If set, the certificate to be used as client certificate while TLS handshaking to the upstream server.
-	ClientCertificate *UpstreamClientCertificate `json:"client_certificate,omitempty"`
+	ClientCertificate *UpstreamClientCertificate `json:"client_certificate"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// What to use as hashing input if the primary `hash_on` does not return a hash (eg. header is missing, or no Consumer identified). Not available if `hash_on` is set to `cookie`.
@@ -661,7 +661,7 @@ type UpstreamInput struct {
 	// Which load balancing algorithm to use.
 	Algorithm *UpstreamAlgorithm `json:"algorithm,omitempty"`
 	// If set, the certificate to be used as client certificate while TLS handshaking to the upstream server.
-	ClientCertificate *UpstreamClientCertificate `json:"client_certificate,omitempty"`
+	ClientCertificate *UpstreamClientCertificate `json:"client_certificate"`
 	// What to use as hashing input if the primary `hash_on` does not return a hash (eg. header is missing, or no Consumer identified). Not available if `hash_on` is set to `cookie`.
 	HashFallback *HashFallback `json:"hash_fallback,omitempty"`
 	// The header name to take the value from as hash input. Only required when `hash_fallback` is set to `header`.

--- a/internal/sdk/models/shared/upstreamtimeoutplugin.go
+++ b/internal/sdk/models/shared/upstreamtimeoutplugin.go
@@ -180,8 +180,8 @@ func (o *UpstreamTimeoutPluginService) GetID() *string {
 type UpstreamTimeoutPlugin struct {
 	Config UpstreamTimeoutPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *UpstreamTimeoutPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *UpstreamTimeoutPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *UpstreamTimeoutPluginConsumer      `json:"consumer"`
+	ConsumerGroup *UpstreamTimeoutPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -193,9 +193,9 @@ type UpstreamTimeoutPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []UpstreamTimeoutPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *UpstreamTimeoutPluginRoute `json:"route,omitempty"`
+	Route *UpstreamTimeoutPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *UpstreamTimeoutPluginService `json:"service,omitempty"`
+	Service *UpstreamTimeoutPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -312,8 +312,8 @@ func (o *UpstreamTimeoutPlugin) GetUpdatedAt() *int64 {
 type UpstreamTimeoutPluginInput struct {
 	Config UpstreamTimeoutPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *UpstreamTimeoutPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *UpstreamTimeoutPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *UpstreamTimeoutPluginConsumer      `json:"consumer"`
+	ConsumerGroup *UpstreamTimeoutPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                          `json:"enabled,omitempty"`
 	ID           *string                        `json:"id,omitempty"`
@@ -323,9 +323,9 @@ type UpstreamTimeoutPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []UpstreamTimeoutPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *UpstreamTimeoutPluginRoute `json:"route,omitempty"`
+	Route *UpstreamTimeoutPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *UpstreamTimeoutPluginService `json:"service,omitempty"`
+	Service *UpstreamTimeoutPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/vaultauthplugin.go
+++ b/internal/sdk/models/shared/vaultauthplugin.go
@@ -216,8 +216,8 @@ func (o *VaultAuthPluginService) GetID() *string {
 type VaultAuthPlugin struct {
 	Config VaultAuthPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *VaultAuthPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *VaultAuthPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *VaultAuthPluginConsumer      `json:"consumer"`
+	ConsumerGroup *VaultAuthPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -229,9 +229,9 @@ type VaultAuthPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []VaultAuthPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *VaultAuthPluginRoute `json:"route,omitempty"`
+	Route *VaultAuthPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *VaultAuthPluginService `json:"service,omitempty"`
+	Service *VaultAuthPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -348,8 +348,8 @@ func (o *VaultAuthPlugin) GetUpdatedAt() *int64 {
 type VaultAuthPluginInput struct {
 	Config VaultAuthPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *VaultAuthPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *VaultAuthPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *VaultAuthPluginConsumer      `json:"consumer"`
+	ConsumerGroup *VaultAuthPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                    `json:"enabled,omitempty"`
 	ID           *string                  `json:"id,omitempty"`
@@ -359,9 +359,9 @@ type VaultAuthPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []VaultAuthPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *VaultAuthPluginRoute `json:"route,omitempty"`
+	Route *VaultAuthPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *VaultAuthPluginService `json:"service,omitempty"`
+	Service *VaultAuthPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/websocketsizelimitplugin.go
+++ b/internal/sdk/models/shared/websocketsizelimitplugin.go
@@ -169,8 +169,8 @@ func (o *WebsocketSizeLimitPluginService) GetID() *string {
 type WebsocketSizeLimitPlugin struct {
 	Config WebsocketSizeLimitPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *WebsocketSizeLimitPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *WebsocketSizeLimitPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *WebsocketSizeLimitPluginConsumer      `json:"consumer"`
+	ConsumerGroup *WebsocketSizeLimitPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -182,9 +182,9 @@ type WebsocketSizeLimitPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []WebsocketSizeLimitPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *WebsocketSizeLimitPluginRoute `json:"route,omitempty"`
+	Route *WebsocketSizeLimitPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *WebsocketSizeLimitPluginService `json:"service,omitempty"`
+	Service *WebsocketSizeLimitPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -301,8 +301,8 @@ func (o *WebsocketSizeLimitPlugin) GetUpdatedAt() *int64 {
 type WebsocketSizeLimitPluginInput struct {
 	Config WebsocketSizeLimitPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *WebsocketSizeLimitPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *WebsocketSizeLimitPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *WebsocketSizeLimitPluginConsumer      `json:"consumer"`
+	ConsumerGroup *WebsocketSizeLimitPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                             `json:"enabled,omitempty"`
 	ID           *string                           `json:"id,omitempty"`
@@ -312,9 +312,9 @@ type WebsocketSizeLimitPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []WebsocketSizeLimitPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *WebsocketSizeLimitPluginRoute `json:"route,omitempty"`
+	Route *WebsocketSizeLimitPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *WebsocketSizeLimitPluginService `json:"service,omitempty"`
+	Service *WebsocketSizeLimitPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/websocketvalidatorplugin.go
+++ b/internal/sdk/models/shared/websocketvalidatorplugin.go
@@ -387,8 +387,8 @@ func (o *WebsocketValidatorPluginService) GetID() *string {
 type WebsocketValidatorPlugin struct {
 	Config WebsocketValidatorPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *WebsocketValidatorPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *WebsocketValidatorPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *WebsocketValidatorPluginConsumer      `json:"consumer"`
+	ConsumerGroup *WebsocketValidatorPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -400,9 +400,9 @@ type WebsocketValidatorPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []WebsocketValidatorPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *WebsocketValidatorPluginRoute `json:"route,omitempty"`
+	Route *WebsocketValidatorPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *WebsocketValidatorPluginService `json:"service,omitempty"`
+	Service *WebsocketValidatorPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -519,8 +519,8 @@ func (o *WebsocketValidatorPlugin) GetUpdatedAt() *int64 {
 type WebsocketValidatorPluginInput struct {
 	Config WebsocketValidatorPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *WebsocketValidatorPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *WebsocketValidatorPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *WebsocketValidatorPluginConsumer      `json:"consumer"`
+	ConsumerGroup *WebsocketValidatorPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                             `json:"enabled,omitempty"`
 	ID           *string                           `json:"id,omitempty"`
@@ -530,9 +530,9 @@ type WebsocketValidatorPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []WebsocketValidatorPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *WebsocketValidatorPluginRoute `json:"route,omitempty"`
+	Route *WebsocketValidatorPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *WebsocketValidatorPluginService `json:"service,omitempty"`
+	Service *WebsocketValidatorPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/xmlthreatprotectionplugin.go
+++ b/internal/sdk/models/shared/xmlthreatprotectionplugin.go
@@ -360,8 +360,8 @@ func (o *XMLThreatProtectionPluginService) GetID() *string {
 type XMLThreatProtectionPlugin struct {
 	Config XMLThreatProtectionPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *XMLThreatProtectionPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *XMLThreatProtectionPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *XMLThreatProtectionPluginConsumer      `json:"consumer"`
+	ConsumerGroup *XMLThreatProtectionPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -373,9 +373,9 @@ type XMLThreatProtectionPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []XMLThreatProtectionPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *XMLThreatProtectionPluginRoute `json:"route,omitempty"`
+	Route *XMLThreatProtectionPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *XMLThreatProtectionPluginService `json:"service,omitempty"`
+	Service *XMLThreatProtectionPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -492,8 +492,8 @@ func (o *XMLThreatProtectionPlugin) GetUpdatedAt() *int64 {
 type XMLThreatProtectionPluginInput struct {
 	Config XMLThreatProtectionPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *XMLThreatProtectionPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *XMLThreatProtectionPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *XMLThreatProtectionPluginConsumer      `json:"consumer"`
+	ConsumerGroup *XMLThreatProtectionPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                              `json:"enabled,omitempty"`
 	ID           *string                            `json:"id,omitempty"`
@@ -503,9 +503,9 @@ type XMLThreatProtectionPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []XMLThreatProtectionPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *XMLThreatProtectionPluginRoute `json:"route,omitempty"`
+	Route *XMLThreatProtectionPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *XMLThreatProtectionPluginService `json:"service,omitempty"`
+	Service *XMLThreatProtectionPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/internal/sdk/models/shared/zipkinplugin.go
+++ b/internal/sdk/models/shared/zipkinplugin.go
@@ -782,8 +782,8 @@ func (o *ZipkinPluginService) GetID() *string {
 type ZipkinPlugin struct {
 	Config ZipkinPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *ZipkinPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *ZipkinPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *ZipkinPluginConsumer      `json:"consumer"`
+	ConsumerGroup *ZipkinPluginConsumerGroup `json:"consumer_group"`
 	// Unix epoch when the resource was created.
 	CreatedAt *int64 `json:"created_at,omitempty"`
 	// Whether the plugin is applied.
@@ -795,9 +795,9 @@ type ZipkinPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []ZipkinPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *ZipkinPluginRoute `json:"route,omitempty"`
+	Route *ZipkinPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *ZipkinPluginService `json:"service,omitempty"`
+	Service *ZipkinPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 	// Unix epoch when the resource was last updated.
@@ -914,8 +914,8 @@ func (o *ZipkinPlugin) GetUpdatedAt() *int64 {
 type ZipkinPluginInput struct {
 	Config ZipkinPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer      *ZipkinPluginConsumer      `json:"consumer,omitempty"`
-	ConsumerGroup *ZipkinPluginConsumerGroup `json:"consumer_group,omitempty"`
+	Consumer      *ZipkinPluginConsumer      `json:"consumer"`
+	ConsumerGroup *ZipkinPluginConsumerGroup `json:"consumer_group"`
 	// Whether the plugin is applied.
 	Enabled      *bool                 `json:"enabled,omitempty"`
 	ID           *string               `json:"id,omitempty"`
@@ -925,9 +925,9 @@ type ZipkinPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
 	Protocols []ZipkinPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
-	Route *ZipkinPluginRoute `json:"route,omitempty"`
+	Route *ZipkinPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *ZipkinPluginService `json:"service,omitempty"`
+	Service *ZipkinPluginService `json:"service"`
 	// An optional set of strings associated with the Plugin for grouping and filtering.
 	Tags []string `json:"tags,omitempty"`
 }

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -14205,12 +14205,14 @@ components:
       properties:
         consumer:
           type: object
+          default: null
           additionalProperties: false
           nullable: true
           properties:
             id:
               type: string
           x-foreign: true
+          x-speakeasy-terraform-plan-only: true
         created_at:
           description: Unix epoch when the resource was created.
           type: integer
@@ -15425,12 +15427,14 @@ components:
       properties:
         consumer:
           type: object
+          default: null
           additionalProperties: false
           nullable: true
           properties:
             id:
               type: string
           x-foreign: true
+          x-speakeasy-terraform-plan-only: true
         created_at:
           description: Unix epoch when the resource was created.
           type: integer
@@ -16502,12 +16506,14 @@ components:
       properties:
         consumer:
           type: object
+          default: null
           additionalProperties: false
           nullable: true
           properties:
             id:
               type: string
           x-foreign: true
+          x-speakeasy-terraform-plan-only: true
         created_at:
           description: Unix epoch when the resource was created.
           type: integer
@@ -16750,12 +16756,14 @@ components:
           nullable: true
         consumer:
           type: object
+          default: null
           additionalProperties: false
           nullable: true
           properties:
             id:
               type: string
           x-foreign: true
+          x-speakeasy-terraform-plan-only: true
         created_at:
           description: Unix epoch when the resource was created.
           type: integer
@@ -17626,12 +17634,14 @@ components:
         set:
           description: The id (an UUID) of the key-set with which to associate the key.
           type: object
+          default: null
           additionalProperties: false
           nullable: true
           properties:
             id:
               type: string
           x-foreign: true
+          x-speakeasy-terraform-plan-only: true
         tags:
           description: An optional set of strings associated with the Key for grouping and filtering.
           type: array
@@ -17661,12 +17671,14 @@ components:
       properties:
         consumer:
           type: object
+          default: null
           additionalProperties: false
           nullable: true
           properties:
             id:
               type: string
           x-foreign: true
+          x-speakeasy-terraform-plan-only: true
         created_at:
           description: Unix epoch when the resource was created.
           type: integer
@@ -21400,20 +21412,24 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
           nullable: true
           properties:
             id:
               type: string
           x-foreign: true
+          x-speakeasy-terraform-plan-only: true
         consumer_group:
           type: object
+          default: null
           additionalProperties: false
           nullable: true
           properties:
             id:
               type: string
           x-foreign: true
+          x-speakeasy-terraform-plan-only: true
         created_at:
           description: Unix epoch when the resource was created.
           type: integer
@@ -21469,21 +21485,25 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.'
           type: object
+          default: null
           additionalProperties: false
           nullable: true
           properties:
             id:
               type: string
           x-foreign: true
+          x-speakeasy-terraform-plan-only: true
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
           nullable: true
           properties:
             id:
               type: string
           x-foreign: true
+          x-speakeasy-terraform-plan-only: true
         tags:
           description: An optional set of strings associated with the Plugin for grouping and filtering.
           type: array
@@ -23139,12 +23159,14 @@ components:
         service:
           description: The Service this Route is associated to. This is where the Route proxies traffic to.
           type: object
+          default: null
           additionalProperties: false
           nullable: true
           properties:
             id:
               type: string
           x-foreign: true
+          x-speakeasy-terraform-plan-only: true
         snis:
           description: A list of SNIs that match this Route when using stream routing.
           type: array
@@ -23245,11 +23267,14 @@ components:
         certificate:
           description: The id (a UUID) of the certificate with which to associate the SNI hostname. The Certificate must have a valid private key associated with it to be used by the SNI object.
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
           x-foreign: true
+          x-speakeasy-terraform-plan-only: true
         created_at:
           description: Unix epoch when the resource was created.
           type: integer
@@ -23718,12 +23743,14 @@ components:
         client_certificate:
           description: Certificate to be used as client certificate while TLS handshaking to the upstream server.
           type: object
+          default: null
           additionalProperties: false
           nullable: true
           properties:
             id:
               type: string
           x-foreign: true
+          x-speakeasy-terraform-plan-only: true
         connect_timeout:
           description: The timeout in milliseconds for establishing a connection to the upstream server.
           type: integer
@@ -24388,12 +24415,14 @@ components:
           readOnly: true
         upstream:
           type: object
+          default: null
           additionalProperties: false
           nullable: true
           properties:
             id:
               type: string
           x-foreign: true
+          x-speakeasy-terraform-plan-only: true
         weight:
           description: 'The weight this target gets within the upstream loadbalancer (`0`-`65535`). If the hostname resolves to an SRV record, the `weight` value will be overridden by the value from the DNS record.'
           type: integer
@@ -24571,12 +24600,14 @@ components:
         client_certificate:
           description: 'If set, the certificate to be used as client certificate while TLS handshaking to the upstream server.'
           type: object
+          default: null
           additionalProperties: false
           nullable: true
           properties:
             id:
               type: string
           x-foreign: true
+          x-speakeasy-terraform-plan-only: true
         created_at:
           description: Unix epoch when the resource was created.
           type: integer


### PR DESCRIPTION
### Bug Fixes

* Removing service, route, consumer etc scope from a plugin now sends `null` to the API, removing the link between the plugin and the resource.