### PR TITLE
Ensure references are deleted when removed from manifests

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,7 +1,7 @@
 lockVersion: 2.0.0
 id: 9d20c53e-7836-4ea8-88b8-a75fb7dce3a2
 management:
-  docChecksum: db564799c7a5b9566b8f533de3fdd416
+  docChecksum: 94ea37eaca6cb8afdf625d78eb0d5298
   docVersion: 2.0.0
   speakeasyVersion: 1.503.0
   generationVersion: 2.526.1
@@ -3514,7 +3514,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 629505}
   update-acl-plugin:
@@ -3524,10 +3524,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 398732}
   delete-acme-plugin:
@@ -3580,7 +3580,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 628873}
   update-aiazurecontentsafety-plugin:
@@ -3590,10 +3590,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 12883}
   delete-aipromptdecorator-plugin:
@@ -3613,7 +3613,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 679068}
   update-aipromptdecorator-plugin:
@@ -3623,10 +3623,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 507885}
   delete-aipromptguard-plugin:
@@ -3646,7 +3646,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 73764}
   update-aipromptguard-plugin:
@@ -3656,10 +3656,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 337772}
   delete-aiprompttemplate-plugin:
@@ -3679,7 +3679,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 156428}
   update-aiprompttemplate-plugin:
@@ -3689,10 +3689,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 320899}
   delete-aiproxy-plugin:
@@ -3712,7 +3712,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 777322}
   update-aiproxy-plugin:
@@ -3722,10 +3722,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 244183}
   delete-aiproxyadvanced-plugin:
@@ -3745,7 +3745,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 362813}
   update-aiproxyadvanced-plugin:
@@ -3755,10 +3755,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 430794}
   delete-airatelimitingadvanced-plugin:
@@ -3778,7 +3778,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 2688}
   update-airatelimitingadvanced-plugin:
@@ -3788,10 +3788,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 500540}
   delete-airequesttransformer-plugin:
@@ -3811,7 +3811,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 102442}
   update-airequesttransformer-plugin:
@@ -3821,10 +3821,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 590113}
   delete-airesponsetransformer-plugin:
@@ -3844,7 +3844,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 906560}
   update-airesponsetransformer-plugin:
@@ -3854,10 +3854,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 287995}
   delete-aisemanticcache-plugin:
@@ -3877,7 +3877,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 182326}
   update-aisemanticcache-plugin:
@@ -3887,10 +3887,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 121583}
   delete-aisemanticpromptguard-plugin:
@@ -3910,7 +3910,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 392992}
   update-aisemanticpromptguard-plugin:
@@ -3920,10 +3920,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 641998}
   delete-awslambda-plugin:
@@ -3943,7 +3943,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 781584}
   update-awslambda-plugin:
@@ -3953,10 +3953,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 622710}
   delete-azurefunctions-plugin:
@@ -3976,7 +3976,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 594459}
   update-azurefunctions-plugin:
@@ -3986,10 +3986,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 689832}
   delete-basicauth-plugin:
@@ -4009,7 +4009,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 607247}
   update-basicauth-plugin:
@@ -4019,10 +4019,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 225103}
   delete-botdetection-plugin:
@@ -4042,7 +4042,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 442064}
   update-botdetection-plugin:
@@ -4052,10 +4052,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 968921}
   delete-canary-plugin:
@@ -4075,7 +4075,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 454356}
   update-canary-plugin:
@@ -4085,10 +4085,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 38571}
   delete-confluent-plugin:
@@ -4108,7 +4108,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 576805}
   update-confluent-plugin:
@@ -4118,10 +4118,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 35088}
   delete-correlationid-plugin:
@@ -4141,7 +4141,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 188898}
   update-correlationid-plugin:
@@ -4151,10 +4151,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 401203}
   delete-cors-plugin:
@@ -4174,7 +4174,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 464115}
   update-cors-plugin:
@@ -4184,10 +4184,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 675653}
   delete-datadog-plugin:
@@ -4207,7 +4207,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 374222}
   update-datadog-plugin:
@@ -4217,10 +4217,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 883338}
   delete-datadogtracing-plugin:
@@ -4240,7 +4240,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 32999}
   update-datadogtracing-plugin:
@@ -4250,10 +4250,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 882290}
   delete-degraphql-plugin:
@@ -4273,7 +4273,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 660394}
   update-degraphql-plugin:
@@ -4283,10 +4283,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 217127}
   delete-exittransformer-plugin:
@@ -4306,7 +4306,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 281271}
   update-exittransformer-plugin:
@@ -4316,10 +4316,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 381009}
   delete-filelog-plugin:
@@ -4339,7 +4339,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 83708}
   update-filelog-plugin:
@@ -4349,10 +4349,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 550354}
   delete-forwardproxy-plugin:
@@ -4372,7 +4372,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 751925}
   update-forwardproxy-plugin:
@@ -4382,10 +4382,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 198810}
   delete-graphqlproxycacheadvanced-plugin:
@@ -4405,7 +4405,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 335386}
   update-graphqlproxycacheadvanced-plugin:
@@ -4415,10 +4415,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 250726}
   delete-graphqlratelimitingadvanced-plugin:
@@ -4438,7 +4438,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 737153}
   update-graphqlratelimitingadvanced-plugin:
@@ -4448,10 +4448,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 861199}
   delete-grpcgateway-plugin:
@@ -4471,7 +4471,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 40557}
   update-grpcgateway-plugin:
@@ -4481,10 +4481,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 373764}
   delete-grpcweb-plugin:
@@ -4504,7 +4504,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 539949}
   update-grpcweb-plugin:
@@ -4514,10 +4514,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 994579}
   delete-headercertauth-plugin:
@@ -4537,7 +4537,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>"}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>"}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 880740}
   update-headercertauth-plugin:
@@ -4547,10 +4547,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>"}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>"}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>"}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>"}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 96512}
   delete-hmacauth-plugin:
@@ -4570,7 +4570,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 724026}
   update-hmacauth-plugin:
@@ -4580,10 +4580,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 911301}
   delete-httplog-plugin:
@@ -4603,7 +4603,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 113757}
   update-httplog-plugin:
@@ -4613,10 +4613,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 547127}
   delete-injectionprotection-plugin:
@@ -4636,7 +4636,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 679223}
   update-injectionprotection-plugin:
@@ -4646,10 +4646,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 846117}
   delete-iprestriction-plugin:
@@ -4669,7 +4669,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 453032}
   update-iprestriction-plugin:
@@ -4679,10 +4679,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 729081}
   delete-jq-plugin:
@@ -4702,7 +4702,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 449086}
   update-jq-plugin:
@@ -4712,10 +4712,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 984795}
   delete-jsonthreatprotection-plugin:
@@ -4735,7 +4735,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 633499}
   update-jsonthreatprotection-plugin:
@@ -4745,10 +4745,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 241073}
   delete-jwedecrypt-plugin:
@@ -4768,7 +4768,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 121273}
   update-jwedecrypt-plugin:
@@ -4778,10 +4778,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 103795}
   delete-jwt-plugin:
@@ -4801,7 +4801,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "run_on_preflight": true}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "run_on_preflight": true}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 813889}
   update-jwt-plugin:
@@ -4811,10 +4811,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "run_on_preflight": true}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "run_on_preflight": true}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "run_on_preflight": true}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "run_on_preflight": true}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 673839}
   delete-jwtsigner-plugin:
@@ -4834,7 +4834,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 978819}
   update-jwtsigner-plugin:
@@ -4844,10 +4844,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 950877}
   delete-kafkalog-plugin:
@@ -4867,7 +4867,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 456294}
   update-kafkalog-plugin:
@@ -4877,10 +4877,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 557713}
   delete-kafkaupstream-plugin:
@@ -4900,7 +4900,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 477436}
   update-kafkaupstream-plugin:
@@ -4910,10 +4910,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 375638}
   delete-keyauth-plugin:
@@ -4933,7 +4933,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false, "key_in_body": false, "key_in_header": true, "key_in_query": true, "key_names": ["apikey"], "run_on_preflight": true}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false, "key_in_body": false, "key_in_header": true, "key_in_query": true, "key_names": ["apikey"], "run_on_preflight": true}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 709328}
   update-keyauth-plugin:
@@ -4943,10 +4943,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false, "key_in_body": false, "key_in_header": true, "key_in_query": true, "key_names": ["apikey"], "run_on_preflight": true}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false, "key_in_body": false, "key_in_header": true, "key_in_query": true, "key_names": ["apikey"], "run_on_preflight": true}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false, "key_in_body": false, "key_in_header": true, "key_in_query": true, "key_names": ["apikey"], "run_on_preflight": true}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false, "key_in_body": false, "key_in_header": true, "key_in_query": true, "key_names": ["apikey"], "run_on_preflight": true}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 277850}
   delete-keyauthenc-plugin:
@@ -4966,7 +4966,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false, "key_in_body": false, "key_in_header": true, "key_in_query": true, "key_names": ["apikey"], "run_on_preflight": true}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false, "key_in_body": false, "key_in_header": true, "key_in_query": true, "key_names": ["apikey"], "run_on_preflight": true}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 195275}
   update-keyauthenc-plugin:
@@ -4976,10 +4976,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false, "key_in_body": false, "key_in_header": true, "key_in_query": true, "key_names": ["apikey"], "run_on_preflight": true}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false, "key_in_body": false, "key_in_header": true, "key_in_query": true, "key_names": ["apikey"], "run_on_preflight": true}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false, "key_in_body": false, "key_in_header": true, "key_in_query": true, "key_names": ["apikey"], "run_on_preflight": true}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false, "key_in_body": false, "key_in_header": true, "key_in_query": true, "key_names": ["apikey"], "run_on_preflight": true}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 176157}
   delete-konnectapplicationauth-plugin:
@@ -4999,7 +4999,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"key_names": ["apikey"]}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"key_names": ["apikey"]}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 869866}
   update-konnectapplicationauth-plugin:
@@ -5009,10 +5009,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"key_names": ["apikey"]}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"key_names": ["apikey"]}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"key_names": ["apikey"]}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"key_names": ["apikey"]}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 310218}
   delete-ldapauth-plugin:
@@ -5032,7 +5032,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 48974}
   update-ldapauth-plugin:
@@ -5042,10 +5042,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 503827}
   delete-ldapauthadvanced-plugin:
@@ -5065,7 +5065,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 502179}
   update-ldapauthadvanced-plugin:
@@ -5075,10 +5075,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 999064}
   delete-loggly-plugin:
@@ -5098,7 +5098,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 152935}
   update-loggly-plugin:
@@ -5108,10 +5108,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 797364}
   delete-mocking-plugin:
@@ -5131,7 +5131,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 533967}
   update-mocking-plugin:
@@ -5141,10 +5141,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 352959}
   delete-mtlsauth-plugin:
@@ -5164,7 +5164,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>"}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>"}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 59405}
   update-mtlsauth-plugin:
@@ -5174,10 +5174,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>"}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>"}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>"}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>"}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 447054}
   delete-oasvalidation-plugin:
@@ -5197,7 +5197,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 377120}
   update-oasvalidation-plugin:
@@ -5207,10 +5207,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 153040}
   delete-oauth2-plugin:
@@ -5230,7 +5230,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 717818}
   update-oauth2-plugin:
@@ -5240,10 +5240,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 294492}
   delete-oauth2introspection-plugin:
@@ -5263,7 +5263,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false, "run_on_preflight": true}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false, "run_on_preflight": true}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 9170}
   update-oauth2introspection-plugin:
@@ -5273,10 +5273,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false, "run_on_preflight": true}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false, "run_on_preflight": true}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false, "run_on_preflight": true}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false, "run_on_preflight": true}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 36517}
   delete-opa-plugin:
@@ -5296,7 +5296,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 296571}
   update-opa-plugin:
@@ -5306,10 +5306,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 864983}
   delete-openidconnect-plugin:
@@ -5329,7 +5329,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false, "run_on_preflight": true, "scopes": ["<value>"]}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false, "run_on_preflight": true, "scopes": ["<value>"]}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 547392}
   update-openidconnect-plugin:
@@ -5339,10 +5339,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false, "run_on_preflight": true, "scopes": ["<value>"]}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false, "run_on_preflight": true, "scopes": ["<value>"]}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false, "run_on_preflight": true, "scopes": ["<value>", "<value>"]}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false, "run_on_preflight": true, "scopes": ["<value>", "<value>"]}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 411125}
   delete-opentelemetry-plugin:
@@ -5362,7 +5362,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 201934}
   update-opentelemetry-plugin:
@@ -5372,10 +5372,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 162327}
   delete-postfunction-plugin:
@@ -5395,7 +5395,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 62418}
   update-postfunction-plugin:
@@ -5405,10 +5405,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 313413}
   delete-prefunction-plugin:
@@ -5428,7 +5428,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 151600}
   update-prefunction-plugin:
@@ -5438,10 +5438,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 641134}
   delete-prometheus-plugin:
@@ -5461,7 +5461,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 168069}
   update-prometheus-plugin:
@@ -5471,10 +5471,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 784896}
   delete-proxycache-plugin:
@@ -5494,7 +5494,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 230134}
   update-proxycache-plugin:
@@ -5504,10 +5504,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 465356}
   delete-proxycacheadvanced-plugin:
@@ -5527,7 +5527,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 758275}
   update-proxycacheadvanced-plugin:
@@ -5537,10 +5537,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 629033}
   delete-ratelimiting-plugin:
@@ -5560,7 +5560,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 517349}
   update-ratelimiting-plugin:
@@ -5570,10 +5570,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 666578}
   delete-ratelimitingadvanced-plugin:
@@ -5593,7 +5593,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 638119}
   update-ratelimitingadvanced-plugin:
@@ -5603,10 +5603,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 168928}
   delete-redirect-plugin:
@@ -5626,7 +5626,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 902826}
   update-redirect-plugin:
@@ -5636,10 +5636,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 654704}
   delete-requestsizelimiting-plugin:
@@ -5659,7 +5659,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 748551}
   update-requestsizelimiting-plugin:
@@ -5669,10 +5669,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 751371}
   delete-requesttermination-plugin:
@@ -5692,7 +5692,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 697897}
   update-requesttermination-plugin:
@@ -5702,10 +5702,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 687217}
   delete-requesttransformer-plugin:
@@ -5725,7 +5725,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 189647}
   update-requesttransformer-plugin:
@@ -5735,10 +5735,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 942313}
   delete-requesttransformeradvanced-plugin:
@@ -5758,7 +5758,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 254381}
   update-requesttransformeradvanced-plugin:
@@ -5768,10 +5768,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 40610}
   delete-requestvalidator-plugin:
@@ -5791,7 +5791,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 861094}
   update-requestvalidator-plugin:
@@ -5801,10 +5801,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 518512}
   delete-responseratelimiting-plugin:
@@ -5824,7 +5824,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 407331}
   update-responseratelimiting-plugin:
@@ -5834,10 +5834,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 670177}
   delete-responsetransformer-plugin:
@@ -5857,7 +5857,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 448524}
   update-responsetransformer-plugin:
@@ -5867,10 +5867,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 478345}
   delete-responsetransformeradvanced-plugin:
@@ -5890,7 +5890,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 912219}
   update-responsetransformeradvanced-plugin:
@@ -5900,10 +5900,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 334000}
   delete-routebyheader-plugin:
@@ -5923,7 +5923,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 681874}
   update-routebyheader-plugin:
@@ -5933,10 +5933,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 673939}
   delete-routetransformeradvanced-plugin:
@@ -5956,7 +5956,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 548866}
   update-routetransformeradvanced-plugin:
@@ -5966,10 +5966,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 748000}
   delete-saml-plugin:
@@ -5989,7 +5989,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>"}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>"}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 299413}
   update-saml-plugin:
@@ -5999,10 +5999,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>"}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>"}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>"}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>"}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 290222}
   delete-serviceprotection-plugin:
@@ -6022,7 +6022,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "service": null}
         "401":
           application/json: {"message": "<value>", "status": 293909}
   update-serviceprotection-plugin:
@@ -6032,10 +6032,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "service": null}
         "401":
           application/json: {"message": "<value>", "status": 405954}
   delete-session-plugin:
@@ -6055,7 +6055,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 426945}
   update-session-plugin:
@@ -6065,10 +6065,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 863822}
   delete-standardwebhooks-plugin:
@@ -6088,7 +6088,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 120023}
   update-standardwebhooks-plugin:
@@ -6098,10 +6098,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 377172}
   delete-statsd-plugin:
@@ -6121,7 +6121,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 582005}
   update-statsd-plugin:
@@ -6131,10 +6131,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 872907}
   delete-statsdadvanced-plugin:
@@ -6154,7 +6154,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 637297}
   update-statsdadvanced-plugin:
@@ -6164,10 +6164,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 225198}
   delete-syslog-plugin:
@@ -6187,7 +6187,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 301428}
   update-syslog-plugin:
@@ -6197,10 +6197,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 231815}
   delete-tcplog-plugin:
@@ -6220,7 +6220,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 69003}
   update-tcplog-plugin:
@@ -6230,10 +6230,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 587993}
   delete-tlshandshakemodifier-plugin:
@@ -6253,7 +6253,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["tls", "grpcs", "grpcs", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["tls", "grpcs", "grpcs", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 726232}
   update-tlshandshakemodifier-plugin:
@@ -6263,10 +6263,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpcs", "grpcs", "grpcs", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpcs", "grpcs", "grpcs", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpcs", "grpcs", "grpcs", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpcs", "grpcs", "grpcs", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 346530}
   delete-tlsmetadataheaders-plugin:
@@ -6286,7 +6286,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["https", "grpcs", "https", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["https", "grpcs", "https", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 835921}
   update-tlsmetadataheaders-plugin:
@@ -6296,10 +6296,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["https", "grpcs", "https", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["https", "grpcs", "https", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["tls", "grpcs", "grpcs", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["tls", "grpcs", "grpcs", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 526850}
   delete-udplog-plugin:
@@ -6319,7 +6319,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 653554}
   update-udplog-plugin:
@@ -6329,10 +6329,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 897301}
   delete-upstreamoauth-plugin:
@@ -6352,7 +6352,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 464620}
   update-upstreamoauth-plugin:
@@ -6362,10 +6362,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 530212}
   delete-upstreamtimeout-plugin:
@@ -6385,7 +6385,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 485536}
   update-upstreamtimeout-plugin:
@@ -6395,10 +6395,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 757626}
   delete-vaultauth-plugin:
@@ -6418,7 +6418,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false, "run_on_preflight": true}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false, "run_on_preflight": true}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 195207}
   update-vaultauth-plugin:
@@ -6428,10 +6428,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false, "run_on_preflight": true}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false, "run_on_preflight": true}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false, "run_on_preflight": true}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false, "run_on_preflight": true}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 130868}
   delete-websocketsizelimit-plugin:
@@ -6451,7 +6451,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["ws", "wss", "wss", "ws"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["ws", "wss", "wss", "ws"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 678973}
   update-websocketsizelimit-plugin:
@@ -6461,10 +6461,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["wss", "ws", "wss", "ws"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["wss", "ws", "wss", "ws"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["wss", "ws", "wss", "ws"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["wss", "ws", "wss", "ws"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 355013}
   delete-websocketvalidator-plugin:
@@ -6484,7 +6484,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["wss", "wss", "wss", "ws"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["wss", "wss", "wss", "ws"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 77197}
   update-websocketvalidator-plugin:
@@ -6494,10 +6494,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["ws", "wss", "ws", "ws"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["ws", "wss", "ws", "ws"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["wss", "wss", "wss", "ws"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["wss", "wss", "wss", "ws"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 918293}
   delete-xmlthreatprotection-plugin:
@@ -6517,7 +6517,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 350911}
   update-xmlthreatprotection-plugin:
@@ -6527,10 +6527,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 162612}
   delete-zipkin-plugin:
@@ -6550,7 +6550,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 589898}
   update-zipkin-plugin:
@@ -6560,10 +6560,10 @@ examples:
           PluginId: "3473c251-5b6c-4f45-b1ff-7ede735a366d"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "200":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 354105}
   create-acl-plugin:
@@ -6572,10 +6572,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 868922}
   create-acme-plugin:
@@ -6596,10 +6596,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 67920}
   create-aipromptdecorator-plugin:
@@ -6608,10 +6608,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 190029}
   create-aipromptguard-plugin:
@@ -6620,10 +6620,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 745070}
   create-aiprompttemplate-plugin:
@@ -6632,10 +6632,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 774826}
   create-aiproxy-plugin:
@@ -6644,10 +6644,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 633208}
   create-aiproxyadvanced-plugin:
@@ -6656,10 +6656,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 998206}
   create-airatelimitingadvanced-plugin:
@@ -6668,10 +6668,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 428413}
   create-airequesttransformer-plugin:
@@ -6680,10 +6680,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 171917}
   create-airesponsetransformer-plugin:
@@ -6692,10 +6692,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 770913}
   create-aisemanticcache-plugin:
@@ -6704,10 +6704,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 634519}
   create-aisemanticpromptguard-plugin:
@@ -6716,10 +6716,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 527537}
   create-awslambda-plugin:
@@ -6728,10 +6728,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 836187}
   create-azurefunctions-plugin:
@@ -6740,10 +6740,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 245137}
   create-basicauth-plugin:
@@ -6752,10 +6752,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 416796}
   create-botdetection-plugin:
@@ -6764,10 +6764,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 795298}
   create-canary-plugin:
@@ -6776,10 +6776,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 661288}
   create-confluent-plugin:
@@ -6788,10 +6788,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 178123}
   create-correlationid-plugin:
@@ -6800,10 +6800,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 200541}
   create-cors-plugin:
@@ -6812,10 +6812,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 529865}
   create-datadog-plugin:
@@ -6824,10 +6824,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 646114}
   create-datadogtracing-plugin:
@@ -6836,10 +6836,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 725941}
   create-degraphql-plugin:
@@ -6848,10 +6848,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 856501}
   create-exittransformer-plugin:
@@ -6860,10 +6860,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 350768}
   create-filelog-plugin:
@@ -6872,10 +6872,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 525789}
   create-forwardproxy-plugin:
@@ -6884,10 +6884,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 643269}
   create-graphqlproxycacheadvanced-plugin:
@@ -6896,10 +6896,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 901937}
   create-graphqlratelimitingadvanced-plugin:
@@ -6908,10 +6908,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 63156}
   create-grpcgateway-plugin:
@@ -6920,10 +6920,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 498560}
   create-grpcweb-plugin:
@@ -6932,10 +6932,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 87902}
   create-headercertauth-plugin:
@@ -6944,10 +6944,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>"}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>"}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>"}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>"}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 309556}
   create-hmacauth-plugin:
@@ -6956,10 +6956,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 737757}
   create-httplog-plugin:
@@ -6968,10 +6968,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 861466}
   create-injectionprotection-plugin:
@@ -6980,10 +6980,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 586026}
   create-iprestriction-plugin:
@@ -6992,10 +6992,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 752423}
   create-jq-plugin:
@@ -7004,10 +7004,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 697664}
   create-jsonthreatprotection-plugin:
@@ -7016,10 +7016,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 170694}
   create-jwedecrypt-plugin:
@@ -7028,10 +7028,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 487760}
   create-jwt-plugin:
@@ -7040,10 +7040,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "run_on_preflight": true}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "run_on_preflight": true}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "run_on_preflight": true}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "run_on_preflight": true}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 585814}
   create-jwtsigner-plugin:
@@ -7052,10 +7052,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 391420}
   create-kafkalog-plugin:
@@ -7064,10 +7064,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 926249}
   create-kafkaupstream-plugin:
@@ -7076,10 +7076,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 194604}
   create-keyauth-plugin:
@@ -7088,10 +7088,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false, "key_in_body": false, "key_in_header": true, "key_in_query": true, "key_names": ["apikey"], "run_on_preflight": true}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false, "key_in_body": false, "key_in_header": true, "key_in_query": true, "key_names": ["apikey"], "run_on_preflight": true}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false, "key_in_body": false, "key_in_header": true, "key_in_query": true, "key_names": ["apikey"], "run_on_preflight": true}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false, "key_in_body": false, "key_in_header": true, "key_in_query": true, "key_names": ["apikey"], "run_on_preflight": true}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 789167}
   create-keyauthenc-plugin:
@@ -7100,10 +7100,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false, "key_in_body": false, "key_in_header": true, "key_in_query": true, "key_names": ["apikey"], "run_on_preflight": true}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false, "key_in_body": false, "key_in_header": true, "key_in_query": true, "key_names": ["apikey"], "run_on_preflight": true}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false, "key_in_body": false, "key_in_header": true, "key_in_query": true, "key_names": ["apikey"], "run_on_preflight": true}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false, "key_in_body": false, "key_in_header": true, "key_in_query": true, "key_names": ["apikey"], "run_on_preflight": true}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 252781}
   create-konnectapplicationauth-plugin:
@@ -7112,10 +7112,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"key_names": ["apikey"]}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"key_names": ["apikey"]}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"key_names": ["apikey"]}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"key_names": ["apikey"]}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 803992}
   create-ldapauth-plugin:
@@ -7124,10 +7124,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 557231}
   create-ldapauthadvanced-plugin:
@@ -7136,10 +7136,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 968737}
   create-loggly-plugin:
@@ -7148,10 +7148,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 603964}
   create-mocking-plugin:
@@ -7160,10 +7160,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 753099}
   create-mtlsauth-plugin:
@@ -7172,10 +7172,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>"}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>"}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>"}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>"}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 446252}
   create-oasvalidation-plugin:
@@ -7184,10 +7184,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 142134}
   create-oauth2-plugin:
@@ -7196,10 +7196,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 253178}
   create-oauth2introspection-plugin:
@@ -7208,10 +7208,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false, "run_on_preflight": true}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false, "run_on_preflight": true}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false, "run_on_preflight": true}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false, "run_on_preflight": true}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 88105}
   create-opa-plugin:
@@ -7220,10 +7220,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 403300}
   create-openidconnect-plugin:
@@ -7232,10 +7232,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false, "run_on_preflight": true, "scopes": ["<value>", "<value>", "<value>"]}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false, "run_on_preflight": true, "scopes": ["<value>", "<value>", "<value>"]}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false, "run_on_preflight": true, "scopes": []}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false, "run_on_preflight": true, "scopes": []}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 148835}
   create-opentelemetry-plugin:
@@ -7244,10 +7244,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 191030}
   create-postfunction-plugin:
@@ -7256,10 +7256,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 490108}
   create-prefunction-plugin:
@@ -7268,10 +7268,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 246793}
   create-prometheus-plugin:
@@ -7280,10 +7280,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 81807}
   create-proxycache-plugin:
@@ -7292,10 +7292,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 977470}
   create-proxycacheadvanced-plugin:
@@ -7304,10 +7304,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 282710}
   create-ratelimiting-plugin:
@@ -7316,10 +7316,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 710442}
   create-ratelimitingadvanced-plugin:
@@ -7328,10 +7328,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 986061}
   create-redirect-plugin:
@@ -7340,10 +7340,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 420525}
   create-requestsizelimiting-plugin:
@@ -7352,10 +7352,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 628263}
   create-requesttermination-plugin:
@@ -7364,10 +7364,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 792725}
   create-requesttransformer-plugin:
@@ -7376,10 +7376,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 24861}
   create-requesttransformeradvanced-plugin:
@@ -7388,10 +7388,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 545968}
   create-requestvalidator-plugin:
@@ -7400,10 +7400,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 618807}
   create-responseratelimiting-plugin:
@@ -7412,10 +7412,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 638232}
   create-responsetransformer-plugin:
@@ -7424,10 +7424,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 632074}
   create-responsetransformeradvanced-plugin:
@@ -7436,10 +7436,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 331145}
   create-routebyheader-plugin:
@@ -7448,10 +7448,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 438092}
   create-routetransformeradvanced-plugin:
@@ -7460,10 +7460,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 427558}
   create-saml-plugin:
@@ -7472,10 +7472,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>"}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>"}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>"}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>"}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 246204}
   create-serviceprotection-plugin:
@@ -7484,10 +7484,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "service": null}
         "401":
           application/json: {"message": "<value>", "status": 342773}
   create-session-plugin:
@@ -7496,10 +7496,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 885621}
   create-standardwebhooks-plugin:
@@ -7508,10 +7508,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 298689}
   create-statsd-plugin:
@@ -7520,10 +7520,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 289002}
   create-statsdadvanced-plugin:
@@ -7532,10 +7532,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 489705}
   create-syslog-plugin:
@@ -7544,10 +7544,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 257739}
   create-tcplog-plugin:
@@ -7556,10 +7556,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 625257}
   create-tlshandshakemodifier-plugin:
@@ -7568,10 +7568,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["https", "grpcs", "tls", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["https", "grpcs", "tls", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpcs", "grpcs", "https", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpcs", "grpcs", "https", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 468481}
   create-tlsmetadataheaders-plugin:
@@ -7580,10 +7580,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["https", "grpcs", "grpcs", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["https", "grpcs", "grpcs", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpcs", "grpcs", "https", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpcs", "grpcs", "https", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 131014}
   create-udplog-plugin:
@@ -7592,10 +7592,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 497553}
   create-upstreamoauth-plugin:
@@ -7604,10 +7604,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "consumer_group": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 405465}
   create-upstreamtimeout-plugin:
@@ -7616,10 +7616,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 105262}
   create-vaultauth-plugin:
@@ -7628,10 +7628,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false, "run_on_preflight": true}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false, "run_on_preflight": true}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false, "run_on_preflight": true}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {"anonymous": "<value>", "hide_credentials": false, "run_on_preflight": true}, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 995340}
   create-websocketsizelimit-plugin:
@@ -7640,10 +7640,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["ws", "ws", "wss", "ws"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["ws", "ws", "wss", "ws"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["wss", "wss", "ws", "ws"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["wss", "wss", "ws", "ws"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 8430}
   create-websocketvalidator-plugin:
@@ -7652,10 +7652,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["wss", "wss", "ws", "ws"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["wss", "wss", "ws", "ws"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["wss", "ws", "wss", "wss"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["wss", "ws", "wss", "wss"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 386922}
   create-xmlthreatprotection-plugin:
@@ -7664,10 +7664,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 102983}
   create-zipkin-plugin:
@@ -7676,10 +7676,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+        application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
       responses:
         "201":
-          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "protocols": ["grpc", "grpcs", "http", "https"]}
+          application/json: {"enabled": true, "id": "3fd1eea1-885a-4011-b986-289943ff8177", "name": "key-auth", "config": {}, "consumer": null, "protocols": ["grpc", "grpcs", "http", "https"], "route": null, "service": null}
         "401":
           application/json: {"message": "<value>", "status": 880195}
   fetch-plugin-schema:
@@ -8449,6 +8449,8 @@ examples:
       parameters:
         path:
           teamId: "<id>"
+      requestBody:
+        application/json: null
       responses:
         "401":
           application/problem+json: {"status": 401, "title": "Unauthorized", "type": "https://httpstatuses.com/401", "instance": "kong:trace:1234567890", "detail": "Invalid credentials"}

--- a/internal/provider/gatewayacl_data_source.go
+++ b/internal/provider/gatewayacl_data_source.go
@@ -29,7 +29,7 @@ type GatewayACLDataSource struct {
 
 // GatewayACLDataSourceModel describes the data model.
 type GatewayACLDataSourceModel struct {
-	Consumer       *tfTypes.ACLWithoutParentsConsumer `tfsdk:"consumer" tfPlanOnly:"true"`
+	Consumer       *tfTypes.ACLWithoutParentsConsumer `tfsdk:"consumer"`
 	ConsumerID     types.String                       `tfsdk:"consumer_id"`
 	ControlPlaneID types.String                       `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                        `tfsdk:"created_at"`

--- a/internal/provider/gatewayacl_resource.go
+++ b/internal/provider/gatewayacl_resource.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	speakeasy_listplanmodifier "github.com/kong/terraform-provider-konnect/v2/internal/planmodifiers/listplanmodifier"
-	speakeasy_objectplanmodifier "github.com/kong/terraform-provider-konnect/v2/internal/planmodifiers/objectplanmodifier"
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect/v2/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect/v2/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect/v2/internal/sdk"
@@ -41,7 +40,7 @@ type GatewayACLResource struct {
 
 // GatewayACLResourceModel describes the resource data model.
 type GatewayACLResourceModel struct {
-	Consumer       *tfTypes.ACLWithoutParentsConsumer `tfsdk:"consumer" tfPlanOnly:"true"`
+	Consumer       *tfTypes.ACLWithoutParentsConsumer `tfsdk:"consumer"`
 	ConsumerID     types.String                       `tfsdk:"consumer_id"`
 	ControlPlaneID types.String                       `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                        `tfsdk:"created_at"`
@@ -66,7 +65,6 @@ func (r *GatewayACLResource) Schema(ctx context.Context, req resource.SchemaRequ
 				})),
 				PlanModifiers: []planmodifier.Object{
 					objectplanmodifier.RequiresReplaceIfConfigured(),
-					speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
 				},
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{

--- a/internal/provider/gatewaybasicauth_data_source.go
+++ b/internal/provider/gatewaybasicauth_data_source.go
@@ -29,7 +29,7 @@ type GatewayBasicAuthDataSource struct {
 
 // GatewayBasicAuthDataSourceModel describes the data model.
 type GatewayBasicAuthDataSourceModel struct {
-	Consumer       *tfTypes.ACLWithoutParentsConsumer `tfsdk:"consumer" tfPlanOnly:"true"`
+	Consumer       *tfTypes.ACLWithoutParentsConsumer `tfsdk:"consumer"`
 	ConsumerID     types.String                       `tfsdk:"consumer_id"`
 	ControlPlaneID types.String                       `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                        `tfsdk:"created_at"`

--- a/internal/provider/gatewaybasicauth_resource.go
+++ b/internal/provider/gatewaybasicauth_resource.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	speakeasy_listplanmodifier "github.com/kong/terraform-provider-konnect/v2/internal/planmodifiers/listplanmodifier"
-	speakeasy_objectplanmodifier "github.com/kong/terraform-provider-konnect/v2/internal/planmodifiers/objectplanmodifier"
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect/v2/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect/v2/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect/v2/internal/sdk"
@@ -41,7 +40,7 @@ type GatewayBasicAuthResource struct {
 
 // GatewayBasicAuthResourceModel describes the resource data model.
 type GatewayBasicAuthResourceModel struct {
-	Consumer       *tfTypes.ACLWithoutParentsConsumer `tfsdk:"consumer" tfPlanOnly:"true"`
+	Consumer       *tfTypes.ACLWithoutParentsConsumer `tfsdk:"consumer"`
 	ConsumerID     types.String                       `tfsdk:"consumer_id"`
 	ControlPlaneID types.String                       `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                        `tfsdk:"created_at"`
@@ -67,7 +66,6 @@ func (r *GatewayBasicAuthResource) Schema(ctx context.Context, req resource.Sche
 				})),
 				PlanModifiers: []planmodifier.Object{
 					objectplanmodifier.RequiresReplaceIfConfigured(),
-					speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
 				},
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{

--- a/internal/provider/gatewayhmacauth_data_source.go
+++ b/internal/provider/gatewayhmacauth_data_source.go
@@ -29,7 +29,7 @@ type GatewayHMACAuthDataSource struct {
 
 // GatewayHMACAuthDataSourceModel describes the data model.
 type GatewayHMACAuthDataSourceModel struct {
-	Consumer       *tfTypes.ACLWithoutParentsConsumer `tfsdk:"consumer" tfPlanOnly:"true"`
+	Consumer       *tfTypes.ACLWithoutParentsConsumer `tfsdk:"consumer"`
 	ConsumerID     types.String                       `tfsdk:"consumer_id"`
 	ControlPlaneID types.String                       `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                        `tfsdk:"created_at"`

--- a/internal/provider/gatewayhmacauth_resource.go
+++ b/internal/provider/gatewayhmacauth_resource.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	speakeasy_listplanmodifier "github.com/kong/terraform-provider-konnect/v2/internal/planmodifiers/listplanmodifier"
-	speakeasy_objectplanmodifier "github.com/kong/terraform-provider-konnect/v2/internal/planmodifiers/objectplanmodifier"
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect/v2/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect/v2/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect/v2/internal/sdk"
@@ -41,7 +40,7 @@ type GatewayHMACAuthResource struct {
 
 // GatewayHMACAuthResourceModel describes the resource data model.
 type GatewayHMACAuthResourceModel struct {
-	Consumer       *tfTypes.ACLWithoutParentsConsumer `tfsdk:"consumer" tfPlanOnly:"true"`
+	Consumer       *tfTypes.ACLWithoutParentsConsumer `tfsdk:"consumer"`
 	ConsumerID     types.String                       `tfsdk:"consumer_id"`
 	ControlPlaneID types.String                       `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                        `tfsdk:"created_at"`
@@ -67,7 +66,6 @@ func (r *GatewayHMACAuthResource) Schema(ctx context.Context, req resource.Schem
 				})),
 				PlanModifiers: []planmodifier.Object{
 					objectplanmodifier.RequiresReplaceIfConfigured(),
-					speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
 				},
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{

--- a/internal/provider/gatewayjwt_data_source.go
+++ b/internal/provider/gatewayjwt_data_source.go
@@ -30,7 +30,7 @@ type GatewayJWTDataSource struct {
 // GatewayJWTDataSourceModel describes the data model.
 type GatewayJWTDataSourceModel struct {
 	Algorithm      types.String                       `tfsdk:"algorithm"`
-	Consumer       *tfTypes.ACLWithoutParentsConsumer `tfsdk:"consumer" tfPlanOnly:"true"`
+	Consumer       *tfTypes.ACLWithoutParentsConsumer `tfsdk:"consumer"`
 	ConsumerID     types.String                       `tfsdk:"consumer_id"`
 	ControlPlaneID types.String                       `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                        `tfsdk:"created_at"`

--- a/internal/provider/gatewayjwt_resource.go
+++ b/internal/provider/gatewayjwt_resource.go
@@ -21,7 +21,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	speakeasy_listplanmodifier "github.com/kong/terraform-provider-konnect/v2/internal/planmodifiers/listplanmodifier"
-	speakeasy_objectplanmodifier "github.com/kong/terraform-provider-konnect/v2/internal/planmodifiers/objectplanmodifier"
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect/v2/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect/v2/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect/v2/internal/sdk"
@@ -44,7 +43,7 @@ type GatewayJWTResource struct {
 // GatewayJWTResourceModel describes the resource data model.
 type GatewayJWTResourceModel struct {
 	Algorithm      types.String                       `tfsdk:"algorithm"`
-	Consumer       *tfTypes.ACLWithoutParentsConsumer `tfsdk:"consumer" tfPlanOnly:"true"`
+	Consumer       *tfTypes.ACLWithoutParentsConsumer `tfsdk:"consumer"`
 	ConsumerID     types.String                       `tfsdk:"consumer_id"`
 	ControlPlaneID types.String                       `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                        `tfsdk:"created_at"`
@@ -97,7 +96,6 @@ func (r *GatewayJWTResource) Schema(ctx context.Context, req resource.SchemaRequ
 				})),
 				PlanModifiers: []planmodifier.Object{
 					objectplanmodifier.RequiresReplaceIfConfigured(),
-					speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
 				},
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{

--- a/internal/provider/gatewaykey_data_source.go
+++ b/internal/provider/gatewaykey_data_source.go
@@ -36,7 +36,7 @@ type GatewayKeyDataSourceModel struct {
 	Kid            types.String                       `tfsdk:"kid"`
 	Name           types.String                       `tfsdk:"name"`
 	Pem            *tfTypes.Pem                       `tfsdk:"pem"`
-	Set            *tfTypes.ACLWithoutParentsConsumer `tfsdk:"set" tfPlanOnly:"true"`
+	Set            *tfTypes.ACLWithoutParentsConsumer `tfsdk:"set"`
 	Tags           []types.String                     `tfsdk:"tags"`
 	UpdatedAt      types.Int64                        `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaykey_resource.go
+++ b/internal/provider/gatewaykey_resource.go
@@ -43,7 +43,7 @@ type GatewayKeyResourceModel struct {
 	Kid            types.String                       `tfsdk:"kid"`
 	Name           types.String                       `tfsdk:"name"`
 	Pem            *tfTypes.Pem                       `tfsdk:"pem"`
-	Set            *tfTypes.ACLWithoutParentsConsumer `tfsdk:"set" tfPlanOnly:"true"`
+	Set            *tfTypes.ACLWithoutParentsConsumer `tfsdk:"set"`
 	Tags           []types.String                     `tfsdk:"tags"`
 	UpdatedAt      types.Int64                        `tfsdk:"updated_at"`
 }

--- a/internal/provider/gatewaykeyauth_data_source.go
+++ b/internal/provider/gatewaykeyauth_data_source.go
@@ -29,7 +29,7 @@ type GatewayKeyAuthDataSource struct {
 
 // GatewayKeyAuthDataSourceModel describes the data model.
 type GatewayKeyAuthDataSourceModel struct {
-	Consumer       *tfTypes.ACLWithoutParentsConsumer `tfsdk:"consumer" tfPlanOnly:"true"`
+	Consumer       *tfTypes.ACLWithoutParentsConsumer `tfsdk:"consumer"`
 	ConsumerID     types.String                       `tfsdk:"consumer_id"`
 	ControlPlaneID types.String                       `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                        `tfsdk:"created_at"`

--- a/internal/provider/gatewaykeyauth_resource.go
+++ b/internal/provider/gatewaykeyauth_resource.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	speakeasy_listplanmodifier "github.com/kong/terraform-provider-konnect/v2/internal/planmodifiers/listplanmodifier"
-	speakeasy_objectplanmodifier "github.com/kong/terraform-provider-konnect/v2/internal/planmodifiers/objectplanmodifier"
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect/v2/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect/v2/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect/v2/internal/sdk"
@@ -41,7 +40,7 @@ type GatewayKeyAuthResource struct {
 
 // GatewayKeyAuthResourceModel describes the resource data model.
 type GatewayKeyAuthResourceModel struct {
-	Consumer       *tfTypes.ACLWithoutParentsConsumer `tfsdk:"consumer" tfPlanOnly:"true"`
+	Consumer       *tfTypes.ACLWithoutParentsConsumer `tfsdk:"consumer"`
 	ConsumerID     types.String                       `tfsdk:"consumer_id"`
 	ControlPlaneID types.String                       `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                        `tfsdk:"created_at"`
@@ -66,7 +65,6 @@ func (r *GatewayKeyAuthResource) Schema(ctx context.Context, req resource.Schema
 				})),
 				PlanModifiers: []planmodifier.Object{
 					objectplanmodifier.RequiresReplaceIfConfigured(),
-					speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
 				},
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{

--- a/internal/provider/gatewaymtlsauth_data_source.go
+++ b/internal/provider/gatewaymtlsauth_data_source.go
@@ -29,8 +29,8 @@ type GatewayMTLSAuthDataSource struct {
 
 // GatewayMTLSAuthDataSourceModel describes the data model.
 type GatewayMTLSAuthDataSourceModel struct {
-	CaCertificate  *tfTypes.ACLWithoutParentsConsumer `tfsdk:"ca_certificate" tfPlanOnly:"true"`
-	Consumer       *tfTypes.ACLWithoutParentsConsumer `tfsdk:"consumer" tfPlanOnly:"true"`
+	CaCertificate  *tfTypes.ACLWithoutParentsConsumer `tfsdk:"ca_certificate"`
+	Consumer       *tfTypes.ACLWithoutParentsConsumer `tfsdk:"consumer"`
 	ConsumerID     types.String                       `tfsdk:"consumer_id"`
 	ControlPlaneID types.String                       `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                        `tfsdk:"created_at"`

--- a/internal/provider/gatewaymtlsauth_resource.go
+++ b/internal/provider/gatewaymtlsauth_resource.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	speakeasy_listplanmodifier "github.com/kong/terraform-provider-konnect/v2/internal/planmodifiers/listplanmodifier"
-	speakeasy_objectplanmodifier "github.com/kong/terraform-provider-konnect/v2/internal/planmodifiers/objectplanmodifier"
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect/v2/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect/v2/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect/v2/internal/sdk"
@@ -41,8 +40,8 @@ type GatewayMTLSAuthResource struct {
 
 // GatewayMTLSAuthResourceModel describes the resource data model.
 type GatewayMTLSAuthResourceModel struct {
-	CaCertificate  *tfTypes.ACLWithoutParentsConsumer `tfsdk:"ca_certificate" tfPlanOnly:"true"`
-	Consumer       *tfTypes.ACLWithoutParentsConsumer `tfsdk:"consumer" tfPlanOnly:"true"`
+	CaCertificate  *tfTypes.ACLWithoutParentsConsumer `tfsdk:"ca_certificate"`
+	Consumer       *tfTypes.ACLWithoutParentsConsumer `tfsdk:"consumer"`
 	ConsumerID     types.String                       `tfsdk:"consumer_id"`
 	ControlPlaneID types.String                       `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                        `tfsdk:"created_at"`
@@ -67,7 +66,6 @@ func (r *GatewayMTLSAuthResource) Schema(ctx context.Context, req resource.Schem
 				})),
 				PlanModifiers: []planmodifier.Object{
 					objectplanmodifier.RequiresReplaceIfConfigured(),
-					speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
 				},
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
@@ -90,7 +88,6 @@ func (r *GatewayMTLSAuthResource) Schema(ctx context.Context, req resource.Schem
 				})),
 				PlanModifiers: []planmodifier.Object{
 					objectplanmodifier.RequiresReplaceIfConfigured(),
-					speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
 				},
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{

--- a/internal/provider/gatewaypluginacl_resource.go
+++ b/internal/provider/gatewaypluginacl_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -149,6 +151,9 @@ func (r *GatewayPluginACLResource) Schema(ctx context.Context, req resource.Sche
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -160,6 +165,9 @@ func (r *GatewayPluginACLResource) Schema(ctx context.Context, req resource.Sche
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginaiazurecontentsafety_resource.go
+++ b/internal/provider/gatewaypluginaiazurecontentsafety_resource.go
@@ -8,9 +8,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -231,6 +233,9 @@ func (r *GatewayPluginAiAzureContentSafetyResource) Schema(ctx context.Context, 
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -242,6 +247,9 @@ func (r *GatewayPluginAiAzureContentSafetyResource) Schema(ctx context.Context, 
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginaipromptdecorator_resource.go
+++ b/internal/provider/gatewaypluginaipromptdecorator_resource.go
@@ -8,9 +8,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -147,6 +149,9 @@ func (r *GatewayPluginAiPromptDecoratorResource) Schema(ctx context.Context, req
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -158,6 +163,9 @@ func (r *GatewayPluginAiPromptDecoratorResource) Schema(ctx context.Context, req
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -227,6 +235,9 @@ func (r *GatewayPluginAiPromptDecoratorResource) Schema(ctx context.Context, req
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -238,6 +249,9 @@ func (r *GatewayPluginAiPromptDecoratorResource) Schema(ctx context.Context, req
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginaipromptguard_resource.go
+++ b/internal/provider/gatewaypluginaipromptguard_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -93,6 +95,9 @@ func (r *GatewayPluginAiPromptGuardResource) Schema(ctx context.Context, req res
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -104,6 +109,9 @@ func (r *GatewayPluginAiPromptGuardResource) Schema(ctx context.Context, req res
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -173,6 +181,9 @@ func (r *GatewayPluginAiPromptGuardResource) Schema(ctx context.Context, req res
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -184,6 +195,9 @@ func (r *GatewayPluginAiPromptGuardResource) Schema(ctx context.Context, req res
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginaiprompttemplate_resource.go
+++ b/internal/provider/gatewaypluginaiprompttemplate_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -112,6 +114,9 @@ func (r *GatewayPluginAiPromptTemplateResource) Schema(ctx context.Context, req 
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -123,6 +128,9 @@ func (r *GatewayPluginAiPromptTemplateResource) Schema(ctx context.Context, req 
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -192,6 +200,9 @@ func (r *GatewayPluginAiPromptTemplateResource) Schema(ctx context.Context, req 
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -203,6 +214,9 @@ func (r *GatewayPluginAiPromptTemplateResource) Schema(ctx context.Context, req 
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginaiproxy_resource.go
+++ b/internal/provider/gatewaypluginaiproxy_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -371,6 +373,9 @@ func (r *GatewayPluginAiProxyResource) Schema(ctx context.Context, req resource.
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -382,6 +387,9 @@ func (r *GatewayPluginAiProxyResource) Schema(ctx context.Context, req resource.
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -451,6 +459,9 @@ func (r *GatewayPluginAiProxyResource) Schema(ctx context.Context, req resource.
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -462,6 +473,9 @@ func (r *GatewayPluginAiProxyResource) Schema(ctx context.Context, req resource.
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginaiproxyadvanced_resource.go
+++ b/internal/provider/gatewaypluginaiproxyadvanced_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -847,6 +849,9 @@ func (r *GatewayPluginAiProxyAdvancedResource) Schema(ctx context.Context, req r
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -858,6 +863,9 @@ func (r *GatewayPluginAiProxyAdvancedResource) Schema(ctx context.Context, req r
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -927,6 +935,9 @@ func (r *GatewayPluginAiProxyAdvancedResource) Schema(ctx context.Context, req r
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -938,6 +949,9 @@ func (r *GatewayPluginAiProxyAdvancedResource) Schema(ctx context.Context, req r
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginairatelimitingadvanced_resource.go
+++ b/internal/provider/gatewaypluginairatelimitingadvanced_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -403,6 +405,9 @@ func (r *GatewayPluginAiRateLimitingAdvancedResource) Schema(ctx context.Context
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -414,6 +419,9 @@ func (r *GatewayPluginAiRateLimitingAdvancedResource) Schema(ctx context.Context
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -483,6 +491,9 @@ func (r *GatewayPluginAiRateLimitingAdvancedResource) Schema(ctx context.Context
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -494,6 +505,9 @@ func (r *GatewayPluginAiRateLimitingAdvancedResource) Schema(ctx context.Context
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginairequesttransformer_resource.go
+++ b/internal/provider/gatewaypluginairequesttransformer_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -405,6 +407,9 @@ func (r *GatewayPluginAiRequestTransformerResource) Schema(ctx context.Context, 
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -474,6 +479,9 @@ func (r *GatewayPluginAiRequestTransformerResource) Schema(ctx context.Context, 
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -485,6 +493,9 @@ func (r *GatewayPluginAiRequestTransformerResource) Schema(ctx context.Context, 
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginairesponsetransformer_resource.go
+++ b/internal/provider/gatewaypluginairesponsetransformer_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -411,6 +413,9 @@ func (r *GatewayPluginAiResponseTransformerResource) Schema(ctx context.Context,
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -422,6 +427,9 @@ func (r *GatewayPluginAiResponseTransformerResource) Schema(ctx context.Context,
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -491,6 +499,9 @@ func (r *GatewayPluginAiResponseTransformerResource) Schema(ctx context.Context,
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -502,6 +513,9 @@ func (r *GatewayPluginAiResponseTransformerResource) Schema(ctx context.Context,
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginaisemanticcache_resource.go
+++ b/internal/provider/gatewaypluginaisemanticcache_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -443,6 +445,9 @@ func (r *GatewayPluginAiSemanticCacheResource) Schema(ctx context.Context, req r
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -454,6 +459,9 @@ func (r *GatewayPluginAiSemanticCacheResource) Schema(ctx context.Context, req r
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -523,6 +531,9 @@ func (r *GatewayPluginAiSemanticCacheResource) Schema(ctx context.Context, req r
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -534,6 +545,9 @@ func (r *GatewayPluginAiSemanticCacheResource) Schema(ctx context.Context, req r
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginaisemanticpromptguard_resource.go
+++ b/internal/provider/gatewaypluginaisemanticpromptguard_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -447,6 +449,9 @@ func (r *GatewayPluginAiSemanticPromptGuardResource) Schema(ctx context.Context,
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -458,6 +463,9 @@ func (r *GatewayPluginAiSemanticPromptGuardResource) Schema(ctx context.Context,
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -527,6 +535,9 @@ func (r *GatewayPluginAiSemanticPromptGuardResource) Schema(ctx context.Context,
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -538,6 +549,9 @@ func (r *GatewayPluginAiSemanticPromptGuardResource) Schema(ctx context.Context,
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginawslambda_resource.go
+++ b/internal/provider/gatewaypluginawslambda_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -230,6 +232,9 @@ func (r *GatewayPluginAwsLambdaResource) Schema(ctx context.Context, req resourc
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -299,6 +304,9 @@ func (r *GatewayPluginAwsLambdaResource) Schema(ctx context.Context, req resourc
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -310,6 +318,9 @@ func (r *GatewayPluginAwsLambdaResource) Schema(ctx context.Context, req resourc
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginazurefunctions_resource.go
+++ b/internal/provider/gatewaypluginazurefunctions_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -115,6 +117,9 @@ func (r *GatewayPluginAzureFunctionsResource) Schema(ctx context.Context, req re
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -184,6 +189,9 @@ func (r *GatewayPluginAzureFunctionsResource) Schema(ctx context.Context, req re
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -195,6 +203,9 @@ func (r *GatewayPluginAzureFunctionsResource) Schema(ctx context.Context, req re
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginbasicauth_resource.go
+++ b/internal/provider/gatewaypluginbasicauth_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -137,6 +139,9 @@ func (r *GatewayPluginBasicAuthResource) Schema(ctx context.Context, req resourc
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -148,6 +153,9 @@ func (r *GatewayPluginBasicAuthResource) Schema(ctx context.Context, req resourc
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginbotdetection_resource.go
+++ b/internal/provider/gatewaypluginbotdetection_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -134,6 +136,9 @@ func (r *GatewayPluginBotDetectionResource) Schema(ctx context.Context, req reso
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -145,6 +150,9 @@ func (r *GatewayPluginBotDetectionResource) Schema(ctx context.Context, req reso
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewayplugincanary_resource.go
+++ b/internal/provider/gatewayplugincanary_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -210,6 +212,9 @@ func (r *GatewayPluginCanaryResource) Schema(ctx context.Context, req resource.S
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -221,6 +226,9 @@ func (r *GatewayPluginCanaryResource) Schema(ctx context.Context, req resource.S
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginconfluent_resource.go
+++ b/internal/provider/gatewaypluginconfluent_resource.go
@@ -8,9 +8,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -211,6 +213,9 @@ func (r *GatewayPluginConfluentResource) Schema(ctx context.Context, req resourc
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -280,6 +285,9 @@ func (r *GatewayPluginConfluentResource) Schema(ctx context.Context, req resourc
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -291,6 +299,9 @@ func (r *GatewayPluginConfluentResource) Schema(ctx context.Context, req resourc
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewayplugincorrelationid_resource.go
+++ b/internal/provider/gatewayplugincorrelationid_resource.go
@@ -8,9 +8,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -89,6 +91,9 @@ func (r *GatewayPluginCorrelationIDResource) Schema(ctx context.Context, req res
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -158,6 +163,9 @@ func (r *GatewayPluginCorrelationIDResource) Schema(ctx context.Context, req res
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -169,6 +177,9 @@ func (r *GatewayPluginCorrelationIDResource) Schema(ctx context.Context, req res
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewayplugincors_resource.go
+++ b/internal/provider/gatewayplugincors_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -166,6 +168,9 @@ func (r *GatewayPluginCorsResource) Schema(ctx context.Context, req resource.Sch
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -177,6 +182,9 @@ func (r *GatewayPluginCorsResource) Schema(ctx context.Context, req resource.Sch
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewayplugindatadog_resource.go
+++ b/internal/provider/gatewayplugindatadog_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -241,6 +243,9 @@ func (r *GatewayPluginDatadogResource) Schema(ctx context.Context, req resource.
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -310,6 +315,9 @@ func (r *GatewayPluginDatadogResource) Schema(ctx context.Context, req resource.
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -321,6 +329,9 @@ func (r *GatewayPluginDatadogResource) Schema(ctx context.Context, req resource.
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewayplugindatadogtracing_resource.go
+++ b/internal/provider/gatewayplugindatadogtracing_resource.go
@@ -8,9 +8,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -108,6 +110,9 @@ func (r *GatewayPluginDatadogTracingResource) Schema(ctx context.Context, req re
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -177,6 +182,9 @@ func (r *GatewayPluginDatadogTracingResource) Schema(ctx context.Context, req re
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -188,6 +196,9 @@ func (r *GatewayPluginDatadogTracingResource) Schema(ctx context.Context, req re
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewayplugindegraphql_resource.go
+++ b/internal/provider/gatewayplugindegraphql_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -127,6 +129,9 @@ func (r *GatewayPluginDegraphqlResource) Schema(ctx context.Context, req resourc
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -138,6 +143,9 @@ func (r *GatewayPluginDegraphqlResource) Schema(ctx context.Context, req resourc
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginexittransformer_resource.go
+++ b/internal/provider/gatewaypluginexittransformer_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -80,6 +82,9 @@ func (r *GatewayPluginExitTransformerResource) Schema(ctx context.Context, req r
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -149,6 +154,9 @@ func (r *GatewayPluginExitTransformerResource) Schema(ctx context.Context, req r
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -160,6 +168,9 @@ func (r *GatewayPluginExitTransformerResource) Schema(ctx context.Context, req r
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginfilelog_resource.go
+++ b/internal/provider/gatewaypluginfilelog_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -92,6 +94,9 @@ func (r *GatewayPluginFileLogResource) Schema(ctx context.Context, req resource.
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -161,6 +166,9 @@ func (r *GatewayPluginFileLogResource) Schema(ctx context.Context, req resource.
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -172,6 +180,9 @@ func (r *GatewayPluginFileLogResource) Schema(ctx context.Context, req resource.
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginforwardproxy_resource.go
+++ b/internal/provider/gatewaypluginforwardproxy_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -131,6 +133,9 @@ func (r *GatewayPluginForwardProxyResource) Schema(ctx context.Context, req reso
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -200,6 +205,9 @@ func (r *GatewayPluginForwardProxyResource) Schema(ctx context.Context, req reso
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -211,6 +219,9 @@ func (r *GatewayPluginForwardProxyResource) Schema(ctx context.Context, req reso
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewayplugingraphqlproxycacheadvanced_resource.go
+++ b/internal/provider/gatewayplugingraphqlproxycacheadvanced_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -283,6 +285,9 @@ func (r *GatewayPluginGraphqlProxyCacheAdvancedResource) Schema(ctx context.Cont
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -352,6 +357,9 @@ func (r *GatewayPluginGraphqlProxyCacheAdvancedResource) Schema(ctx context.Cont
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -363,6 +371,9 @@ func (r *GatewayPluginGraphqlProxyCacheAdvancedResource) Schema(ctx context.Cont
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewayplugingraphqlratelimitingadvanced_resource.go
+++ b/internal/provider/gatewayplugingraphqlratelimitingadvanced_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -332,6 +334,9 @@ func (r *GatewayPluginGraphqlRateLimitingAdvancedResource) Schema(ctx context.Co
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -401,6 +406,9 @@ func (r *GatewayPluginGraphqlRateLimitingAdvancedResource) Schema(ctx context.Co
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -412,6 +420,9 @@ func (r *GatewayPluginGraphqlRateLimitingAdvancedResource) Schema(ctx context.Co
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewayplugingrpcgateway_resource.go
+++ b/internal/provider/gatewayplugingrpcgateway_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -70,6 +72,9 @@ func (r *GatewayPluginGrpcGatewayResource) Schema(ctx context.Context, req resou
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -139,6 +144,9 @@ func (r *GatewayPluginGrpcGatewayResource) Schema(ctx context.Context, req resou
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -150,6 +158,9 @@ func (r *GatewayPluginGrpcGatewayResource) Schema(ctx context.Context, req resou
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewayplugingrpcweb_resource.go
+++ b/internal/provider/gatewayplugingrpcweb_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -80,6 +82,9 @@ func (r *GatewayPluginGrpcWebResource) Schema(ctx context.Context, req resource.
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -149,6 +154,9 @@ func (r *GatewayPluginGrpcWebResource) Schema(ctx context.Context, req resource.
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -160,6 +168,9 @@ func (r *GatewayPluginGrpcWebResource) Schema(ctx context.Context, req resource.
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginheadercertauth_resource.go
+++ b/internal/provider/gatewaypluginheadercertauth_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -239,6 +241,9 @@ func (r *GatewayPluginHeaderCertAuthResource) Schema(ctx context.Context, req re
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -250,6 +255,9 @@ func (r *GatewayPluginHeaderCertAuthResource) Schema(ctx context.Context, req re
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginhmacauth_resource.go
+++ b/internal/provider/gatewaypluginhmacauth_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -159,6 +161,9 @@ func (r *GatewayPluginHmacAuthResource) Schema(ctx context.Context, req resource
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -170,6 +175,9 @@ func (r *GatewayPluginHmacAuthResource) Schema(ctx context.Context, req resource
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginhttplog_resource.go
+++ b/internal/provider/gatewaypluginhttplog_resource.go
@@ -10,9 +10,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -196,6 +198,9 @@ func (r *GatewayPluginHTTPLogResource) Schema(ctx context.Context, req resource.
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -265,6 +270,9 @@ func (r *GatewayPluginHTTPLogResource) Schema(ctx context.Context, req resource.
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -276,6 +284,9 @@ func (r *GatewayPluginHTTPLogResource) Schema(ctx context.Context, req resource.
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewayplugininjectionprotection_resource.go
+++ b/internal/provider/gatewayplugininjectionprotection_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -191,6 +193,9 @@ func (r *GatewayPluginInjectionProtectionResource) Schema(ctx context.Context, r
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -202,6 +207,9 @@ func (r *GatewayPluginInjectionProtectionResource) Schema(ctx context.Context, r
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginiprestriction_resource.go
+++ b/internal/provider/gatewaypluginiprestriction_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -88,6 +90,9 @@ func (r *GatewayPluginIPRestrictionResource) Schema(ctx context.Context, req res
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -99,6 +104,9 @@ func (r *GatewayPluginIPRestrictionResource) Schema(ctx context.Context, req res
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -168,6 +176,9 @@ func (r *GatewayPluginIPRestrictionResource) Schema(ctx context.Context, req res
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -179,6 +190,9 @@ func (r *GatewayPluginIPRestrictionResource) Schema(ctx context.Context, req res
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginjq_resource.go
+++ b/internal/provider/gatewaypluginjq_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -140,6 +142,9 @@ func (r *GatewayPluginJqResource) Schema(ctx context.Context, req resource.Schem
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -209,6 +214,9 @@ func (r *GatewayPluginJqResource) Schema(ctx context.Context, req resource.Schem
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -220,6 +228,9 @@ func (r *GatewayPluginJqResource) Schema(ctx context.Context, req resource.Schem
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginjsonthreatprotection_resource.go
+++ b/internal/provider/gatewaypluginjsonthreatprotection_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -197,6 +199,9 @@ func (r *GatewayPluginJSONThreatProtectionResource) Schema(ctx context.Context, 
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -208,6 +213,9 @@ func (r *GatewayPluginJSONThreatProtectionResource) Schema(ctx context.Context, 
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginjwedecrypt_resource.go
+++ b/internal/provider/gatewaypluginjwedecrypt_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -143,6 +145,9 @@ func (r *GatewayPluginJweDecryptResource) Schema(ctx context.Context, req resour
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -154,6 +159,9 @@ func (r *GatewayPluginJweDecryptResource) Schema(ctx context.Context, req resour
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginjwt_resource.go
+++ b/internal/provider/gatewaypluginjwt_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -176,6 +178,9 @@ func (r *GatewayPluginJwtResource) Schema(ctx context.Context, req resource.Sche
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -187,6 +192,9 @@ func (r *GatewayPluginJwtResource) Schema(ctx context.Context, req resource.Sche
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginjwtsigner_resource.go
+++ b/internal/provider/gatewaypluginjwtsigner_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -666,6 +668,9 @@ func (r *GatewayPluginJwtSignerResource) Schema(ctx context.Context, req resourc
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -677,6 +682,9 @@ func (r *GatewayPluginJwtSignerResource) Schema(ctx context.Context, req resourc
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginkafkalog_resource.go
+++ b/internal/provider/gatewaypluginkafkalog_resource.go
@@ -10,9 +10,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -239,6 +241,9 @@ func (r *GatewayPluginKafkaLogResource) Schema(ctx context.Context, req resource
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -308,6 +313,9 @@ func (r *GatewayPluginKafkaLogResource) Schema(ctx context.Context, req resource
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -319,6 +327,9 @@ func (r *GatewayPluginKafkaLogResource) Schema(ctx context.Context, req resource
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginkafkaupstream_resource.go
+++ b/internal/provider/gatewaypluginkafkaupstream_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -249,6 +251,9 @@ func (r *GatewayPluginKafkaUpstreamResource) Schema(ctx context.Context, req res
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -318,6 +323,9 @@ func (r *GatewayPluginKafkaUpstreamResource) Schema(ctx context.Context, req res
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -329,6 +337,9 @@ func (r *GatewayPluginKafkaUpstreamResource) Schema(ctx context.Context, req res
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginkeyauth_resource.go
+++ b/internal/provider/gatewaypluginkeyauth_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -163,6 +165,9 @@ func (r *GatewayPluginKeyAuthResource) Schema(ctx context.Context, req resource.
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -174,6 +179,9 @@ func (r *GatewayPluginKeyAuthResource) Schema(ctx context.Context, req resource.
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginkeyauthenc_resource.go
+++ b/internal/provider/gatewaypluginkeyauthenc_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -163,6 +165,9 @@ func (r *GatewayPluginKeyAuthEncResource) Schema(ctx context.Context, req resour
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -174,6 +179,9 @@ func (r *GatewayPluginKeyAuthEncResource) Schema(ctx context.Context, req resour
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginkonnectapplicationauth_resource.go
+++ b/internal/provider/gatewaypluginkonnectapplicationauth_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -1999,6 +2001,9 @@ func (r *GatewayPluginKonnectApplicationAuthResource) Schema(ctx context.Context
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -2010,6 +2015,9 @@ func (r *GatewayPluginKonnectApplicationAuthResource) Schema(ctx context.Context
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginldapauth_resource.go
+++ b/internal/provider/gatewaypluginldapauth_resource.go
@@ -8,9 +8,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -197,6 +199,9 @@ func (r *GatewayPluginLdapAuthResource) Schema(ctx context.Context, req resource
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -208,6 +213,9 @@ func (r *GatewayPluginLdapAuthResource) Schema(ctx context.Context, req resource
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginldapauthadvanced_resource.go
+++ b/internal/provider/gatewaypluginldapauthadvanced_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -239,6 +241,9 @@ func (r *GatewayPluginLdapAuthAdvancedResource) Schema(ctx context.Context, req 
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -250,6 +255,9 @@ func (r *GatewayPluginLdapAuthAdvancedResource) Schema(ctx context.Context, req 
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginloggly_resource.go
+++ b/internal/provider/gatewaypluginloggly_resource.go
@@ -10,9 +10,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -173,6 +175,9 @@ func (r *GatewayPluginLogglyResource) Schema(ctx context.Context, req resource.S
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -242,6 +247,9 @@ func (r *GatewayPluginLogglyResource) Schema(ctx context.Context, req resource.S
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -253,6 +261,9 @@ func (r *GatewayPluginLogglyResource) Schema(ctx context.Context, req resource.S
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginmocking_resource.go
+++ b/internal/provider/gatewaypluginmocking_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -116,6 +118,9 @@ func (r *GatewayPluginMockingResource) Schema(ctx context.Context, req resource.
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -185,6 +190,9 @@ func (r *GatewayPluginMockingResource) Schema(ctx context.Context, req resource.
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -196,6 +204,9 @@ func (r *GatewayPluginMockingResource) Schema(ctx context.Context, req resource.
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginmtlsauth_resource.go
+++ b/internal/provider/gatewaypluginmtlsauth_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -223,6 +225,9 @@ func (r *GatewayPluginMtlsAuthResource) Schema(ctx context.Context, req resource
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -234,6 +239,9 @@ func (r *GatewayPluginMtlsAuthResource) Schema(ctx context.Context, req resource
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginoasvalidation_resource.go
+++ b/internal/provider/gatewaypluginoasvalidation_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -140,6 +142,9 @@ func (r *GatewayPluginOasValidationResource) Schema(ctx context.Context, req res
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -209,6 +214,9 @@ func (r *GatewayPluginOasValidationResource) Schema(ctx context.Context, req res
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -220,6 +228,9 @@ func (r *GatewayPluginOasValidationResource) Schema(ctx context.Context, req res
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginoauth2_resource.go
+++ b/internal/provider/gatewaypluginoauth2_resource.go
@@ -8,9 +8,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -221,6 +223,9 @@ func (r *GatewayPluginOauth2Resource) Schema(ctx context.Context, req resource.S
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -232,6 +237,9 @@ func (r *GatewayPluginOauth2Resource) Schema(ctx context.Context, req resource.S
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginoauth2introspection_resource.go
+++ b/internal/provider/gatewaypluginoauth2introspection_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -202,6 +204,9 @@ func (r *GatewayPluginOauth2IntrospectionResource) Schema(ctx context.Context, r
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -213,6 +218,9 @@ func (r *GatewayPluginOauth2IntrospectionResource) Schema(ctx context.Context, r
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginopa_resource.go
+++ b/internal/provider/gatewaypluginopa_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -188,6 +190,9 @@ func (r *GatewayPluginOpaResource) Schema(ctx context.Context, req resource.Sche
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -199,6 +204,9 @@ func (r *GatewayPluginOpaResource) Schema(ctx context.Context, req resource.Sche
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginopenidconnect_resource.go
+++ b/internal/provider/gatewaypluginopenidconnect_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -1893,6 +1895,9 @@ func (r *GatewayPluginOpenidConnectResource) Schema(ctx context.Context, req res
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -1904,6 +1909,9 @@ func (r *GatewayPluginOpenidConnectResource) Schema(ctx context.Context, req res
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginopentelemetry_resource.go
+++ b/internal/provider/gatewaypluginopentelemetry_resource.go
@@ -10,9 +10,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -257,6 +259,9 @@ func (r *GatewayPluginOpentelemetryResource) Schema(ctx context.Context, req res
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -326,6 +331,9 @@ func (r *GatewayPluginOpentelemetryResource) Schema(ctx context.Context, req res
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -337,6 +345,9 @@ func (r *GatewayPluginOpentelemetryResource) Schema(ctx context.Context, req res
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginpostfunction_resource.go
+++ b/internal/provider/gatewaypluginpostfunction_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -172,6 +174,9 @@ func (r *GatewayPluginPostFunctionResource) Schema(ctx context.Context, req reso
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -183,6 +188,9 @@ func (r *GatewayPluginPostFunctionResource) Schema(ctx context.Context, req reso
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginprefunction_resource.go
+++ b/internal/provider/gatewaypluginprefunction_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -172,6 +174,9 @@ func (r *GatewayPluginPreFunctionResource) Schema(ctx context.Context, req resou
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -183,6 +188,9 @@ func (r *GatewayPluginPreFunctionResource) Schema(ctx context.Context, req resou
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginprometheus_resource.go
+++ b/internal/provider/gatewaypluginprometheus_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -95,6 +97,9 @@ func (r *GatewayPluginPrometheusResource) Schema(ctx context.Context, req resour
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -164,6 +169,9 @@ func (r *GatewayPluginPrometheusResource) Schema(ctx context.Context, req resour
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -175,6 +183,9 @@ func (r *GatewayPluginPrometheusResource) Schema(ctx context.Context, req resour
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginproxycache_resource.go
+++ b/internal/provider/gatewaypluginproxycache_resource.go
@@ -8,9 +8,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -155,6 +157,9 @@ func (r *GatewayPluginProxyCacheResource) Schema(ctx context.Context, req resour
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -166,6 +171,9 @@ func (r *GatewayPluginProxyCacheResource) Schema(ctx context.Context, req resour
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -235,6 +243,9 @@ func (r *GatewayPluginProxyCacheResource) Schema(ctx context.Context, req resour
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -246,6 +257,9 @@ func (r *GatewayPluginProxyCacheResource) Schema(ctx context.Context, req resour
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginproxycacheadvanced_resource.go
+++ b/internal/provider/gatewaypluginproxycacheadvanced_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -342,6 +344,9 @@ func (r *GatewayPluginProxyCacheAdvancedResource) Schema(ctx context.Context, re
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -353,6 +358,9 @@ func (r *GatewayPluginProxyCacheAdvancedResource) Schema(ctx context.Context, re
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -422,6 +430,9 @@ func (r *GatewayPluginProxyCacheAdvancedResource) Schema(ctx context.Context, re
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -433,6 +444,9 @@ func (r *GatewayPluginProxyCacheAdvancedResource) Schema(ctx context.Context, re
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginratelimiting_resource.go
+++ b/internal/provider/gatewaypluginratelimiting_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -220,6 +222,9 @@ func (r *GatewayPluginRateLimitingResource) Schema(ctx context.Context, req reso
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -231,6 +236,9 @@ func (r *GatewayPluginRateLimitingResource) Schema(ctx context.Context, req reso
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -300,6 +308,9 @@ func (r *GatewayPluginRateLimitingResource) Schema(ctx context.Context, req reso
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -311,6 +322,9 @@ func (r *GatewayPluginRateLimitingResource) Schema(ctx context.Context, req reso
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginratelimitingadvanced_resource.go
+++ b/internal/provider/gatewaypluginratelimitingadvanced_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -379,6 +381,9 @@ func (r *GatewayPluginRateLimitingAdvancedResource) Schema(ctx context.Context, 
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -390,6 +395,9 @@ func (r *GatewayPluginRateLimitingAdvancedResource) Schema(ctx context.Context, 
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -459,6 +467,9 @@ func (r *GatewayPluginRateLimitingAdvancedResource) Schema(ctx context.Context, 
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -470,6 +481,9 @@ func (r *GatewayPluginRateLimitingAdvancedResource) Schema(ctx context.Context, 
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginredirect_resource.go
+++ b/internal/provider/gatewaypluginredirect_resource.go
@@ -8,9 +8,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -86,6 +88,9 @@ func (r *GatewayPluginRedirectResource) Schema(ctx context.Context, req resource
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -97,6 +102,9 @@ func (r *GatewayPluginRedirectResource) Schema(ctx context.Context, req resource
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -166,6 +174,9 @@ func (r *GatewayPluginRedirectResource) Schema(ctx context.Context, req resource
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -177,6 +188,9 @@ func (r *GatewayPluginRedirectResource) Schema(ctx context.Context, req resource
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginrequestsizelimiting_resource.go
+++ b/internal/provider/gatewaypluginrequestsizelimiting_resource.go
@@ -8,9 +8,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -89,6 +91,9 @@ func (r *GatewayPluginRequestSizeLimitingResource) Schema(ctx context.Context, r
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -158,6 +163,9 @@ func (r *GatewayPluginRequestSizeLimitingResource) Schema(ctx context.Context, r
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -169,6 +177,9 @@ func (r *GatewayPluginRequestSizeLimitingResource) Schema(ctx context.Context, r
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginrequesttermination_resource.go
+++ b/internal/provider/gatewaypluginrequesttermination_resource.go
@@ -8,9 +8,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -101,6 +103,9 @@ func (r *GatewayPluginRequestTerminationResource) Schema(ctx context.Context, re
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -112,6 +117,9 @@ func (r *GatewayPluginRequestTerminationResource) Schema(ctx context.Context, re
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -181,6 +189,9 @@ func (r *GatewayPluginRequestTerminationResource) Schema(ctx context.Context, re
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -192,6 +203,9 @@ func (r *GatewayPluginRequestTerminationResource) Schema(ctx context.Context, re
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginrequesttransformer_resource.go
+++ b/internal/provider/gatewaypluginrequesttransformer_resource.go
@@ -8,9 +8,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -186,6 +188,9 @@ func (r *GatewayPluginRequestTransformerResource) Schema(ctx context.Context, re
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -197,6 +202,9 @@ func (r *GatewayPluginRequestTransformerResource) Schema(ctx context.Context, re
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -266,6 +274,9 @@ func (r *GatewayPluginRequestTransformerResource) Schema(ctx context.Context, re
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -277,6 +288,9 @@ func (r *GatewayPluginRequestTransformerResource) Schema(ctx context.Context, re
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginrequesttransformeradvanced_resource.go
+++ b/internal/provider/gatewaypluginrequesttransformeradvanced_resource.go
@@ -8,9 +8,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -217,6 +219,9 @@ func (r *GatewayPluginRequestTransformerAdvancedResource) Schema(ctx context.Con
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -228,6 +233,9 @@ func (r *GatewayPluginRequestTransformerAdvancedResource) Schema(ctx context.Con
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -297,6 +305,9 @@ func (r *GatewayPluginRequestTransformerAdvancedResource) Schema(ctx context.Con
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -308,6 +319,9 @@ func (r *GatewayPluginRequestTransformerAdvancedResource) Schema(ctx context.Con
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginrequestvalidator_resource.go
+++ b/internal/provider/gatewaypluginrequestvalidator_resource.go
@@ -8,9 +8,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -169,6 +171,9 @@ func (r *GatewayPluginRequestValidatorResource) Schema(ctx context.Context, req 
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -238,6 +243,9 @@ func (r *GatewayPluginRequestValidatorResource) Schema(ctx context.Context, req 
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -249,6 +257,9 @@ func (r *GatewayPluginRequestValidatorResource) Schema(ctx context.Context, req 
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginresponseratelimiting_resource.go
+++ b/internal/provider/gatewaypluginresponseratelimiting_resource.go
@@ -10,9 +10,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -181,6 +183,9 @@ func (r *GatewayPluginResponseRatelimitingResource) Schema(ctx context.Context, 
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -250,6 +255,9 @@ func (r *GatewayPluginResponseRatelimitingResource) Schema(ctx context.Context, 
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -261,6 +269,9 @@ func (r *GatewayPluginResponseRatelimitingResource) Schema(ctx context.Context, 
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginresponsetransformer_resource.go
+++ b/internal/provider/gatewaypluginresponsetransformer_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -167,6 +169,9 @@ func (r *GatewayPluginResponseTransformerResource) Schema(ctx context.Context, r
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -178,6 +183,9 @@ func (r *GatewayPluginResponseTransformerResource) Schema(ctx context.Context, r
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -247,6 +255,9 @@ func (r *GatewayPluginResponseTransformerResource) Schema(ctx context.Context, r
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -258,6 +269,9 @@ func (r *GatewayPluginResponseTransformerResource) Schema(ctx context.Context, r
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginresponsetransformeradvanced_resource.go
+++ b/internal/provider/gatewaypluginresponsetransformeradvanced_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -223,6 +225,9 @@ func (r *GatewayPluginResponseTransformerAdvancedResource) Schema(ctx context.Co
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -234,6 +239,9 @@ func (r *GatewayPluginResponseTransformerAdvancedResource) Schema(ctx context.Co
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -303,6 +311,9 @@ func (r *GatewayPluginResponseTransformerAdvancedResource) Schema(ctx context.Co
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -314,6 +325,9 @@ func (r *GatewayPluginResponseTransformerAdvancedResource) Schema(ctx context.Co
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginroutebyheader_resource.go
+++ b/internal/provider/gatewaypluginroutebyheader_resource.go
@@ -8,9 +8,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -101,6 +103,9 @@ func (r *GatewayPluginRouteByHeaderResource) Schema(ctx context.Context, req res
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -170,6 +175,9 @@ func (r *GatewayPluginRouteByHeaderResource) Schema(ctx context.Context, req res
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -181,6 +189,9 @@ func (r *GatewayPluginRouteByHeaderResource) Schema(ctx context.Context, req res
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginroutetransformeradvanced_resource.go
+++ b/internal/provider/gatewaypluginroutetransformeradvanced_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -81,6 +83,9 @@ func (r *GatewayPluginRouteTransformerAdvancedResource) Schema(ctx context.Conte
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -150,6 +155,9 @@ func (r *GatewayPluginRouteTransformerAdvancedResource) Schema(ctx context.Conte
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -161,6 +169,9 @@ func (r *GatewayPluginRouteTransformerAdvancedResource) Schema(ctx context.Conte
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginsaml_resource.go
+++ b/internal/provider/gatewaypluginsaml_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -570,6 +572,9 @@ func (r *GatewayPluginSamlResource) Schema(ctx context.Context, req resource.Sch
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -581,6 +586,9 @@ func (r *GatewayPluginSamlResource) Schema(ctx context.Context, req resource.Sch
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginserviceprotection_resource.go
+++ b/internal/provider/gatewaypluginserviceprotection_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -381,6 +383,9 @@ func (r *GatewayPluginServiceProtectionResource) Schema(ctx context.Context, req
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginsession_resource.go
+++ b/internal/provider/gatewaypluginsession_resource.go
@@ -8,9 +8,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -255,6 +257,9 @@ func (r *GatewayPluginSessionResource) Schema(ctx context.Context, req resource.
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -266,6 +271,9 @@ func (r *GatewayPluginSessionResource) Schema(ctx context.Context, req resource.
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginstandardwebhooks_resource.go
+++ b/internal/provider/gatewaypluginstandardwebhooks_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -75,6 +77,9 @@ func (r *GatewayPluginStandardWebhooksResource) Schema(ctx context.Context, req 
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -144,6 +149,9 @@ func (r *GatewayPluginStandardWebhooksResource) Schema(ctx context.Context, req 
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -155,6 +163,9 @@ func (r *GatewayPluginStandardWebhooksResource) Schema(ctx context.Context, req 
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginstatsd_resource.go
+++ b/internal/provider/gatewaypluginstatsd_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -316,6 +318,9 @@ func (r *GatewayPluginStatsdResource) Schema(ctx context.Context, req resource.S
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -385,6 +390,9 @@ func (r *GatewayPluginStatsdResource) Schema(ctx context.Context, req resource.S
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -396,6 +404,9 @@ func (r *GatewayPluginStatsdResource) Schema(ctx context.Context, req resource.S
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginstatsdadvanced_resource.go
+++ b/internal/provider/gatewaypluginstatsdadvanced_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -293,6 +295,9 @@ func (r *GatewayPluginStatsdAdvancedResource) Schema(ctx context.Context, req re
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -362,6 +367,9 @@ func (r *GatewayPluginStatsdAdvancedResource) Schema(ctx context.Context, req re
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -373,6 +381,9 @@ func (r *GatewayPluginStatsdAdvancedResource) Schema(ctx context.Context, req re
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginsyslog_resource.go
+++ b/internal/provider/gatewaypluginsyslog_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -175,6 +177,9 @@ func (r *GatewayPluginSyslogResource) Schema(ctx context.Context, req resource.S
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -244,6 +249,9 @@ func (r *GatewayPluginSyslogResource) Schema(ctx context.Context, req resource.S
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -255,6 +263,9 @@ func (r *GatewayPluginSyslogResource) Schema(ctx context.Context, req resource.S
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewayplugintcplog_resource.go
+++ b/internal/provider/gatewayplugintcplog_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -111,6 +113,9 @@ func (r *GatewayPluginTCPLogResource) Schema(ctx context.Context, req resource.S
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -180,6 +185,9 @@ func (r *GatewayPluginTCPLogResource) Schema(ctx context.Context, req resource.S
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -191,6 +199,9 @@ func (r *GatewayPluginTCPLogResource) Schema(ctx context.Context, req resource.S
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewayplugintlshandshakemodifier_resource.go
+++ b/internal/provider/gatewayplugintlshandshakemodifier_resource.go
@@ -8,9 +8,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -132,6 +134,9 @@ func (r *GatewayPluginTLSHandshakeModifierResource) Schema(ctx context.Context, 
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -143,6 +148,9 @@ func (r *GatewayPluginTLSHandshakeModifierResource) Schema(ctx context.Context, 
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewayplugintlsmetadataheaders_resource.go
+++ b/internal/provider/gatewayplugintlsmetadataheaders_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -152,6 +154,9 @@ func (r *GatewayPluginTLSMetadataHeadersResource) Schema(ctx context.Context, re
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -163,6 +168,9 @@ func (r *GatewayPluginTLSMetadataHeadersResource) Schema(ctx context.Context, re
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginudplog_resource.go
+++ b/internal/provider/gatewaypluginudplog_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -96,6 +98,9 @@ func (r *GatewayPluginUDPLogResource) Schema(ctx context.Context, req resource.S
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -165,6 +170,9 @@ func (r *GatewayPluginUDPLogResource) Schema(ctx context.Context, req resource.S
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -176,6 +184,9 @@ func (r *GatewayPluginUDPLogResource) Schema(ctx context.Context, req resource.S
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginupstreamoauth_resource.go
+++ b/internal/provider/gatewaypluginupstreamoauth_resource.go
@@ -10,9 +10,11 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/mapvalidator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -476,6 +478,9 @@ func (r *GatewayPluginUpstreamOauthResource) Schema(ctx context.Context, req res
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -487,6 +492,9 @@ func (r *GatewayPluginUpstreamOauthResource) Schema(ctx context.Context, req res
 			"consumer_group": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -556,6 +564,9 @@ func (r *GatewayPluginUpstreamOauthResource) Schema(ctx context.Context, req res
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -567,6 +578,9 @@ func (r *GatewayPluginUpstreamOauthResource) Schema(ctx context.Context, req res
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginupstreamtimeout_resource.go
+++ b/internal/provider/gatewaypluginupstreamtimeout_resource.go
@@ -8,9 +8,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -91,6 +93,9 @@ func (r *GatewayPluginUpstreamTimeoutResource) Schema(ctx context.Context, req r
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -160,6 +165,9 @@ func (r *GatewayPluginUpstreamTimeoutResource) Schema(ctx context.Context, req r
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -171,6 +179,9 @@ func (r *GatewayPluginUpstreamTimeoutResource) Schema(ctx context.Context, req r
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginvaultauth_resource.go
+++ b/internal/provider/gatewaypluginvaultauth_resource.go
@@ -7,9 +7,11 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -157,6 +159,9 @@ func (r *GatewayPluginVaultAuthResource) Schema(ctx context.Context, req resourc
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -168,6 +173,9 @@ func (r *GatewayPluginVaultAuthResource) Schema(ctx context.Context, req resourc
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginwebsocketsizelimit_resource.go
+++ b/internal/provider/gatewaypluginwebsocketsizelimit_resource.go
@@ -8,9 +8,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -81,6 +83,9 @@ func (r *GatewayPluginWebsocketSizeLimitResource) Schema(ctx context.Context, re
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -150,6 +155,9 @@ func (r *GatewayPluginWebsocketSizeLimitResource) Schema(ctx context.Context, re
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -161,6 +169,9 @@ func (r *GatewayPluginWebsocketSizeLimitResource) Schema(ctx context.Context, re
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginwebsocketvalidator_resource.go
+++ b/internal/provider/gatewaypluginwebsocketvalidator_resource.go
@@ -8,9 +8,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -172,6 +174,9 @@ func (r *GatewayPluginWebsocketValidatorResource) Schema(ctx context.Context, re
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -241,6 +246,9 @@ func (r *GatewayPluginWebsocketValidatorResource) Schema(ctx context.Context, re
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -252,6 +260,9 @@ func (r *GatewayPluginWebsocketValidatorResource) Schema(ctx context.Context, re
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginxmlthreatprotection_resource.go
+++ b/internal/provider/gatewaypluginxmlthreatprotection_resource.go
@@ -8,9 +8,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -187,6 +189,9 @@ func (r *GatewayPluginXMLThreatProtectionResource) Schema(ctx context.Context, r
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -256,6 +261,9 @@ func (r *GatewayPluginXMLThreatProtectionResource) Schema(ctx context.Context, r
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -267,6 +275,9 @@ func (r *GatewayPluginXMLThreatProtectionResource) Schema(ctx context.Context, r
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewaypluginzipkin_resource.go
+++ b/internal/provider/gatewaypluginzipkin_resource.go
@@ -9,9 +9,11 @@ import (
 	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework-validators/int64validator"
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
@@ -319,6 +321,9 @@ func (r *GatewayPluginZipkinResource) Schema(ctx context.Context, req resource.S
 			"consumer": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -388,6 +393,9 @@ func (r *GatewayPluginZipkinResource) Schema(ctx context.Context, req resource.S
 			"route": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,
@@ -399,6 +407,9 @@ func (r *GatewayPluginZipkinResource) Schema(ctx context.Context, req resource.S
 			"service": schema.SingleNestedAttribute{
 				Computed: true,
 				Optional: true,
+				Default: objectdefault.StaticValue(types.ObjectNull(map[string]attr.Type{
+					"id": types.StringType,
+				})),
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{
 						Computed: true,

--- a/internal/provider/gatewayroute_data_source.go
+++ b/internal/provider/gatewayroute_data_source.go
@@ -45,7 +45,7 @@ type GatewayRouteDataSourceModel struct {
 	RegexPriority           types.Int64                                 `tfsdk:"regex_priority"`
 	RequestBuffering        types.Bool                                  `tfsdk:"request_buffering"`
 	ResponseBuffering       types.Bool                                  `tfsdk:"response_buffering"`
-	Service                 *tfTypes.ACLWithoutParentsConsumer          `tfsdk:"service" tfPlanOnly:"true"`
+	Service                 *tfTypes.ACLWithoutParentsConsumer          `tfsdk:"service"`
 	Snis                    []types.String                              `tfsdk:"snis"`
 	Sources                 []tfTypes.AiProxyAdvancedPluginClusterNodes `tfsdk:"sources"`
 	StripPath               types.Bool                                  `tfsdk:"strip_path"`

--- a/internal/provider/gatewayroute_resource.go
+++ b/internal/provider/gatewayroute_resource.go
@@ -56,7 +56,7 @@ type GatewayRouteResourceModel struct {
 	RegexPriority           types.Int64                                 `tfsdk:"regex_priority"`
 	RequestBuffering        types.Bool                                  `tfsdk:"request_buffering"`
 	ResponseBuffering       types.Bool                                  `tfsdk:"response_buffering"`
-	Service                 *tfTypes.ACLWithoutParentsConsumer          `tfsdk:"service" tfPlanOnly:"true"`
+	Service                 *tfTypes.ACLWithoutParentsConsumer          `tfsdk:"service"`
 	Snis                    []types.String                              `tfsdk:"snis"`
 	Sources                 []tfTypes.AiProxyAdvancedPluginClusterNodes `tfsdk:"sources"`
 	StripPath               types.Bool                                  `tfsdk:"strip_path"`

--- a/internal/provider/gatewayrouteexpression_data_source.go
+++ b/internal/provider/gatewayrouteexpression_data_source.go
@@ -41,7 +41,7 @@ type GatewayRouteExpressionDataSourceModel struct {
 	Protocols               []types.String                     `tfsdk:"protocols"`
 	RequestBuffering        types.Bool                         `tfsdk:"request_buffering"`
 	ResponseBuffering       types.Bool                         `tfsdk:"response_buffering"`
-	Service                 *tfTypes.ACLWithoutParentsConsumer `tfsdk:"service" tfPlanOnly:"true"`
+	Service                 *tfTypes.ACLWithoutParentsConsumer `tfsdk:"service"`
 	StripPath               types.Bool                         `tfsdk:"strip_path"`
 	Tags                    []types.String                     `tfsdk:"tags"`
 	UpdatedAt               types.Int64                        `tfsdk:"updated_at"`

--- a/internal/provider/gatewayrouteexpression_resource.go
+++ b/internal/provider/gatewayrouteexpression_resource.go
@@ -51,7 +51,7 @@ type GatewayRouteExpressionResourceModel struct {
 	Protocols               []types.String                     `tfsdk:"protocols"`
 	RequestBuffering        types.Bool                         `tfsdk:"request_buffering"`
 	ResponseBuffering       types.Bool                         `tfsdk:"response_buffering"`
-	Service                 *tfTypes.ACLWithoutParentsConsumer `tfsdk:"service" tfPlanOnly:"true"`
+	Service                 *tfTypes.ACLWithoutParentsConsumer `tfsdk:"service"`
 	StripPath               types.Bool                         `tfsdk:"strip_path"`
 	Tags                    []types.String                     `tfsdk:"tags"`
 	UpdatedAt               types.Int64                        `tfsdk:"updated_at"`

--- a/internal/provider/gatewayservice_data_source.go
+++ b/internal/provider/gatewayservice_data_source.go
@@ -30,7 +30,7 @@ type GatewayServiceDataSource struct {
 // GatewayServiceDataSourceModel describes the data model.
 type GatewayServiceDataSourceModel struct {
 	CaCertificates    []types.String                     `tfsdk:"ca_certificates"`
-	ClientCertificate *tfTypes.ACLWithoutParentsConsumer `tfsdk:"client_certificate" tfPlanOnly:"true"`
+	ClientCertificate *tfTypes.ACLWithoutParentsConsumer `tfsdk:"client_certificate"`
 	ConnectTimeout    types.Int64                        `tfsdk:"connect_timeout"`
 	ControlPlaneID    types.String                       `tfsdk:"control_plane_id"`
 	CreatedAt         types.Int64                        `tfsdk:"created_at"`

--- a/internal/provider/gatewayservice_resource.go
+++ b/internal/provider/gatewayservice_resource.go
@@ -39,7 +39,7 @@ type GatewayServiceResource struct {
 // GatewayServiceResourceModel describes the resource data model.
 type GatewayServiceResourceModel struct {
 	CaCertificates    []types.String                     `tfsdk:"ca_certificates"`
-	ClientCertificate *tfTypes.ACLWithoutParentsConsumer `tfsdk:"client_certificate" tfPlanOnly:"true"`
+	ClientCertificate *tfTypes.ACLWithoutParentsConsumer `tfsdk:"client_certificate"`
 	ConnectTimeout    types.Int64                        `tfsdk:"connect_timeout"`
 	ControlPlaneID    types.String                       `tfsdk:"control_plane_id"`
 	CreatedAt         types.Int64                        `tfsdk:"created_at"`

--- a/internal/provider/gatewaysni_data_source.go
+++ b/internal/provider/gatewaysni_data_source.go
@@ -29,7 +29,7 @@ type GatewaySNIDataSource struct {
 
 // GatewaySNIDataSourceModel describes the data model.
 type GatewaySNIDataSourceModel struct {
-	Certificate    *tfTypes.ACLWithoutParentsConsumer `tfsdk:"certificate" tfPlanOnly:"true"`
+	Certificate    *tfTypes.ACLWithoutParentsConsumer `tfsdk:"certificate"`
 	ControlPlaneID types.String                       `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                        `tfsdk:"created_at"`
 	ID             types.String                       `tfsdk:"id"`

--- a/internal/provider/gatewaysni_resource.go
+++ b/internal/provider/gatewaysni_resource.go
@@ -36,7 +36,7 @@ type GatewaySNIResource struct {
 
 // GatewaySNIResourceModel describes the resource data model.
 type GatewaySNIResourceModel struct {
-	Certificate    *tfTypes.ACLWithoutParentsConsumer `tfsdk:"certificate" tfPlanOnly:"true"`
+	Certificate    *tfTypes.ACLWithoutParentsConsumer `tfsdk:"certificate"`
 	ControlPlaneID types.String                       `tfsdk:"control_plane_id"`
 	CreatedAt      types.Int64                        `tfsdk:"created_at"`
 	ID             types.String                       `tfsdk:"id"`

--- a/internal/provider/gatewaytarget_data_source.go
+++ b/internal/provider/gatewaytarget_data_source.go
@@ -35,7 +35,7 @@ type GatewayTargetDataSourceModel struct {
 	Tags           []types.String                     `tfsdk:"tags"`
 	Target         types.String                       `tfsdk:"target"`
 	UpdatedAt      types.Number                       `tfsdk:"updated_at"`
-	Upstream       *tfTypes.ACLWithoutParentsConsumer `tfsdk:"upstream" tfPlanOnly:"true"`
+	Upstream       *tfTypes.ACLWithoutParentsConsumer `tfsdk:"upstream"`
 	UpstreamID     types.String                       `tfsdk:"upstream_id"`
 	Weight         types.Int64                        `tfsdk:"weight"`
 }

--- a/internal/provider/gatewaytarget_resource.go
+++ b/internal/provider/gatewaytarget_resource.go
@@ -21,7 +21,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	speakeasy_int64planmodifier "github.com/kong/terraform-provider-konnect/v2/internal/planmodifiers/int64planmodifier"
 	speakeasy_listplanmodifier "github.com/kong/terraform-provider-konnect/v2/internal/planmodifiers/listplanmodifier"
-	speakeasy_objectplanmodifier "github.com/kong/terraform-provider-konnect/v2/internal/planmodifiers/objectplanmodifier"
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect/v2/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect/v2/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect/v2/internal/sdk"
@@ -49,7 +48,7 @@ type GatewayTargetResourceModel struct {
 	Tags           []types.String                     `tfsdk:"tags"`
 	Target         types.String                       `tfsdk:"target"`
 	UpdatedAt      types.Number                       `tfsdk:"updated_at"`
-	Upstream       *tfTypes.ACLWithoutParentsConsumer `tfsdk:"upstream" tfPlanOnly:"true"`
+	Upstream       *tfTypes.ACLWithoutParentsConsumer `tfsdk:"upstream"`
 	UpstreamID     types.String                       `tfsdk:"upstream_id"`
 	Weight         types.Int64                        `tfsdk:"weight"`
 }
@@ -113,7 +112,6 @@ func (r *GatewayTargetResource) Schema(ctx context.Context, req resource.SchemaR
 				})),
 				PlanModifiers: []planmodifier.Object{
 					objectplanmodifier.RequiresReplaceIfConfigured(),
-					speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
 				},
 				Attributes: map[string]schema.Attribute{
 					"id": schema.StringAttribute{

--- a/internal/provider/gatewayupstream_data_source.go
+++ b/internal/provider/gatewayupstream_data_source.go
@@ -30,7 +30,7 @@ type GatewayUpstreamDataSource struct {
 // GatewayUpstreamDataSourceModel describes the data model.
 type GatewayUpstreamDataSourceModel struct {
 	Algorithm              types.String                       `tfsdk:"algorithm"`
-	ClientCertificate      *tfTypes.ACLWithoutParentsConsumer `tfsdk:"client_certificate" tfPlanOnly:"true"`
+	ClientCertificate      *tfTypes.ACLWithoutParentsConsumer `tfsdk:"client_certificate"`
 	ControlPlaneID         types.String                       `tfsdk:"control_plane_id"`
 	CreatedAt              types.Int64                        `tfsdk:"created_at"`
 	HashFallback           types.String                       `tfsdk:"hash_fallback"`

--- a/internal/provider/gatewayupstream_resource.go
+++ b/internal/provider/gatewayupstream_resource.go
@@ -39,7 +39,7 @@ type GatewayUpstreamResource struct {
 // GatewayUpstreamResourceModel describes the resource data model.
 type GatewayUpstreamResourceModel struct {
 	Algorithm              types.String                       `tfsdk:"algorithm"`
-	ClientCertificate      *tfTypes.ACLWithoutParentsConsumer `tfsdk:"client_certificate" tfPlanOnly:"true"`
+	ClientCertificate      *tfTypes.ACLWithoutParentsConsumer `tfsdk:"client_certificate"`
 	ControlPlaneID         types.String                       `tfsdk:"control_plane_id"`
 	CreatedAt              types.Int64                        `tfsdk:"created_at"`
 	HashFallback           types.String                       `tfsdk:"hash_fallback"`

--- a/internal/sdk/models/shared/aclplugin.go
+++ b/internal/sdk/models/shared/aclplugin.go
@@ -171,9 +171,9 @@ type ACLPlugin struct {
 	// A set of strings representing HTTP protocols.
 	Protocols []ACLPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *ACLPluginRoute `json:"route,omitempty"`
+	Route *ACLPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *ACLPluginService `json:"service,omitempty"`
+	Service *ACLPluginService `json:"service"`
 }
 
 func (a ACLPlugin) MarshalJSON() ([]byte, error) {
@@ -282,9 +282,9 @@ type ACLPluginInput struct {
 	// A set of strings representing HTTP protocols.
 	Protocols []ACLPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *ACLPluginRoute `json:"route,omitempty"`
+	Route *ACLPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *ACLPluginService `json:"service,omitempty"`
+	Service *ACLPluginService `json:"service"`
 }
 
 func (a ACLPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/aiazurecontentsafetyplugin.go
+++ b/internal/sdk/models/shared/aiazurecontentsafetyplugin.go
@@ -316,9 +316,9 @@ type AiAzureContentSafetyPlugin struct {
 	// A set of strings representing HTTP protocols.
 	Protocols []AiAzureContentSafetyPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *AiAzureContentSafetyPluginRoute `json:"route,omitempty"`
+	Route *AiAzureContentSafetyPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *AiAzureContentSafetyPluginService `json:"service,omitempty"`
+	Service *AiAzureContentSafetyPluginService `json:"service"`
 }
 
 func (a AiAzureContentSafetyPlugin) MarshalJSON() ([]byte, error) {
@@ -427,9 +427,9 @@ type AiAzureContentSafetyPluginInput struct {
 	// A set of strings representing HTTP protocols.
 	Protocols []AiAzureContentSafetyPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *AiAzureContentSafetyPluginRoute `json:"route,omitempty"`
+	Route *AiAzureContentSafetyPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *AiAzureContentSafetyPluginService `json:"service,omitempty"`
+	Service *AiAzureContentSafetyPluginService `json:"service"`
 }
 
 func (a AiAzureContentSafetyPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/aipromptdecoratorplugin.go
+++ b/internal/sdk/models/shared/aipromptdecoratorplugin.go
@@ -282,15 +282,15 @@ type AiPromptDecoratorPlugin struct {
 	UpdatedAt *int64                        `json:"updated_at,omitempty"`
 	Config    AiPromptDecoratorPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *AiPromptDecoratorPluginConsumer `json:"consumer,omitempty"`
+	Consumer *AiPromptDecoratorPluginConsumer `json:"consumer"`
 	// If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups
-	ConsumerGroup *AiPromptDecoratorPluginConsumerGroup `json:"consumer_group,omitempty"`
+	ConsumerGroup *AiPromptDecoratorPluginConsumerGroup `json:"consumer_group"`
 	// A set of strings representing HTTP protocols.
 	Protocols []AiPromptDecoratorPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *AiPromptDecoratorPluginRoute `json:"route,omitempty"`
+	Route *AiPromptDecoratorPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *AiPromptDecoratorPluginService `json:"service,omitempty"`
+	Service *AiPromptDecoratorPluginService `json:"service"`
 }
 
 func (a AiPromptDecoratorPlugin) MarshalJSON() ([]byte, error) {
@@ -411,15 +411,15 @@ type AiPromptDecoratorPluginInput struct {
 	Tags   []string                      `json:"tags,omitempty"`
 	Config AiPromptDecoratorPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *AiPromptDecoratorPluginConsumer `json:"consumer,omitempty"`
+	Consumer *AiPromptDecoratorPluginConsumer `json:"consumer"`
 	// If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups
-	ConsumerGroup *AiPromptDecoratorPluginConsumerGroup `json:"consumer_group,omitempty"`
+	ConsumerGroup *AiPromptDecoratorPluginConsumerGroup `json:"consumer_group"`
 	// A set of strings representing HTTP protocols.
 	Protocols []AiPromptDecoratorPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *AiPromptDecoratorPluginRoute `json:"route,omitempty"`
+	Route *AiPromptDecoratorPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *AiPromptDecoratorPluginService `json:"service,omitempty"`
+	Service *AiPromptDecoratorPluginService `json:"service"`
 }
 
 func (a AiPromptDecoratorPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/aipromptguardplugin.go
+++ b/internal/sdk/models/shared/aipromptguardplugin.go
@@ -193,15 +193,15 @@ type AiPromptGuardPlugin struct {
 	UpdatedAt *int64                    `json:"updated_at,omitempty"`
 	Config    AiPromptGuardPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *AiPromptGuardPluginConsumer `json:"consumer,omitempty"`
+	Consumer *AiPromptGuardPluginConsumer `json:"consumer"`
 	// If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups
-	ConsumerGroup *AiPromptGuardPluginConsumerGroup `json:"consumer_group,omitempty"`
+	ConsumerGroup *AiPromptGuardPluginConsumerGroup `json:"consumer_group"`
 	// A set of strings representing HTTP protocols.
 	Protocols []AiPromptGuardPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *AiPromptGuardPluginRoute `json:"route,omitempty"`
+	Route *AiPromptGuardPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *AiPromptGuardPluginService `json:"service,omitempty"`
+	Service *AiPromptGuardPluginService `json:"service"`
 }
 
 func (a AiPromptGuardPlugin) MarshalJSON() ([]byte, error) {
@@ -322,15 +322,15 @@ type AiPromptGuardPluginInput struct {
 	Tags   []string                  `json:"tags,omitempty"`
 	Config AiPromptGuardPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *AiPromptGuardPluginConsumer `json:"consumer,omitempty"`
+	Consumer *AiPromptGuardPluginConsumer `json:"consumer"`
 	// If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups
-	ConsumerGroup *AiPromptGuardPluginConsumerGroup `json:"consumer_group,omitempty"`
+	ConsumerGroup *AiPromptGuardPluginConsumerGroup `json:"consumer_group"`
 	// A set of strings representing HTTP protocols.
 	Protocols []AiPromptGuardPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *AiPromptGuardPluginRoute `json:"route,omitempty"`
+	Route *AiPromptGuardPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *AiPromptGuardPluginService `json:"service,omitempty"`
+	Service *AiPromptGuardPluginService `json:"service"`
 }
 
 func (a AiPromptGuardPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/aiprompttemplateplugin.go
+++ b/internal/sdk/models/shared/aiprompttemplateplugin.go
@@ -205,15 +205,15 @@ type AiPromptTemplatePlugin struct {
 	UpdatedAt *int64                       `json:"updated_at,omitempty"`
 	Config    AiPromptTemplatePluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *AiPromptTemplatePluginConsumer `json:"consumer,omitempty"`
+	Consumer *AiPromptTemplatePluginConsumer `json:"consumer"`
 	// If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups
-	ConsumerGroup *AiPromptTemplatePluginConsumerGroup `json:"consumer_group,omitempty"`
+	ConsumerGroup *AiPromptTemplatePluginConsumerGroup `json:"consumer_group"`
 	// A set of strings representing HTTP protocols.
 	Protocols []AiPromptTemplatePluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *AiPromptTemplatePluginRoute `json:"route,omitempty"`
+	Route *AiPromptTemplatePluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *AiPromptTemplatePluginService `json:"service,omitempty"`
+	Service *AiPromptTemplatePluginService `json:"service"`
 }
 
 func (a AiPromptTemplatePlugin) MarshalJSON() ([]byte, error) {
@@ -334,15 +334,15 @@ type AiPromptTemplatePluginInput struct {
 	Tags   []string                     `json:"tags,omitempty"`
 	Config AiPromptTemplatePluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *AiPromptTemplatePluginConsumer `json:"consumer,omitempty"`
+	Consumer *AiPromptTemplatePluginConsumer `json:"consumer"`
 	// If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups
-	ConsumerGroup *AiPromptTemplatePluginConsumerGroup `json:"consumer_group,omitempty"`
+	ConsumerGroup *AiPromptTemplatePluginConsumerGroup `json:"consumer_group"`
 	// A set of strings representing HTTP protocols.
 	Protocols []AiPromptTemplatePluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *AiPromptTemplatePluginRoute `json:"route,omitempty"`
+	Route *AiPromptTemplatePluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *AiPromptTemplatePluginService `json:"service,omitempty"`
+	Service *AiPromptTemplatePluginService `json:"service"`
 }
 
 func (a AiPromptTemplatePluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/aiproxyadvancedplugin.go
+++ b/internal/sdk/models/shared/aiproxyadvancedplugin.go
@@ -1631,15 +1631,15 @@ type AiProxyAdvancedPlugin struct {
 	UpdatedAt *int64                      `json:"updated_at,omitempty"`
 	Config    AiProxyAdvancedPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *AiProxyAdvancedPluginConsumer `json:"consumer,omitempty"`
+	Consumer *AiProxyAdvancedPluginConsumer `json:"consumer"`
 	// If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups
-	ConsumerGroup *AiProxyAdvancedPluginConsumerGroup `json:"consumer_group,omitempty"`
+	ConsumerGroup *AiProxyAdvancedPluginConsumerGroup `json:"consumer_group"`
 	// A set of strings representing HTTP protocols.
 	Protocols []AiProxyAdvancedPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *AiProxyAdvancedPluginRoute `json:"route,omitempty"`
+	Route *AiProxyAdvancedPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *AiProxyAdvancedPluginService `json:"service,omitempty"`
+	Service *AiProxyAdvancedPluginService `json:"service"`
 }
 
 func (a AiProxyAdvancedPlugin) MarshalJSON() ([]byte, error) {
@@ -1760,15 +1760,15 @@ type AiProxyAdvancedPluginInput struct {
 	Tags   []string                    `json:"tags,omitempty"`
 	Config AiProxyAdvancedPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *AiProxyAdvancedPluginConsumer `json:"consumer,omitempty"`
+	Consumer *AiProxyAdvancedPluginConsumer `json:"consumer"`
 	// If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups
-	ConsumerGroup *AiProxyAdvancedPluginConsumerGroup `json:"consumer_group,omitempty"`
+	ConsumerGroup *AiProxyAdvancedPluginConsumerGroup `json:"consumer_group"`
 	// A set of strings representing HTTP protocols.
 	Protocols []AiProxyAdvancedPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *AiProxyAdvancedPluginRoute `json:"route,omitempty"`
+	Route *AiProxyAdvancedPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *AiProxyAdvancedPluginService `json:"service,omitempty"`
+	Service *AiProxyAdvancedPluginService `json:"service"`
 }
 
 func (a AiProxyAdvancedPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/aiproxyplugin.go
+++ b/internal/sdk/models/shared/aiproxyplugin.go
@@ -797,15 +797,15 @@ type AiProxyPlugin struct {
 	UpdatedAt *int64              `json:"updated_at,omitempty"`
 	Config    AiProxyPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *AiProxyPluginConsumer `json:"consumer,omitempty"`
+	Consumer *AiProxyPluginConsumer `json:"consumer"`
 	// If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups
-	ConsumerGroup *AiProxyPluginConsumerGroup `json:"consumer_group,omitempty"`
+	ConsumerGroup *AiProxyPluginConsumerGroup `json:"consumer_group"`
 	// A set of strings representing HTTP protocols.
 	Protocols []AiProxyPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *AiProxyPluginRoute `json:"route,omitempty"`
+	Route *AiProxyPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *AiProxyPluginService `json:"service,omitempty"`
+	Service *AiProxyPluginService `json:"service"`
 }
 
 func (a AiProxyPlugin) MarshalJSON() ([]byte, error) {
@@ -926,15 +926,15 @@ type AiProxyPluginInput struct {
 	Tags   []string            `json:"tags,omitempty"`
 	Config AiProxyPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *AiProxyPluginConsumer `json:"consumer,omitempty"`
+	Consumer *AiProxyPluginConsumer `json:"consumer"`
 	// If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups
-	ConsumerGroup *AiProxyPluginConsumerGroup `json:"consumer_group,omitempty"`
+	ConsumerGroup *AiProxyPluginConsumerGroup `json:"consumer_group"`
 	// A set of strings representing HTTP protocols.
 	Protocols []AiProxyPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *AiProxyPluginRoute `json:"route,omitempty"`
+	Route *AiProxyPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *AiProxyPluginService `json:"service,omitempty"`
+	Service *AiProxyPluginService `json:"service"`
 }
 
 func (a AiProxyPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/airatelimitingadvancedplugin.go
+++ b/internal/sdk/models/shared/airatelimitingadvancedplugin.go
@@ -777,15 +777,15 @@ type AiRateLimitingAdvancedPlugin struct {
 	UpdatedAt *int64                             `json:"updated_at,omitempty"`
 	Config    AiRateLimitingAdvancedPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *AiRateLimitingAdvancedPluginConsumer `json:"consumer,omitempty"`
+	Consumer *AiRateLimitingAdvancedPluginConsumer `json:"consumer"`
 	// If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups
-	ConsumerGroup *AiRateLimitingAdvancedPluginConsumerGroup `json:"consumer_group,omitempty"`
+	ConsumerGroup *AiRateLimitingAdvancedPluginConsumerGroup `json:"consumer_group"`
 	// A set of strings representing HTTP protocols.
 	Protocols []AiRateLimitingAdvancedPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *AiRateLimitingAdvancedPluginRoute `json:"route,omitempty"`
+	Route *AiRateLimitingAdvancedPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *AiRateLimitingAdvancedPluginService `json:"service,omitempty"`
+	Service *AiRateLimitingAdvancedPluginService `json:"service"`
 }
 
 func (a AiRateLimitingAdvancedPlugin) MarshalJSON() ([]byte, error) {
@@ -906,15 +906,15 @@ type AiRateLimitingAdvancedPluginInput struct {
 	Tags   []string                           `json:"tags,omitempty"`
 	Config AiRateLimitingAdvancedPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *AiRateLimitingAdvancedPluginConsumer `json:"consumer,omitempty"`
+	Consumer *AiRateLimitingAdvancedPluginConsumer `json:"consumer"`
 	// If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups
-	ConsumerGroup *AiRateLimitingAdvancedPluginConsumerGroup `json:"consumer_group,omitempty"`
+	ConsumerGroup *AiRateLimitingAdvancedPluginConsumerGroup `json:"consumer_group"`
 	// A set of strings representing HTTP protocols.
 	Protocols []AiRateLimitingAdvancedPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *AiRateLimitingAdvancedPluginRoute `json:"route,omitempty"`
+	Route *AiRateLimitingAdvancedPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *AiRateLimitingAdvancedPluginService `json:"service,omitempty"`
+	Service *AiRateLimitingAdvancedPluginService `json:"service"`
 }
 
 func (a AiRateLimitingAdvancedPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/airequesttransformerplugin.go
+++ b/internal/sdk/models/shared/airequesttransformerplugin.go
@@ -820,13 +820,13 @@ type AiRequestTransformerPlugin struct {
 	UpdatedAt *int64                           `json:"updated_at,omitempty"`
 	Config    AiRequestTransformerPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups
-	ConsumerGroup *AiRequestTransformerPluginConsumerGroup `json:"consumer_group,omitempty"`
+	ConsumerGroup *AiRequestTransformerPluginConsumerGroup `json:"consumer_group"`
 	// A set of strings representing HTTP protocols.
 	Protocols []AiRequestTransformerPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *AiRequestTransformerPluginRoute `json:"route,omitempty"`
+	Route *AiRequestTransformerPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *AiRequestTransformerPluginService `json:"service,omitempty"`
+	Service *AiRequestTransformerPluginService `json:"service"`
 }
 
 func (a AiRequestTransformerPlugin) MarshalJSON() ([]byte, error) {
@@ -940,13 +940,13 @@ type AiRequestTransformerPluginInput struct {
 	Tags   []string                         `json:"tags,omitempty"`
 	Config AiRequestTransformerPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups
-	ConsumerGroup *AiRequestTransformerPluginConsumerGroup `json:"consumer_group,omitempty"`
+	ConsumerGroup *AiRequestTransformerPluginConsumerGroup `json:"consumer_group"`
 	// A set of strings representing HTTP protocols.
 	Protocols []AiRequestTransformerPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *AiRequestTransformerPluginRoute `json:"route,omitempty"`
+	Route *AiRequestTransformerPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *AiRequestTransformerPluginService `json:"service,omitempty"`
+	Service *AiRequestTransformerPluginService `json:"service"`
 }
 
 func (a AiRequestTransformerPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/airesponsetransformerplugin.go
+++ b/internal/sdk/models/shared/airesponsetransformerplugin.go
@@ -841,15 +841,15 @@ type AiResponseTransformerPlugin struct {
 	UpdatedAt *int64                            `json:"updated_at,omitempty"`
 	Config    AiResponseTransformerPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *AiResponseTransformerPluginConsumer `json:"consumer,omitempty"`
+	Consumer *AiResponseTransformerPluginConsumer `json:"consumer"`
 	// If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups
-	ConsumerGroup *AiResponseTransformerPluginConsumerGroup `json:"consumer_group,omitempty"`
+	ConsumerGroup *AiResponseTransformerPluginConsumerGroup `json:"consumer_group"`
 	// A set of strings representing HTTP protocols.
 	Protocols []AiResponseTransformerPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *AiResponseTransformerPluginRoute `json:"route,omitempty"`
+	Route *AiResponseTransformerPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *AiResponseTransformerPluginService `json:"service,omitempty"`
+	Service *AiResponseTransformerPluginService `json:"service"`
 }
 
 func (a AiResponseTransformerPlugin) MarshalJSON() ([]byte, error) {
@@ -970,15 +970,15 @@ type AiResponseTransformerPluginInput struct {
 	Tags   []string                          `json:"tags,omitempty"`
 	Config AiResponseTransformerPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *AiResponseTransformerPluginConsumer `json:"consumer,omitempty"`
+	Consumer *AiResponseTransformerPluginConsumer `json:"consumer"`
 	// If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups
-	ConsumerGroup *AiResponseTransformerPluginConsumerGroup `json:"consumer_group,omitempty"`
+	ConsumerGroup *AiResponseTransformerPluginConsumerGroup `json:"consumer_group"`
 	// A set of strings representing HTTP protocols.
 	Protocols []AiResponseTransformerPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *AiResponseTransformerPluginRoute `json:"route,omitempty"`
+	Route *AiResponseTransformerPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *AiResponseTransformerPluginService `json:"service,omitempty"`
+	Service *AiResponseTransformerPluginService `json:"service"`
 }
 
 func (a AiResponseTransformerPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/aisemanticcacheplugin.go
+++ b/internal/sdk/models/shared/aisemanticcacheplugin.go
@@ -843,15 +843,15 @@ type AiSemanticCachePlugin struct {
 	UpdatedAt *int64                      `json:"updated_at,omitempty"`
 	Config    AiSemanticCachePluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *AiSemanticCachePluginConsumer `json:"consumer,omitempty"`
+	Consumer *AiSemanticCachePluginConsumer `json:"consumer"`
 	// If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups
-	ConsumerGroup *AiSemanticCachePluginConsumerGroup `json:"consumer_group,omitempty"`
+	ConsumerGroup *AiSemanticCachePluginConsumerGroup `json:"consumer_group"`
 	// A set of strings representing HTTP protocols.
 	Protocols []AiSemanticCachePluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *AiSemanticCachePluginRoute `json:"route,omitempty"`
+	Route *AiSemanticCachePluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *AiSemanticCachePluginService `json:"service,omitempty"`
+	Service *AiSemanticCachePluginService `json:"service"`
 }
 
 func (a AiSemanticCachePlugin) MarshalJSON() ([]byte, error) {
@@ -972,15 +972,15 @@ type AiSemanticCachePluginInput struct {
 	Tags   []string                    `json:"tags,omitempty"`
 	Config AiSemanticCachePluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *AiSemanticCachePluginConsumer `json:"consumer,omitempty"`
+	Consumer *AiSemanticCachePluginConsumer `json:"consumer"`
 	// If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups
-	ConsumerGroup *AiSemanticCachePluginConsumerGroup `json:"consumer_group,omitempty"`
+	ConsumerGroup *AiSemanticCachePluginConsumerGroup `json:"consumer_group"`
 	// A set of strings representing HTTP protocols.
 	Protocols []AiSemanticCachePluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *AiSemanticCachePluginRoute `json:"route,omitempty"`
+	Route *AiSemanticCachePluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *AiSemanticCachePluginService `json:"service,omitempty"`
+	Service *AiSemanticCachePluginService `json:"service"`
 }
 
 func (a AiSemanticCachePluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/aisemanticpromptguardplugin.go
+++ b/internal/sdk/models/shared/aisemanticpromptguardplugin.go
@@ -847,15 +847,15 @@ type AiSemanticPromptGuardPlugin struct {
 	UpdatedAt *int64                            `json:"updated_at,omitempty"`
 	Config    AiSemanticPromptGuardPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *AiSemanticPromptGuardPluginConsumer `json:"consumer,omitempty"`
+	Consumer *AiSemanticPromptGuardPluginConsumer `json:"consumer"`
 	// If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups
-	ConsumerGroup *AiSemanticPromptGuardPluginConsumerGroup `json:"consumer_group,omitempty"`
+	ConsumerGroup *AiSemanticPromptGuardPluginConsumerGroup `json:"consumer_group"`
 	// A set of strings representing HTTP protocols.
 	Protocols []AiSemanticPromptGuardPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *AiSemanticPromptGuardPluginRoute `json:"route,omitempty"`
+	Route *AiSemanticPromptGuardPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *AiSemanticPromptGuardPluginService `json:"service,omitempty"`
+	Service *AiSemanticPromptGuardPluginService `json:"service"`
 }
 
 func (a AiSemanticPromptGuardPlugin) MarshalJSON() ([]byte, error) {
@@ -976,15 +976,15 @@ type AiSemanticPromptGuardPluginInput struct {
 	Tags   []string                          `json:"tags,omitempty"`
 	Config AiSemanticPromptGuardPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *AiSemanticPromptGuardPluginConsumer `json:"consumer,omitempty"`
+	Consumer *AiSemanticPromptGuardPluginConsumer `json:"consumer"`
 	// If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups
-	ConsumerGroup *AiSemanticPromptGuardPluginConsumerGroup `json:"consumer_group,omitempty"`
+	ConsumerGroup *AiSemanticPromptGuardPluginConsumerGroup `json:"consumer_group"`
 	// A set of strings representing HTTP protocols.
 	Protocols []AiSemanticPromptGuardPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *AiSemanticPromptGuardPluginRoute `json:"route,omitempty"`
+	Route *AiSemanticPromptGuardPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *AiSemanticPromptGuardPluginService `json:"service,omitempty"`
+	Service *AiSemanticPromptGuardPluginService `json:"service"`
 }
 
 func (a AiSemanticPromptGuardPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/awslambdaplugin.go
+++ b/internal/sdk/models/shared/awslambdaplugin.go
@@ -489,13 +489,13 @@ type AwsLambdaPlugin struct {
 	UpdatedAt *int64                `json:"updated_at,omitempty"`
 	Config    AwsLambdaPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *AwsLambdaPluginConsumer `json:"consumer,omitempty"`
+	Consumer *AwsLambdaPluginConsumer `json:"consumer"`
 	// A set of strings representing HTTP protocols.
 	Protocols []AwsLambdaPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *AwsLambdaPluginRoute `json:"route,omitempty"`
+	Route *AwsLambdaPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *AwsLambdaPluginService `json:"service,omitempty"`
+	Service *AwsLambdaPluginService `json:"service"`
 }
 
 func (a AwsLambdaPlugin) MarshalJSON() ([]byte, error) {
@@ -609,13 +609,13 @@ type AwsLambdaPluginInput struct {
 	Tags   []string              `json:"tags,omitempty"`
 	Config AwsLambdaPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *AwsLambdaPluginConsumer `json:"consumer,omitempty"`
+	Consumer *AwsLambdaPluginConsumer `json:"consumer"`
 	// A set of strings representing HTTP protocols.
 	Protocols []AwsLambdaPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *AwsLambdaPluginRoute `json:"route,omitempty"`
+	Route *AwsLambdaPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *AwsLambdaPluginService `json:"service,omitempty"`
+	Service *AwsLambdaPluginService `json:"service"`
 }
 
 func (a AwsLambdaPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/azurefunctionsplugin.go
+++ b/internal/sdk/models/shared/azurefunctionsplugin.go
@@ -245,13 +245,13 @@ type AzureFunctionsPlugin struct {
 	UpdatedAt *int64                     `json:"updated_at,omitempty"`
 	Config    AzureFunctionsPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *AzureFunctionsPluginConsumer `json:"consumer,omitempty"`
+	Consumer *AzureFunctionsPluginConsumer `json:"consumer"`
 	// A set of strings representing protocols.
 	Protocols []AzureFunctionsPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *AzureFunctionsPluginRoute `json:"route,omitempty"`
+	Route *AzureFunctionsPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *AzureFunctionsPluginService `json:"service,omitempty"`
+	Service *AzureFunctionsPluginService `json:"service"`
 }
 
 func (a AzureFunctionsPlugin) MarshalJSON() ([]byte, error) {
@@ -365,13 +365,13 @@ type AzureFunctionsPluginInput struct {
 	Tags   []string                   `json:"tags,omitempty"`
 	Config AzureFunctionsPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *AzureFunctionsPluginConsumer `json:"consumer,omitempty"`
+	Consumer *AzureFunctionsPluginConsumer `json:"consumer"`
 	// A set of strings representing protocols.
 	Protocols []AzureFunctionsPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *AzureFunctionsPluginRoute `json:"route,omitempty"`
+	Route *AzureFunctionsPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *AzureFunctionsPluginService `json:"service,omitempty"`
+	Service *AzureFunctionsPluginService `json:"service"`
 }
 
 func (a AzureFunctionsPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/basicauthplugin.go
+++ b/internal/sdk/models/shared/basicauthplugin.go
@@ -159,9 +159,9 @@ type BasicAuthPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support tcp and tls.
 	Protocols []BasicAuthPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *BasicAuthPluginRoute `json:"route,omitempty"`
+	Route *BasicAuthPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *BasicAuthPluginService `json:"service,omitempty"`
+	Service *BasicAuthPluginService `json:"service"`
 }
 
 func (b BasicAuthPlugin) MarshalJSON() ([]byte, error) {
@@ -270,9 +270,9 @@ type BasicAuthPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support tcp and tls.
 	Protocols []BasicAuthPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *BasicAuthPluginRoute `json:"route,omitempty"`
+	Route *BasicAuthPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *BasicAuthPluginService `json:"service,omitempty"`
+	Service *BasicAuthPluginService `json:"service"`
 }
 
 func (b BasicAuthPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/botdetectionplugin.go
+++ b/internal/sdk/models/shared/botdetectionplugin.go
@@ -144,9 +144,9 @@ type BotDetectionPlugin struct {
 	// A set of strings representing HTTP protocols.
 	Protocols []BotDetectionPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *BotDetectionPluginRoute `json:"route,omitempty"`
+	Route *BotDetectionPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *BotDetectionPluginService `json:"service,omitempty"`
+	Service *BotDetectionPluginService `json:"service"`
 }
 
 func (b BotDetectionPlugin) MarshalJSON() ([]byte, error) {
@@ -255,9 +255,9 @@ type BotDetectionPluginInput struct {
 	// A set of strings representing HTTP protocols.
 	Protocols []BotDetectionPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *BotDetectionPluginRoute `json:"route,omitempty"`
+	Route *BotDetectionPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *BotDetectionPluginService `json:"service,omitempty"`
+	Service *BotDetectionPluginService `json:"service"`
 }
 
 func (b BotDetectionPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/canaryplugin.go
+++ b/internal/sdk/models/shared/canaryplugin.go
@@ -287,9 +287,9 @@ type CanaryPlugin struct {
 	// A set of strings representing HTTP protocols.
 	Protocols []CanaryPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *CanaryPluginRoute `json:"route,omitempty"`
+	Route *CanaryPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *CanaryPluginService `json:"service,omitempty"`
+	Service *CanaryPluginService `json:"service"`
 }
 
 func (c CanaryPlugin) MarshalJSON() ([]byte, error) {
@@ -398,9 +398,9 @@ type CanaryPluginInput struct {
 	// A set of strings representing HTTP protocols.
 	Protocols []CanaryPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *CanaryPluginRoute `json:"route,omitempty"`
+	Route *CanaryPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *CanaryPluginService `json:"service,omitempty"`
+	Service *CanaryPluginService `json:"service"`
 }
 
 func (c CanaryPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/confluentplugin.go
+++ b/internal/sdk/models/shared/confluentplugin.go
@@ -393,13 +393,13 @@ type ConfluentPlugin struct {
 	UpdatedAt *int64                `json:"updated_at,omitempty"`
 	Config    ConfluentPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *ConfluentPluginConsumer `json:"consumer,omitempty"`
+	Consumer *ConfluentPluginConsumer `json:"consumer"`
 	// A set of strings representing HTTP protocols.
 	Protocols []ConfluentPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *ConfluentPluginRoute `json:"route,omitempty"`
+	Route *ConfluentPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *ConfluentPluginService `json:"service,omitempty"`
+	Service *ConfluentPluginService `json:"service"`
 }
 
 func (c ConfluentPlugin) MarshalJSON() ([]byte, error) {
@@ -513,13 +513,13 @@ type ConfluentPluginInput struct {
 	Tags   []string              `json:"tags,omitempty"`
 	Config ConfluentPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *ConfluentPluginConsumer `json:"consumer,omitempty"`
+	Consumer *ConfluentPluginConsumer `json:"consumer"`
 	// A set of strings representing HTTP protocols.
 	Protocols []ConfluentPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *ConfluentPluginRoute `json:"route,omitempty"`
+	Route *ConfluentPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *ConfluentPluginService `json:"service,omitempty"`
+	Service *ConfluentPluginService `json:"service"`
 }
 
 func (c ConfluentPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/correlationidplugin.go
+++ b/internal/sdk/models/shared/correlationidplugin.go
@@ -193,13 +193,13 @@ type CorrelationIDPlugin struct {
 	UpdatedAt *int64                    `json:"updated_at,omitempty"`
 	Config    CorrelationIDPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *CorrelationIDPluginConsumer `json:"consumer,omitempty"`
+	Consumer *CorrelationIDPluginConsumer `json:"consumer"`
 	// A set of strings representing HTTP protocols.
 	Protocols []CorrelationIDPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *CorrelationIDPluginRoute `json:"route,omitempty"`
+	Route *CorrelationIDPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *CorrelationIDPluginService `json:"service,omitempty"`
+	Service *CorrelationIDPluginService `json:"service"`
 }
 
 func (c CorrelationIDPlugin) MarshalJSON() ([]byte, error) {
@@ -313,13 +313,13 @@ type CorrelationIDPluginInput struct {
 	Tags   []string                  `json:"tags,omitempty"`
 	Config CorrelationIDPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *CorrelationIDPluginConsumer `json:"consumer,omitempty"`
+	Consumer *CorrelationIDPluginConsumer `json:"consumer"`
 	// A set of strings representing HTTP protocols.
 	Protocols []CorrelationIDPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *CorrelationIDPluginRoute `json:"route,omitempty"`
+	Route *CorrelationIDPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *CorrelationIDPluginService `json:"service,omitempty"`
+	Service *CorrelationIDPluginService `json:"service"`
 }
 
 func (c CorrelationIDPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/corsplugin.go
+++ b/internal/sdk/models/shared/corsplugin.go
@@ -245,9 +245,9 @@ type CorsPlugin struct {
 	// A set of strings representing HTTP protocols.
 	Protocols []CorsPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *CorsPluginRoute `json:"route,omitempty"`
+	Route *CorsPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *CorsPluginService `json:"service,omitempty"`
+	Service *CorsPluginService `json:"service"`
 }
 
 func (c CorsPlugin) MarshalJSON() ([]byte, error) {
@@ -356,9 +356,9 @@ type CorsPluginInput struct {
 	// A set of strings representing HTTP protocols.
 	Protocols []CorsPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *CorsPluginRoute `json:"route,omitempty"`
+	Route *CorsPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *CorsPluginService `json:"service,omitempty"`
+	Service *CorsPluginService `json:"service"`
 }
 
 func (c CorsPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/datadogplugin.go
+++ b/internal/sdk/models/shared/datadogplugin.go
@@ -514,13 +514,13 @@ type DatadogPlugin struct {
 	UpdatedAt *int64              `json:"updated_at,omitempty"`
 	Config    DatadogPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *DatadogPluginConsumer `json:"consumer,omitempty"`
+	Consumer *DatadogPluginConsumer `json:"consumer"`
 	// A set of strings representing protocols.
 	Protocols []DatadogPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *DatadogPluginRoute `json:"route,omitempty"`
+	Route *DatadogPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *DatadogPluginService `json:"service,omitempty"`
+	Service *DatadogPluginService `json:"service"`
 }
 
 func (d DatadogPlugin) MarshalJSON() ([]byte, error) {
@@ -634,13 +634,13 @@ type DatadogPluginInput struct {
 	Tags   []string            `json:"tags,omitempty"`
 	Config DatadogPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *DatadogPluginConsumer `json:"consumer,omitempty"`
+	Consumer *DatadogPluginConsumer `json:"consumer"`
 	// A set of strings representing protocols.
 	Protocols []DatadogPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *DatadogPluginRoute `json:"route,omitempty"`
+	Route *DatadogPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *DatadogPluginService `json:"service,omitempty"`
+	Service *DatadogPluginService `json:"service"`
 }
 
 func (d DatadogPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/datadogtracingplugin.go
+++ b/internal/sdk/models/shared/datadogtracingplugin.go
@@ -200,13 +200,13 @@ type DatadogTracingPlugin struct {
 	UpdatedAt *int64                     `json:"updated_at,omitempty"`
 	Config    DatadogTracingPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups
-	ConsumerGroup *DatadogTracingPluginConsumerGroup `json:"consumer_group,omitempty"`
+	ConsumerGroup *DatadogTracingPluginConsumerGroup `json:"consumer_group"`
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support tcp and tls.
 	Protocols []DatadogTracingPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *DatadogTracingPluginRoute `json:"route,omitempty"`
+	Route *DatadogTracingPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *DatadogTracingPluginService `json:"service,omitempty"`
+	Service *DatadogTracingPluginService `json:"service"`
 }
 
 func (d DatadogTracingPlugin) MarshalJSON() ([]byte, error) {
@@ -320,13 +320,13 @@ type DatadogTracingPluginInput struct {
 	Tags   []string                   `json:"tags,omitempty"`
 	Config DatadogTracingPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups
-	ConsumerGroup *DatadogTracingPluginConsumerGroup `json:"consumer_group,omitempty"`
+	ConsumerGroup *DatadogTracingPluginConsumerGroup `json:"consumer_group"`
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support tcp and tls.
 	Protocols []DatadogTracingPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *DatadogTracingPluginRoute `json:"route,omitempty"`
+	Route *DatadogTracingPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *DatadogTracingPluginService `json:"service,omitempty"`
+	Service *DatadogTracingPluginService `json:"service"`
 }
 
 func (d DatadogTracingPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/degraphqlplugin.go
+++ b/internal/sdk/models/shared/degraphqlplugin.go
@@ -135,9 +135,9 @@ type DegraphqlPlugin struct {
 	// A set of strings representing HTTP protocols.
 	Protocols []DegraphqlPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *DegraphqlPluginRoute `json:"route,omitempty"`
+	Route *DegraphqlPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *DegraphqlPluginService `json:"service,omitempty"`
+	Service *DegraphqlPluginService `json:"service"`
 }
 
 func (d DegraphqlPlugin) MarshalJSON() ([]byte, error) {
@@ -246,9 +246,9 @@ type DegraphqlPluginInput struct {
 	// A set of strings representing HTTP protocols.
 	Protocols []DegraphqlPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *DegraphqlPluginRoute `json:"route,omitempty"`
+	Route *DegraphqlPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *DegraphqlPluginService `json:"service,omitempty"`
+	Service *DegraphqlPluginService `json:"service"`
 }
 
 func (d DegraphqlPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/exittransformerplugin.go
+++ b/internal/sdk/models/shared/exittransformerplugin.go
@@ -162,13 +162,13 @@ type ExitTransformerPlugin struct {
 	UpdatedAt *int64                      `json:"updated_at,omitempty"`
 	Config    ExitTransformerPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *ExitTransformerPluginConsumer `json:"consumer,omitempty"`
+	Consumer *ExitTransformerPluginConsumer `json:"consumer"`
 	// A set of strings representing HTTP protocols.
 	Protocols []ExitTransformerPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *ExitTransformerPluginRoute `json:"route,omitempty"`
+	Route *ExitTransformerPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *ExitTransformerPluginService `json:"service,omitempty"`
+	Service *ExitTransformerPluginService `json:"service"`
 }
 
 func (e ExitTransformerPlugin) MarshalJSON() ([]byte, error) {
@@ -282,13 +282,13 @@ type ExitTransformerPluginInput struct {
 	Tags   []string                    `json:"tags,omitempty"`
 	Config ExitTransformerPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *ExitTransformerPluginConsumer `json:"consumer,omitempty"`
+	Consumer *ExitTransformerPluginConsumer `json:"consumer"`
 	// A set of strings representing HTTP protocols.
 	Protocols []ExitTransformerPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *ExitTransformerPluginRoute `json:"route,omitempty"`
+	Route *ExitTransformerPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *ExitTransformerPluginService `json:"service,omitempty"`
+	Service *ExitTransformerPluginService `json:"service"`
 }
 
 func (e ExitTransformerPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/filelogplugin.go
+++ b/internal/sdk/models/shared/filelogplugin.go
@@ -182,13 +182,13 @@ type FileLogPlugin struct {
 	UpdatedAt *int64              `json:"updated_at,omitempty"`
 	Config    FileLogPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *FileLogPluginConsumer `json:"consumer,omitempty"`
+	Consumer *FileLogPluginConsumer `json:"consumer"`
 	// A set of strings representing protocols.
 	Protocols []FileLogPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *FileLogPluginRoute `json:"route,omitempty"`
+	Route *FileLogPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *FileLogPluginService `json:"service,omitempty"`
+	Service *FileLogPluginService `json:"service"`
 }
 
 func (f FileLogPlugin) MarshalJSON() ([]byte, error) {
@@ -302,13 +302,13 @@ type FileLogPluginInput struct {
 	Tags   []string            `json:"tags,omitempty"`
 	Config FileLogPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *FileLogPluginConsumer `json:"consumer,omitempty"`
+	Consumer *FileLogPluginConsumer `json:"consumer"`
 	// A set of strings representing protocols.
 	Protocols []FileLogPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *FileLogPluginRoute `json:"route,omitempty"`
+	Route *FileLogPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *FileLogPluginService `json:"service,omitempty"`
+	Service *FileLogPluginService `json:"service"`
 }
 
 func (f FileLogPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/forwardproxyplugin.go
+++ b/internal/sdk/models/shared/forwardproxyplugin.go
@@ -273,13 +273,13 @@ type ForwardProxyPlugin struct {
 	UpdatedAt *int64                   `json:"updated_at,omitempty"`
 	Config    ForwardProxyPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *ForwardProxyPluginConsumer `json:"consumer,omitempty"`
+	Consumer *ForwardProxyPluginConsumer `json:"consumer"`
 	// A set of strings representing HTTP protocols.
 	Protocols []ForwardProxyPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *ForwardProxyPluginRoute `json:"route,omitempty"`
+	Route *ForwardProxyPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *ForwardProxyPluginService `json:"service,omitempty"`
+	Service *ForwardProxyPluginService `json:"service"`
 }
 
 func (f ForwardProxyPlugin) MarshalJSON() ([]byte, error) {
@@ -393,13 +393,13 @@ type ForwardProxyPluginInput struct {
 	Tags   []string                 `json:"tags,omitempty"`
 	Config ForwardProxyPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *ForwardProxyPluginConsumer `json:"consumer,omitempty"`
+	Consumer *ForwardProxyPluginConsumer `json:"consumer"`
 	// A set of strings representing HTTP protocols.
 	Protocols []ForwardProxyPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *ForwardProxyPluginRoute `json:"route,omitempty"`
+	Route *ForwardProxyPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *ForwardProxyPluginService `json:"service,omitempty"`
+	Service *ForwardProxyPluginService `json:"service"`
 }
 
 func (f ForwardProxyPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/graphqlproxycacheadvancedplugin.go
+++ b/internal/sdk/models/shared/graphqlproxycacheadvancedplugin.go
@@ -491,13 +491,13 @@ type GraphqlProxyCacheAdvancedPlugin struct {
 	UpdatedAt *int64                                `json:"updated_at,omitempty"`
 	Config    GraphqlProxyCacheAdvancedPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *GraphqlProxyCacheAdvancedPluginConsumer `json:"consumer,omitempty"`
+	Consumer *GraphqlProxyCacheAdvancedPluginConsumer `json:"consumer"`
 	// A set of strings representing HTTP protocols.
 	Protocols []GraphqlProxyCacheAdvancedPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *GraphqlProxyCacheAdvancedPluginRoute `json:"route,omitempty"`
+	Route *GraphqlProxyCacheAdvancedPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *GraphqlProxyCacheAdvancedPluginService `json:"service,omitempty"`
+	Service *GraphqlProxyCacheAdvancedPluginService `json:"service"`
 }
 
 func (g GraphqlProxyCacheAdvancedPlugin) MarshalJSON() ([]byte, error) {
@@ -611,13 +611,13 @@ type GraphqlProxyCacheAdvancedPluginInput struct {
 	Tags   []string                              `json:"tags,omitempty"`
 	Config GraphqlProxyCacheAdvancedPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *GraphqlProxyCacheAdvancedPluginConsumer `json:"consumer,omitempty"`
+	Consumer *GraphqlProxyCacheAdvancedPluginConsumer `json:"consumer"`
 	// A set of strings representing HTTP protocols.
 	Protocols []GraphqlProxyCacheAdvancedPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *GraphqlProxyCacheAdvancedPluginRoute `json:"route,omitempty"`
+	Route *GraphqlProxyCacheAdvancedPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *GraphqlProxyCacheAdvancedPluginService `json:"service,omitempty"`
+	Service *GraphqlProxyCacheAdvancedPluginService `json:"service"`
 }
 
 func (g GraphqlProxyCacheAdvancedPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/graphqlratelimitingadvancedplugin.go
+++ b/internal/sdk/models/shared/graphqlratelimitingadvancedplugin.go
@@ -627,13 +627,13 @@ type GraphqlRateLimitingAdvancedPlugin struct {
 	UpdatedAt *int64                                  `json:"updated_at,omitempty"`
 	Config    GraphqlRateLimitingAdvancedPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *GraphqlRateLimitingAdvancedPluginConsumer `json:"consumer,omitempty"`
+	Consumer *GraphqlRateLimitingAdvancedPluginConsumer `json:"consumer"`
 	// A set of strings representing HTTP protocols.
 	Protocols []GraphqlRateLimitingAdvancedPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *GraphqlRateLimitingAdvancedPluginRoute `json:"route,omitempty"`
+	Route *GraphqlRateLimitingAdvancedPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *GraphqlRateLimitingAdvancedPluginService `json:"service,omitempty"`
+	Service *GraphqlRateLimitingAdvancedPluginService `json:"service"`
 }
 
 func (g GraphqlRateLimitingAdvancedPlugin) MarshalJSON() ([]byte, error) {
@@ -747,13 +747,13 @@ type GraphqlRateLimitingAdvancedPluginInput struct {
 	Tags   []string                                `json:"tags,omitempty"`
 	Config GraphqlRateLimitingAdvancedPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *GraphqlRateLimitingAdvancedPluginConsumer `json:"consumer,omitempty"`
+	Consumer *GraphqlRateLimitingAdvancedPluginConsumer `json:"consumer"`
 	// A set of strings representing HTTP protocols.
 	Protocols []GraphqlRateLimitingAdvancedPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *GraphqlRateLimitingAdvancedPluginRoute `json:"route,omitempty"`
+	Route *GraphqlRateLimitingAdvancedPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *GraphqlRateLimitingAdvancedPluginService `json:"service,omitempty"`
+	Service *GraphqlRateLimitingAdvancedPluginService `json:"service"`
 }
 
 func (g GraphqlRateLimitingAdvancedPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/grpcgatewayplugin.go
+++ b/internal/sdk/models/shared/grpcgatewayplugin.go
@@ -164,13 +164,13 @@ type GrpcGatewayPlugin struct {
 	UpdatedAt *int64                  `json:"updated_at,omitempty"`
 	Config    GrpcGatewayPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *GrpcGatewayPluginConsumer `json:"consumer,omitempty"`
+	Consumer *GrpcGatewayPluginConsumer `json:"consumer"`
 	// A set of strings representing protocols.
 	Protocols []GrpcGatewayPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *GrpcGatewayPluginRoute `json:"route,omitempty"`
+	Route *GrpcGatewayPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *GrpcGatewayPluginService `json:"service,omitempty"`
+	Service *GrpcGatewayPluginService `json:"service"`
 }
 
 func (g GrpcGatewayPlugin) MarshalJSON() ([]byte, error) {
@@ -284,13 +284,13 @@ type GrpcGatewayPluginInput struct {
 	Tags   []string                `json:"tags,omitempty"`
 	Config GrpcGatewayPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *GrpcGatewayPluginConsumer `json:"consumer,omitempty"`
+	Consumer *GrpcGatewayPluginConsumer `json:"consumer"`
 	// A set of strings representing protocols.
 	Protocols []GrpcGatewayPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *GrpcGatewayPluginRoute `json:"route,omitempty"`
+	Route *GrpcGatewayPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *GrpcGatewayPluginService `json:"service,omitempty"`
+	Service *GrpcGatewayPluginService `json:"service"`
 }
 
 func (g GrpcGatewayPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/grpcwebplugin.go
+++ b/internal/sdk/models/shared/grpcwebplugin.go
@@ -182,13 +182,13 @@ type GrpcWebPlugin struct {
 	UpdatedAt *int64              `json:"updated_at,omitempty"`
 	Config    GrpcWebPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *GrpcWebPluginConsumer `json:"consumer,omitempty"`
+	Consumer *GrpcWebPluginConsumer `json:"consumer"`
 	// A set of strings representing protocols.
 	Protocols []GrpcWebPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *GrpcWebPluginRoute `json:"route,omitempty"`
+	Route *GrpcWebPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *GrpcWebPluginService `json:"service,omitempty"`
+	Service *GrpcWebPluginService `json:"service"`
 }
 
 func (g GrpcWebPlugin) MarshalJSON() ([]byte, error) {
@@ -302,13 +302,13 @@ type GrpcWebPluginInput struct {
 	Tags   []string            `json:"tags,omitempty"`
 	Config GrpcWebPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *GrpcWebPluginConsumer `json:"consumer,omitempty"`
+	Consumer *GrpcWebPluginConsumer `json:"consumer"`
 	// A set of strings representing protocols.
 	Protocols []GrpcWebPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *GrpcWebPluginRoute `json:"route,omitempty"`
+	Route *GrpcWebPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *GrpcWebPluginService `json:"service,omitempty"`
+	Service *GrpcWebPluginService `json:"service"`
 }
 
 func (g GrpcWebPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/headercertauthplugin.go
+++ b/internal/sdk/models/shared/headercertauthplugin.go
@@ -398,9 +398,9 @@ type HeaderCertAuthPlugin struct {
 	// A set of strings representing HTTP protocols.
 	Protocols []HeaderCertAuthPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *HeaderCertAuthPluginRoute `json:"route,omitempty"`
+	Route *HeaderCertAuthPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *HeaderCertAuthPluginService `json:"service,omitempty"`
+	Service *HeaderCertAuthPluginService `json:"service"`
 }
 
 func (h HeaderCertAuthPlugin) MarshalJSON() ([]byte, error) {
@@ -509,9 +509,9 @@ type HeaderCertAuthPluginInput struct {
 	// A set of strings representing HTTP protocols.
 	Protocols []HeaderCertAuthPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *HeaderCertAuthPluginRoute `json:"route,omitempty"`
+	Route *HeaderCertAuthPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *HeaderCertAuthPluginService `json:"service,omitempty"`
+	Service *HeaderCertAuthPluginService `json:"service"`
 }
 
 func (h HeaderCertAuthPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/hmacauthplugin.go
+++ b/internal/sdk/models/shared/hmacauthplugin.go
@@ -227,9 +227,9 @@ type HmacAuthPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support tcp and tls.
 	Protocols []HmacAuthPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *HmacAuthPluginRoute `json:"route,omitempty"`
+	Route *HmacAuthPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *HmacAuthPluginService `json:"service,omitempty"`
+	Service *HmacAuthPluginService `json:"service"`
 }
 
 func (h HmacAuthPlugin) MarshalJSON() ([]byte, error) {
@@ -338,9 +338,9 @@ type HmacAuthPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support tcp and tls.
 	Protocols []HmacAuthPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *HmacAuthPluginRoute `json:"route,omitempty"`
+	Route *HmacAuthPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *HmacAuthPluginService `json:"service,omitempty"`
+	Service *HmacAuthPluginService `json:"service"`
 }
 
 func (h HmacAuthPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/httplogplugin.go
+++ b/internal/sdk/models/shared/httplogplugin.go
@@ -412,13 +412,13 @@ type HTTPLogPlugin struct {
 	UpdatedAt *int64              `json:"updated_at,omitempty"`
 	Config    HTTPLogPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *HTTPLogPluginConsumer `json:"consumer,omitempty"`
+	Consumer *HTTPLogPluginConsumer `json:"consumer"`
 	// A set of strings representing protocols.
 	Protocols []HTTPLogPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *HTTPLogPluginRoute `json:"route,omitempty"`
+	Route *HTTPLogPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *HTTPLogPluginService `json:"service,omitempty"`
+	Service *HTTPLogPluginService `json:"service"`
 }
 
 func (h HTTPLogPlugin) MarshalJSON() ([]byte, error) {
@@ -532,13 +532,13 @@ type HTTPLogPluginInput struct {
 	Tags   []string            `json:"tags,omitempty"`
 	Config HTTPLogPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *HTTPLogPluginConsumer `json:"consumer,omitempty"`
+	Consumer *HTTPLogPluginConsumer `json:"consumer"`
 	// A set of strings representing protocols.
 	Protocols []HTTPLogPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *HTTPLogPluginRoute `json:"route,omitempty"`
+	Route *HTTPLogPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *HTTPLogPluginService `json:"service,omitempty"`
+	Service *HTTPLogPluginService `json:"service"`
 }
 
 func (h HTTPLogPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/injectionprotectionplugin.go
+++ b/internal/sdk/models/shared/injectionprotectionplugin.go
@@ -295,9 +295,9 @@ type InjectionProtectionPlugin struct {
 	// A set of strings representing HTTP protocols.
 	Protocols []InjectionProtectionPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *InjectionProtectionPluginRoute `json:"route,omitempty"`
+	Route *InjectionProtectionPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *InjectionProtectionPluginService `json:"service,omitempty"`
+	Service *InjectionProtectionPluginService `json:"service"`
 }
 
 func (i InjectionProtectionPlugin) MarshalJSON() ([]byte, error) {
@@ -406,9 +406,9 @@ type InjectionProtectionPluginInput struct {
 	// A set of strings representing HTTP protocols.
 	Protocols []InjectionProtectionPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *InjectionProtectionPluginRoute `json:"route,omitempty"`
+	Route *InjectionProtectionPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *InjectionProtectionPluginService `json:"service,omitempty"`
+	Service *InjectionProtectionPluginService `json:"service"`
 }
 
 func (i InjectionProtectionPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/iprestrictionplugin.go
+++ b/internal/sdk/models/shared/iprestrictionplugin.go
@@ -203,15 +203,15 @@ type IPRestrictionPlugin struct {
 	UpdatedAt *int64                    `json:"updated_at,omitempty"`
 	Config    IPRestrictionPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *IPRestrictionPluginConsumer `json:"consumer,omitempty"`
+	Consumer *IPRestrictionPluginConsumer `json:"consumer"`
 	// If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups
-	ConsumerGroup *IPRestrictionPluginConsumerGroup `json:"consumer_group,omitempty"`
+	ConsumerGroup *IPRestrictionPluginConsumerGroup `json:"consumer_group"`
 	// A set of strings representing protocols.
 	Protocols []IPRestrictionPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *IPRestrictionPluginRoute `json:"route,omitempty"`
+	Route *IPRestrictionPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *IPRestrictionPluginService `json:"service,omitempty"`
+	Service *IPRestrictionPluginService `json:"service"`
 }
 
 func (i IPRestrictionPlugin) MarshalJSON() ([]byte, error) {
@@ -332,15 +332,15 @@ type IPRestrictionPluginInput struct {
 	Tags   []string                  `json:"tags,omitempty"`
 	Config IPRestrictionPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *IPRestrictionPluginConsumer `json:"consumer,omitempty"`
+	Consumer *IPRestrictionPluginConsumer `json:"consumer"`
 	// If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups
-	ConsumerGroup *IPRestrictionPluginConsumerGroup `json:"consumer_group,omitempty"`
+	ConsumerGroup *IPRestrictionPluginConsumerGroup `json:"consumer_group"`
 	// A set of strings representing protocols.
 	Protocols []IPRestrictionPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *IPRestrictionPluginRoute `json:"route,omitempty"`
+	Route *IPRestrictionPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *IPRestrictionPluginService `json:"service,omitempty"`
+	Service *IPRestrictionPluginService `json:"service"`
 }
 
 func (i IPRestrictionPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/jqplugin.go
+++ b/internal/sdk/models/shared/jqplugin.go
@@ -278,13 +278,13 @@ type JqPlugin struct {
 	UpdatedAt *int64         `json:"updated_at,omitempty"`
 	Config    JqPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *JqPluginConsumer `json:"consumer,omitempty"`
+	Consumer *JqPluginConsumer `json:"consumer"`
 	// A set of strings representing HTTP protocols.
 	Protocols []JqPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *JqPluginRoute `json:"route,omitempty"`
+	Route *JqPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *JqPluginService `json:"service,omitempty"`
+	Service *JqPluginService `json:"service"`
 }
 
 func (j JqPlugin) MarshalJSON() ([]byte, error) {
@@ -398,13 +398,13 @@ type JqPluginInput struct {
 	Tags   []string       `json:"tags,omitempty"`
 	Config JqPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *JqPluginConsumer `json:"consumer,omitempty"`
+	Consumer *JqPluginConsumer `json:"consumer"`
 	// A set of strings representing HTTP protocols.
 	Protocols []JqPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *JqPluginRoute `json:"route,omitempty"`
+	Route *JqPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *JqPluginService `json:"service,omitempty"`
+	Service *JqPluginService `json:"service"`
 }
 
 func (j JqPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/jsonthreatprotectionplugin.go
+++ b/internal/sdk/models/shared/jsonthreatprotectionplugin.go
@@ -234,9 +234,9 @@ type JSONThreatProtectionPlugin struct {
 	// A set of strings representing HTTP protocols.
 	Protocols []JSONThreatProtectionPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *JSONThreatProtectionPluginRoute `json:"route,omitempty"`
+	Route *JSONThreatProtectionPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *JSONThreatProtectionPluginService `json:"service,omitempty"`
+	Service *JSONThreatProtectionPluginService `json:"service"`
 }
 
 func (j JSONThreatProtectionPlugin) MarshalJSON() ([]byte, error) {
@@ -345,9 +345,9 @@ type JSONThreatProtectionPluginInput struct {
 	// A set of strings representing HTTP protocols.
 	Protocols []JSONThreatProtectionPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *JSONThreatProtectionPluginRoute `json:"route,omitempty"`
+	Route *JSONThreatProtectionPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *JSONThreatProtectionPluginService `json:"service,omitempty"`
+	Service *JSONThreatProtectionPluginService `json:"service"`
 }
 
 func (j JSONThreatProtectionPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/jwedecryptplugin.go
+++ b/internal/sdk/models/shared/jwedecryptplugin.go
@@ -162,9 +162,9 @@ type JweDecryptPlugin struct {
 	// A set of strings representing HTTP protocols.
 	Protocols []JweDecryptPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *JweDecryptPluginRoute `json:"route,omitempty"`
+	Route *JweDecryptPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *JweDecryptPluginService `json:"service,omitempty"`
+	Service *JweDecryptPluginService `json:"service"`
 }
 
 func (j JweDecryptPlugin) MarshalJSON() ([]byte, error) {
@@ -273,9 +273,9 @@ type JweDecryptPluginInput struct {
 	// A set of strings representing HTTP protocols.
 	Protocols []JweDecryptPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *JweDecryptPluginRoute `json:"route,omitempty"`
+	Route *JweDecryptPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *JweDecryptPluginService `json:"service,omitempty"`
+	Service *JweDecryptPluginService `json:"service"`
 }
 
 func (j JweDecryptPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/jwtplugin.go
+++ b/internal/sdk/models/shared/jwtplugin.go
@@ -242,9 +242,9 @@ type JwtPlugin struct {
 	// A set of strings representing HTTP protocols.
 	Protocols []JwtPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *JwtPluginRoute `json:"route,omitempty"`
+	Route *JwtPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *JwtPluginService `json:"service,omitempty"`
+	Service *JwtPluginService `json:"service"`
 }
 
 func (j JwtPlugin) MarshalJSON() ([]byte, error) {
@@ -353,9 +353,9 @@ type JwtPluginInput struct {
 	// A set of strings representing HTTP protocols.
 	Protocols []JwtPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *JwtPluginRoute `json:"route,omitempty"`
+	Route *JwtPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *JwtPluginService `json:"service,omitempty"`
+	Service *JwtPluginService `json:"service"`
 }
 
 func (j JwtPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/jwtsignerplugin.go
+++ b/internal/sdk/models/shared/jwtsignerplugin.go
@@ -1192,9 +1192,9 @@ type JwtSignerPlugin struct {
 	// A set of strings representing HTTP protocols.
 	Protocols []JwtSignerPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *JwtSignerPluginRoute `json:"route,omitempty"`
+	Route *JwtSignerPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *JwtSignerPluginService `json:"service,omitempty"`
+	Service *JwtSignerPluginService `json:"service"`
 }
 
 func (j JwtSignerPlugin) MarshalJSON() ([]byte, error) {
@@ -1303,9 +1303,9 @@ type JwtSignerPluginInput struct {
 	// A set of strings representing HTTP protocols.
 	Protocols []JwtSignerPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *JwtSignerPluginRoute `json:"route,omitempty"`
+	Route *JwtSignerPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *JwtSignerPluginService `json:"service,omitempty"`
+	Service *JwtSignerPluginService `json:"service"`
 }
 
 func (j JwtSignerPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/kafkalogplugin.go
+++ b/internal/sdk/models/shared/kafkalogplugin.go
@@ -474,13 +474,13 @@ type KafkaLogPlugin struct {
 	UpdatedAt *int64               `json:"updated_at,omitempty"`
 	Config    KafkaLogPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *KafkaLogPluginConsumer `json:"consumer,omitempty"`
+	Consumer *KafkaLogPluginConsumer `json:"consumer"`
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support tcp and tls.
 	Protocols []KafkaLogPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *KafkaLogPluginRoute `json:"route,omitempty"`
+	Route *KafkaLogPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *KafkaLogPluginService `json:"service,omitempty"`
+	Service *KafkaLogPluginService `json:"service"`
 }
 
 func (k KafkaLogPlugin) MarshalJSON() ([]byte, error) {
@@ -594,13 +594,13 @@ type KafkaLogPluginInput struct {
 	Tags   []string             `json:"tags,omitempty"`
 	Config KafkaLogPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *KafkaLogPluginConsumer `json:"consumer,omitempty"`
+	Consumer *KafkaLogPluginConsumer `json:"consumer"`
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support tcp and tls.
 	Protocols []KafkaLogPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *KafkaLogPluginRoute `json:"route,omitempty"`
+	Route *KafkaLogPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *KafkaLogPluginService `json:"service,omitempty"`
+	Service *KafkaLogPluginService `json:"service"`
 }
 
 func (k KafkaLogPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/kafkaupstreamplugin.go
+++ b/internal/sdk/models/shared/kafkaupstreamplugin.go
@@ -496,13 +496,13 @@ type KafkaUpstreamPlugin struct {
 	UpdatedAt *int64                    `json:"updated_at,omitempty"`
 	Config    KafkaUpstreamPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *KafkaUpstreamPluginConsumer `json:"consumer,omitempty"`
+	Consumer *KafkaUpstreamPluginConsumer `json:"consumer"`
 	// A set of strings representing HTTP protocols.
 	Protocols []KafkaUpstreamPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *KafkaUpstreamPluginRoute `json:"route,omitempty"`
+	Route *KafkaUpstreamPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *KafkaUpstreamPluginService `json:"service,omitempty"`
+	Service *KafkaUpstreamPluginService `json:"service"`
 }
 
 func (k KafkaUpstreamPlugin) MarshalJSON() ([]byte, error) {
@@ -616,13 +616,13 @@ type KafkaUpstreamPluginInput struct {
 	Tags   []string                  `json:"tags,omitempty"`
 	Config KafkaUpstreamPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *KafkaUpstreamPluginConsumer `json:"consumer,omitempty"`
+	Consumer *KafkaUpstreamPluginConsumer `json:"consumer"`
 	// A set of strings representing HTTP protocols.
 	Protocols []KafkaUpstreamPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *KafkaUpstreamPluginRoute `json:"route,omitempty"`
+	Route *KafkaUpstreamPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *KafkaUpstreamPluginService `json:"service,omitempty"`
+	Service *KafkaUpstreamPluginService `json:"service"`
 }
 
 func (k KafkaUpstreamPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/keyauthencplugin.go
+++ b/internal/sdk/models/shared/keyauthencplugin.go
@@ -204,9 +204,9 @@ type KeyAuthEncPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support tcp and tls.
 	Protocols []KeyAuthEncPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *KeyAuthEncPluginRoute `json:"route,omitempty"`
+	Route *KeyAuthEncPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *KeyAuthEncPluginService `json:"service,omitempty"`
+	Service *KeyAuthEncPluginService `json:"service"`
 }
 
 func (k KeyAuthEncPlugin) MarshalJSON() ([]byte, error) {
@@ -315,9 +315,9 @@ type KeyAuthEncPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support tcp and tls.
 	Protocols []KeyAuthEncPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *KeyAuthEncPluginRoute `json:"route,omitempty"`
+	Route *KeyAuthEncPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *KeyAuthEncPluginService `json:"service,omitempty"`
+	Service *KeyAuthEncPluginService `json:"service"`
 }
 
 func (k KeyAuthEncPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/keyauthplugin.go
+++ b/internal/sdk/models/shared/keyauthplugin.go
@@ -204,9 +204,9 @@ type KeyAuthPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support tcp and tls.
 	Protocols []KeyAuthPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *KeyAuthPluginRoute `json:"route,omitempty"`
+	Route *KeyAuthPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *KeyAuthPluginService `json:"service,omitempty"`
+	Service *KeyAuthPluginService `json:"service"`
 }
 
 func (k KeyAuthPlugin) MarshalJSON() ([]byte, error) {
@@ -315,9 +315,9 @@ type KeyAuthPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support tcp and tls.
 	Protocols []KeyAuthPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *KeyAuthPluginRoute `json:"route,omitempty"`
+	Route *KeyAuthPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *KeyAuthPluginService `json:"service,omitempty"`
+	Service *KeyAuthPluginService `json:"service"`
 }
 
 func (k KeyAuthPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/konnectapplicationauthplugin.go
+++ b/internal/sdk/models/shared/konnectapplicationauthplugin.go
@@ -4156,9 +4156,9 @@ type KonnectApplicationAuthPlugin struct {
 	// A set of strings representing HTTP protocols.
 	Protocols []KonnectApplicationAuthPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *KonnectApplicationAuthPluginRoute `json:"route,omitempty"`
+	Route *KonnectApplicationAuthPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *KonnectApplicationAuthPluginService `json:"service,omitempty"`
+	Service *KonnectApplicationAuthPluginService `json:"service"`
 }
 
 func (k KonnectApplicationAuthPlugin) MarshalJSON() ([]byte, error) {
@@ -4267,9 +4267,9 @@ type KonnectApplicationAuthPluginInput struct {
 	// A set of strings representing HTTP protocols.
 	Protocols []KonnectApplicationAuthPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *KonnectApplicationAuthPluginRoute `json:"route,omitempty"`
+	Route *KonnectApplicationAuthPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *KonnectApplicationAuthPluginService `json:"service,omitempty"`
+	Service *KonnectApplicationAuthPluginService `json:"service"`
 }
 
 func (k KonnectApplicationAuthPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/ldapauthadvancedplugin.go
+++ b/internal/sdk/models/shared/ldapauthadvancedplugin.go
@@ -365,9 +365,9 @@ type LdapAuthAdvancedPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support tcp and tls.
 	Protocols []LdapAuthAdvancedPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *LdapAuthAdvancedPluginRoute `json:"route,omitempty"`
+	Route *LdapAuthAdvancedPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *LdapAuthAdvancedPluginService `json:"service,omitempty"`
+	Service *LdapAuthAdvancedPluginService `json:"service"`
 }
 
 func (l LdapAuthAdvancedPlugin) MarshalJSON() ([]byte, error) {
@@ -476,9 +476,9 @@ type LdapAuthAdvancedPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support tcp and tls.
 	Protocols []LdapAuthAdvancedPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *LdapAuthAdvancedPluginRoute `json:"route,omitempty"`
+	Route *LdapAuthAdvancedPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *LdapAuthAdvancedPluginService `json:"service,omitempty"`
+	Service *LdapAuthAdvancedPluginService `json:"service"`
 }
 
 func (l LdapAuthAdvancedPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/ldapauthplugin.go
+++ b/internal/sdk/models/shared/ldapauthplugin.go
@@ -258,9 +258,9 @@ type LdapAuthPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support tcp and tls.
 	Protocols []LdapAuthPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *LdapAuthPluginRoute `json:"route,omitempty"`
+	Route *LdapAuthPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *LdapAuthPluginService `json:"service,omitempty"`
+	Service *LdapAuthPluginService `json:"service"`
 }
 
 func (l LdapAuthPlugin) MarshalJSON() ([]byte, error) {
@@ -369,9 +369,9 @@ type LdapAuthPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support tcp and tls.
 	Protocols []LdapAuthPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *LdapAuthPluginRoute `json:"route,omitempty"`
+	Route *LdapAuthPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *LdapAuthPluginService `json:"service,omitempty"`
+	Service *LdapAuthPluginService `json:"service"`
 }
 
 func (l LdapAuthPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/logglyplugin.go
+++ b/internal/sdk/models/shared/logglyplugin.go
@@ -414,13 +414,13 @@ type LogglyPlugin struct {
 	UpdatedAt *int64             `json:"updated_at,omitempty"`
 	Config    LogglyPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *LogglyPluginConsumer `json:"consumer,omitempty"`
+	Consumer *LogglyPluginConsumer `json:"consumer"`
 	// A set of strings representing protocols.
 	Protocols []LogglyPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *LogglyPluginRoute `json:"route,omitempty"`
+	Route *LogglyPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *LogglyPluginService `json:"service,omitempty"`
+	Service *LogglyPluginService `json:"service"`
 }
 
 func (l LogglyPlugin) MarshalJSON() ([]byte, error) {
@@ -534,13 +534,13 @@ type LogglyPluginInput struct {
 	Tags   []string           `json:"tags,omitempty"`
 	Config LogglyPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *LogglyPluginConsumer `json:"consumer,omitempty"`
+	Consumer *LogglyPluginConsumer `json:"consumer"`
 	// A set of strings representing protocols.
 	Protocols []LogglyPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *LogglyPluginRoute `json:"route,omitempty"`
+	Route *LogglyPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *LogglyPluginService `json:"service,omitempty"`
+	Service *LogglyPluginService `json:"service"`
 }
 
 func (l LogglyPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/mockingplugin.go
+++ b/internal/sdk/models/shared/mockingplugin.go
@@ -226,13 +226,13 @@ type MockingPlugin struct {
 	UpdatedAt *int64              `json:"updated_at,omitempty"`
 	Config    MockingPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *MockingPluginConsumer `json:"consumer,omitempty"`
+	Consumer *MockingPluginConsumer `json:"consumer"`
 	// A set of strings representing HTTP protocols.
 	Protocols []MockingPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *MockingPluginRoute `json:"route,omitempty"`
+	Route *MockingPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *MockingPluginService `json:"service,omitempty"`
+	Service *MockingPluginService `json:"service"`
 }
 
 func (m MockingPlugin) MarshalJSON() ([]byte, error) {
@@ -346,13 +346,13 @@ type MockingPluginInput struct {
 	Tags   []string            `json:"tags,omitempty"`
 	Config MockingPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *MockingPluginConsumer `json:"consumer,omitempty"`
+	Consumer *MockingPluginConsumer `json:"consumer"`
 	// A set of strings representing HTTP protocols.
 	Protocols []MockingPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *MockingPluginRoute `json:"route,omitempty"`
+	Route *MockingPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *MockingPluginService `json:"service,omitempty"`
+	Service *MockingPluginService `json:"service"`
 }
 
 func (m MockingPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/mtlsauthplugin.go
+++ b/internal/sdk/models/shared/mtlsauthplugin.go
@@ -353,9 +353,9 @@ type MtlsAuthPlugin struct {
 	// A set of strings representing HTTP protocols.
 	Protocols []MtlsAuthPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *MtlsAuthPluginRoute `json:"route,omitempty"`
+	Route *MtlsAuthPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *MtlsAuthPluginService `json:"service,omitempty"`
+	Service *MtlsAuthPluginService `json:"service"`
 }
 
 func (m MtlsAuthPlugin) MarshalJSON() ([]byte, error) {
@@ -464,9 +464,9 @@ type MtlsAuthPluginInput struct {
 	// A set of strings representing HTTP protocols.
 	Protocols []MtlsAuthPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *MtlsAuthPluginRoute `json:"route,omitempty"`
+	Route *MtlsAuthPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *MtlsAuthPluginService `json:"service,omitempty"`
+	Service *MtlsAuthPluginService `json:"service"`
 }
 
 func (m MtlsAuthPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/oasvalidationplugin.go
+++ b/internal/sdk/models/shared/oasvalidationplugin.go
@@ -271,13 +271,13 @@ type OasValidationPlugin struct {
 	UpdatedAt *int64                    `json:"updated_at,omitempty"`
 	Config    OasValidationPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *OasValidationPluginConsumer `json:"consumer,omitempty"`
+	Consumer *OasValidationPluginConsumer `json:"consumer"`
 	// A set of strings representing HTTP protocols.
 	Protocols []OasValidationPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *OasValidationPluginRoute `json:"route,omitempty"`
+	Route *OasValidationPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *OasValidationPluginService `json:"service,omitempty"`
+	Service *OasValidationPluginService `json:"service"`
 }
 
 func (o OasValidationPlugin) MarshalJSON() ([]byte, error) {
@@ -391,13 +391,13 @@ type OasValidationPluginInput struct {
 	Tags   []string                  `json:"tags,omitempty"`
 	Config OasValidationPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *OasValidationPluginConsumer `json:"consumer,omitempty"`
+	Consumer *OasValidationPluginConsumer `json:"consumer"`
 	// A set of strings representing HTTP protocols.
 	Protocols []OasValidationPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *OasValidationPluginRoute `json:"route,omitempty"`
+	Route *OasValidationPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *OasValidationPluginService `json:"service,omitempty"`
+	Service *OasValidationPluginService `json:"service"`
 }
 
 func (o OasValidationPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/oauth2introspectionplugin.go
+++ b/internal/sdk/models/shared/oauth2introspectionplugin.go
@@ -270,9 +270,9 @@ type Oauth2IntrospectionPlugin struct {
 	// A set of strings representing HTTP protocols.
 	Protocols []Oauth2IntrospectionPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *Oauth2IntrospectionPluginRoute `json:"route,omitempty"`
+	Route *Oauth2IntrospectionPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *Oauth2IntrospectionPluginService `json:"service,omitempty"`
+	Service *Oauth2IntrospectionPluginService `json:"service"`
 }
 
 func (o Oauth2IntrospectionPlugin) MarshalJSON() ([]byte, error) {
@@ -381,9 +381,9 @@ type Oauth2IntrospectionPluginInput struct {
 	// A set of strings representing HTTP protocols.
 	Protocols []Oauth2IntrospectionPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *Oauth2IntrospectionPluginRoute `json:"route,omitempty"`
+	Route *Oauth2IntrospectionPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *Oauth2IntrospectionPluginService `json:"service,omitempty"`
+	Service *Oauth2IntrospectionPluginService `json:"service"`
 }
 
 func (o Oauth2IntrospectionPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/oauth2plugin.go
+++ b/internal/sdk/models/shared/oauth2plugin.go
@@ -323,9 +323,9 @@ type Oauth2Plugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support tcp and tls.
 	Protocols []Oauth2PluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *Oauth2PluginRoute `json:"route,omitempty"`
+	Route *Oauth2PluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *Oauth2PluginService `json:"service,omitempty"`
+	Service *Oauth2PluginService `json:"service"`
 }
 
 func (o Oauth2Plugin) MarshalJSON() ([]byte, error) {
@@ -434,9 +434,9 @@ type Oauth2PluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support tcp and tls.
 	Protocols []Oauth2PluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *Oauth2PluginRoute `json:"route,omitempty"`
+	Route *Oauth2PluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *Oauth2PluginService `json:"service,omitempty"`
+	Service *Oauth2PluginService `json:"service"`
 }
 
 func (o Oauth2PluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/opaplugin.go
+++ b/internal/sdk/models/shared/opaplugin.go
@@ -251,9 +251,9 @@ type OpaPlugin struct {
 	// A set of strings representing HTTP protocols.
 	Protocols []OpaPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *OpaPluginRoute `json:"route,omitempty"`
+	Route *OpaPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *OpaPluginService `json:"service,omitempty"`
+	Service *OpaPluginService `json:"service"`
 }
 
 func (o OpaPlugin) MarshalJSON() ([]byte, error) {
@@ -362,9 +362,9 @@ type OpaPluginInput struct {
 	// A set of strings representing HTTP protocols.
 	Protocols []OpaPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *OpaPluginRoute `json:"route,omitempty"`
+	Route *OpaPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *OpaPluginService `json:"service,omitempty"`
+	Service *OpaPluginService `json:"service"`
 }
 
 func (o OpaPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/openidconnectplugin.go
+++ b/internal/sdk/models/shared/openidconnectplugin.go
@@ -4011,9 +4011,9 @@ type OpenidConnectPlugin struct {
 	// A set of strings representing HTTP protocols.
 	Protocols []OpenidConnectPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *OpenidConnectPluginRoute `json:"route,omitempty"`
+	Route *OpenidConnectPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *OpenidConnectPluginService `json:"service,omitempty"`
+	Service *OpenidConnectPluginService `json:"service"`
 }
 
 func (o OpenidConnectPlugin) MarshalJSON() ([]byte, error) {
@@ -4122,9 +4122,9 @@ type OpenidConnectPluginInput struct {
 	// A set of strings representing HTTP protocols.
 	Protocols []OpenidConnectPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *OpenidConnectPluginRoute `json:"route,omitempty"`
+	Route *OpenidConnectPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *OpenidConnectPluginService `json:"service,omitempty"`
+	Service *OpenidConnectPluginService `json:"service"`
 }
 
 func (o OpenidConnectPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/opentelemetryplugin.go
+++ b/internal/sdk/models/shared/opentelemetryplugin.go
@@ -581,13 +581,13 @@ type OpentelemetryPlugin struct {
 	UpdatedAt *int64                    `json:"updated_at,omitempty"`
 	Config    OpentelemetryPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *OpentelemetryPluginConsumer `json:"consumer,omitempty"`
+	Consumer *OpentelemetryPluginConsumer `json:"consumer"`
 	// A set of strings representing HTTP protocols.
 	Protocols []OpentelemetryPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *OpentelemetryPluginRoute `json:"route,omitempty"`
+	Route *OpentelemetryPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *OpentelemetryPluginService `json:"service,omitempty"`
+	Service *OpentelemetryPluginService `json:"service"`
 }
 
 func (o OpentelemetryPlugin) MarshalJSON() ([]byte, error) {
@@ -701,13 +701,13 @@ type OpentelemetryPluginInput struct {
 	Tags   []string                  `json:"tags,omitempty"`
 	Config OpentelemetryPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *OpentelemetryPluginConsumer `json:"consumer,omitempty"`
+	Consumer *OpentelemetryPluginConsumer `json:"consumer"`
 	// A set of strings representing HTTP protocols.
 	Protocols []OpentelemetryPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *OpentelemetryPluginRoute `json:"route,omitempty"`
+	Route *OpentelemetryPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *OpentelemetryPluginService `json:"service,omitempty"`
+	Service *OpentelemetryPluginService `json:"service"`
 }
 
 func (o OpentelemetryPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/postfunctionplugin.go
+++ b/internal/sdk/models/shared/postfunctionplugin.go
@@ -225,9 +225,9 @@ type PostFunctionPlugin struct {
 	// A set of strings representing protocols.
 	Protocols []PostFunctionPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *PostFunctionPluginRoute `json:"route,omitempty"`
+	Route *PostFunctionPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *PostFunctionPluginService `json:"service,omitempty"`
+	Service *PostFunctionPluginService `json:"service"`
 }
 
 func (p PostFunctionPlugin) MarshalJSON() ([]byte, error) {
@@ -336,9 +336,9 @@ type PostFunctionPluginInput struct {
 	// A set of strings representing protocols.
 	Protocols []PostFunctionPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *PostFunctionPluginRoute `json:"route,omitempty"`
+	Route *PostFunctionPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *PostFunctionPluginService `json:"service,omitempty"`
+	Service *PostFunctionPluginService `json:"service"`
 }
 
 func (p PostFunctionPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/prefunctionplugin.go
+++ b/internal/sdk/models/shared/prefunctionplugin.go
@@ -225,9 +225,9 @@ type PreFunctionPlugin struct {
 	// A set of strings representing protocols.
 	Protocols []PreFunctionPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *PreFunctionPluginRoute `json:"route,omitempty"`
+	Route *PreFunctionPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *PreFunctionPluginService `json:"service,omitempty"`
+	Service *PreFunctionPluginService `json:"service"`
 }
 
 func (p PreFunctionPlugin) MarshalJSON() ([]byte, error) {
@@ -336,9 +336,9 @@ type PreFunctionPluginInput struct {
 	// A set of strings representing protocols.
 	Protocols []PreFunctionPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *PreFunctionPluginRoute `json:"route,omitempty"`
+	Route *PreFunctionPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *PreFunctionPluginService `json:"service,omitempty"`
+	Service *PreFunctionPluginService `json:"service"`
 }
 
 func (p PreFunctionPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/prometheusplugin.go
+++ b/internal/sdk/models/shared/prometheusplugin.go
@@ -209,13 +209,13 @@ type PrometheusPlugin struct {
 	UpdatedAt *int64                 `json:"updated_at,omitempty"`
 	Config    PrometheusPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *PrometheusPluginConsumer `json:"consumer,omitempty"`
+	Consumer *PrometheusPluginConsumer `json:"consumer"`
 	// A set of strings representing protocols.
 	Protocols []PrometheusPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *PrometheusPluginRoute `json:"route,omitempty"`
+	Route *PrometheusPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *PrometheusPluginService `json:"service,omitempty"`
+	Service *PrometheusPluginService `json:"service"`
 }
 
 func (p PrometheusPlugin) MarshalJSON() ([]byte, error) {
@@ -329,13 +329,13 @@ type PrometheusPluginInput struct {
 	Tags   []string               `json:"tags,omitempty"`
 	Config PrometheusPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *PrometheusPluginConsumer `json:"consumer,omitempty"`
+	Consumer *PrometheusPluginConsumer `json:"consumer"`
 	// A set of strings representing protocols.
 	Protocols []PrometheusPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *PrometheusPluginRoute `json:"route,omitempty"`
+	Route *PrometheusPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *PrometheusPluginService `json:"service,omitempty"`
+	Service *PrometheusPluginService `json:"service"`
 }
 
 func (p PrometheusPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/proxycacheadvancedplugin.go
+++ b/internal/sdk/models/shared/proxycacheadvancedplugin.go
@@ -638,15 +638,15 @@ type ProxyCacheAdvancedPlugin struct {
 	UpdatedAt *int64                         `json:"updated_at,omitempty"`
 	Config    ProxyCacheAdvancedPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *ProxyCacheAdvancedPluginConsumer `json:"consumer,omitempty"`
+	Consumer *ProxyCacheAdvancedPluginConsumer `json:"consumer"`
 	// If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups
-	ConsumerGroup *ProxyCacheAdvancedPluginConsumerGroup `json:"consumer_group,omitempty"`
+	ConsumerGroup *ProxyCacheAdvancedPluginConsumerGroup `json:"consumer_group"`
 	// A set of strings representing HTTP protocols.
 	Protocols []ProxyCacheAdvancedPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *ProxyCacheAdvancedPluginRoute `json:"route,omitempty"`
+	Route *ProxyCacheAdvancedPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *ProxyCacheAdvancedPluginService `json:"service,omitempty"`
+	Service *ProxyCacheAdvancedPluginService `json:"service"`
 }
 
 func (p ProxyCacheAdvancedPlugin) MarshalJSON() ([]byte, error) {
@@ -767,15 +767,15 @@ type ProxyCacheAdvancedPluginInput struct {
 	Tags   []string                       `json:"tags,omitempty"`
 	Config ProxyCacheAdvancedPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *ProxyCacheAdvancedPluginConsumer `json:"consumer,omitempty"`
+	Consumer *ProxyCacheAdvancedPluginConsumer `json:"consumer"`
 	// If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups
-	ConsumerGroup *ProxyCacheAdvancedPluginConsumerGroup `json:"consumer_group,omitempty"`
+	ConsumerGroup *ProxyCacheAdvancedPluginConsumerGroup `json:"consumer_group"`
 	// A set of strings representing HTTP protocols.
 	Protocols []ProxyCacheAdvancedPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *ProxyCacheAdvancedPluginRoute `json:"route,omitempty"`
+	Route *ProxyCacheAdvancedPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *ProxyCacheAdvancedPluginService `json:"service,omitempty"`
+	Service *ProxyCacheAdvancedPluginService `json:"service"`
 }
 
 func (p ProxyCacheAdvancedPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/proxycacheplugin.go
+++ b/internal/sdk/models/shared/proxycacheplugin.go
@@ -372,15 +372,15 @@ type ProxyCachePlugin struct {
 	UpdatedAt *int64                 `json:"updated_at,omitempty"`
 	Config    ProxyCachePluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *ProxyCachePluginConsumer `json:"consumer,omitempty"`
+	Consumer *ProxyCachePluginConsumer `json:"consumer"`
 	// If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups
-	ConsumerGroup *ProxyCachePluginConsumerGroup `json:"consumer_group,omitempty"`
+	ConsumerGroup *ProxyCachePluginConsumerGroup `json:"consumer_group"`
 	// A set of strings representing protocols.
 	Protocols []ProxyCachePluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *ProxyCachePluginRoute `json:"route,omitempty"`
+	Route *ProxyCachePluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *ProxyCachePluginService `json:"service,omitempty"`
+	Service *ProxyCachePluginService `json:"service"`
 }
 
 func (p ProxyCachePlugin) MarshalJSON() ([]byte, error) {
@@ -501,15 +501,15 @@ type ProxyCachePluginInput struct {
 	Tags   []string               `json:"tags,omitempty"`
 	Config ProxyCachePluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *ProxyCachePluginConsumer `json:"consumer,omitempty"`
+	Consumer *ProxyCachePluginConsumer `json:"consumer"`
 	// If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups
-	ConsumerGroup *ProxyCachePluginConsumerGroup `json:"consumer_group,omitempty"`
+	ConsumerGroup *ProxyCachePluginConsumerGroup `json:"consumer_group"`
 	// A set of strings representing protocols.
 	Protocols []ProxyCachePluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *ProxyCachePluginRoute `json:"route,omitempty"`
+	Route *ProxyCachePluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *ProxyCachePluginService `json:"service,omitempty"`
+	Service *ProxyCachePluginService `json:"service"`
 }
 
 func (p ProxyCachePluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/ratelimitingadvancedplugin.go
+++ b/internal/sdk/models/shared/ratelimitingadvancedplugin.go
@@ -764,15 +764,15 @@ type RateLimitingAdvancedPlugin struct {
 	UpdatedAt *int64                           `json:"updated_at,omitempty"`
 	Config    RateLimitingAdvancedPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *RateLimitingAdvancedPluginConsumer `json:"consumer,omitempty"`
+	Consumer *RateLimitingAdvancedPluginConsumer `json:"consumer"`
 	// If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups
-	ConsumerGroup *RateLimitingAdvancedPluginConsumerGroup `json:"consumer_group,omitempty"`
+	ConsumerGroup *RateLimitingAdvancedPluginConsumerGroup `json:"consumer_group"`
 	// A set of strings representing HTTP protocols.
 	Protocols []RateLimitingAdvancedPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *RateLimitingAdvancedPluginRoute `json:"route,omitempty"`
+	Route *RateLimitingAdvancedPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *RateLimitingAdvancedPluginService `json:"service,omitempty"`
+	Service *RateLimitingAdvancedPluginService `json:"service"`
 }
 
 func (r RateLimitingAdvancedPlugin) MarshalJSON() ([]byte, error) {
@@ -893,15 +893,15 @@ type RateLimitingAdvancedPluginInput struct {
 	Tags   []string                         `json:"tags,omitempty"`
 	Config RateLimitingAdvancedPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *RateLimitingAdvancedPluginConsumer `json:"consumer,omitempty"`
+	Consumer *RateLimitingAdvancedPluginConsumer `json:"consumer"`
 	// If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups
-	ConsumerGroup *RateLimitingAdvancedPluginConsumerGroup `json:"consumer_group,omitempty"`
+	ConsumerGroup *RateLimitingAdvancedPluginConsumerGroup `json:"consumer_group"`
 	// A set of strings representing HTTP protocols.
 	Protocols []RateLimitingAdvancedPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *RateLimitingAdvancedPluginRoute `json:"route,omitempty"`
+	Route *RateLimitingAdvancedPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *RateLimitingAdvancedPluginService `json:"service,omitempty"`
+	Service *RateLimitingAdvancedPluginService `json:"service"`
 }
 
 func (r RateLimitingAdvancedPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/ratelimitingplugin.go
+++ b/internal/sdk/models/shared/ratelimitingplugin.go
@@ -449,15 +449,15 @@ type RateLimitingPlugin struct {
 	UpdatedAt *int64                   `json:"updated_at,omitempty"`
 	Config    RateLimitingPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *RateLimitingPluginConsumer `json:"consumer,omitempty"`
+	Consumer *RateLimitingPluginConsumer `json:"consumer"`
 	// If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups
-	ConsumerGroup *RateLimitingPluginConsumerGroup `json:"consumer_group,omitempty"`
+	ConsumerGroup *RateLimitingPluginConsumerGroup `json:"consumer_group"`
 	// A set of strings representing HTTP protocols.
 	Protocols []RateLimitingPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *RateLimitingPluginRoute `json:"route,omitempty"`
+	Route *RateLimitingPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *RateLimitingPluginService `json:"service,omitempty"`
+	Service *RateLimitingPluginService `json:"service"`
 }
 
 func (r RateLimitingPlugin) MarshalJSON() ([]byte, error) {
@@ -578,15 +578,15 @@ type RateLimitingPluginInput struct {
 	Tags   []string                 `json:"tags,omitempty"`
 	Config RateLimitingPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *RateLimitingPluginConsumer `json:"consumer,omitempty"`
+	Consumer *RateLimitingPluginConsumer `json:"consumer"`
 	// If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups
-	ConsumerGroup *RateLimitingPluginConsumerGroup `json:"consumer_group,omitempty"`
+	ConsumerGroup *RateLimitingPluginConsumerGroup `json:"consumer_group"`
 	// A set of strings representing HTTP protocols.
 	Protocols []RateLimitingPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *RateLimitingPluginRoute `json:"route,omitempty"`
+	Route *RateLimitingPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *RateLimitingPluginService `json:"service,omitempty"`
+	Service *RateLimitingPluginService `json:"service"`
 }
 
 func (r RateLimitingPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/redirectplugin.go
+++ b/internal/sdk/models/shared/redirectplugin.go
@@ -175,15 +175,15 @@ type RedirectPlugin struct {
 	UpdatedAt *int64               `json:"updated_at,omitempty"`
 	Config    RedirectPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *RedirectPluginConsumer `json:"consumer,omitempty"`
+	Consumer *RedirectPluginConsumer `json:"consumer"`
 	// If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups
-	ConsumerGroup *RedirectPluginConsumerGroup `json:"consumer_group,omitempty"`
+	ConsumerGroup *RedirectPluginConsumerGroup `json:"consumer_group"`
 	// A set of strings representing HTTP protocols.
 	Protocols []RedirectPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *RedirectPluginRoute `json:"route,omitempty"`
+	Route *RedirectPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *RedirectPluginService `json:"service,omitempty"`
+	Service *RedirectPluginService `json:"service"`
 }
 
 func (r RedirectPlugin) MarshalJSON() ([]byte, error) {
@@ -304,15 +304,15 @@ type RedirectPluginInput struct {
 	Tags   []string             `json:"tags,omitempty"`
 	Config RedirectPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *RedirectPluginConsumer `json:"consumer,omitempty"`
+	Consumer *RedirectPluginConsumer `json:"consumer"`
 	// If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups
-	ConsumerGroup *RedirectPluginConsumerGroup `json:"consumer_group,omitempty"`
+	ConsumerGroup *RedirectPluginConsumerGroup `json:"consumer_group"`
 	// A set of strings representing HTTP protocols.
 	Protocols []RedirectPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *RedirectPluginRoute `json:"route,omitempty"`
+	Route *RedirectPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *RedirectPluginService `json:"service,omitempty"`
+	Service *RedirectPluginService `json:"service"`
 }
 
 func (r RedirectPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/requestsizelimitingplugin.go
+++ b/internal/sdk/models/shared/requestsizelimitingplugin.go
@@ -193,13 +193,13 @@ type RequestSizeLimitingPlugin struct {
 	UpdatedAt *int64                          `json:"updated_at,omitempty"`
 	Config    RequestSizeLimitingPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *RequestSizeLimitingPluginConsumer `json:"consumer,omitempty"`
+	Consumer *RequestSizeLimitingPluginConsumer `json:"consumer"`
 	// A set of strings representing HTTP protocols.
 	Protocols []RequestSizeLimitingPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *RequestSizeLimitingPluginRoute `json:"route,omitempty"`
+	Route *RequestSizeLimitingPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *RequestSizeLimitingPluginService `json:"service,omitempty"`
+	Service *RequestSizeLimitingPluginService `json:"service"`
 }
 
 func (r RequestSizeLimitingPlugin) MarshalJSON() ([]byte, error) {
@@ -313,13 +313,13 @@ type RequestSizeLimitingPluginInput struct {
 	Tags   []string                        `json:"tags,omitempty"`
 	Config RequestSizeLimitingPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *RequestSizeLimitingPluginConsumer `json:"consumer,omitempty"`
+	Consumer *RequestSizeLimitingPluginConsumer `json:"consumer"`
 	// A set of strings representing HTTP protocols.
 	Protocols []RequestSizeLimitingPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *RequestSizeLimitingPluginRoute `json:"route,omitempty"`
+	Route *RequestSizeLimitingPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *RequestSizeLimitingPluginService `json:"service,omitempty"`
+	Service *RequestSizeLimitingPluginService `json:"service"`
 }
 
 func (r RequestSizeLimitingPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/requestterminationplugin.go
+++ b/internal/sdk/models/shared/requestterminationplugin.go
@@ -202,15 +202,15 @@ type RequestTerminationPlugin struct {
 	UpdatedAt *int64                         `json:"updated_at,omitempty"`
 	Config    RequestTerminationPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *RequestTerminationPluginConsumer `json:"consumer,omitempty"`
+	Consumer *RequestTerminationPluginConsumer `json:"consumer"`
 	// If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups
-	ConsumerGroup *RequestTerminationPluginConsumerGroup `json:"consumer_group,omitempty"`
+	ConsumerGroup *RequestTerminationPluginConsumerGroup `json:"consumer_group"`
 	// A set of strings representing HTTP protocols.
 	Protocols []RequestTerminationPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *RequestTerminationPluginRoute `json:"route,omitempty"`
+	Route *RequestTerminationPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *RequestTerminationPluginService `json:"service,omitempty"`
+	Service *RequestTerminationPluginService `json:"service"`
 }
 
 func (r RequestTerminationPlugin) MarshalJSON() ([]byte, error) {
@@ -331,15 +331,15 @@ type RequestTerminationPluginInput struct {
 	Tags   []string                       `json:"tags,omitempty"`
 	Config RequestTerminationPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *RequestTerminationPluginConsumer `json:"consumer,omitempty"`
+	Consumer *RequestTerminationPluginConsumer `json:"consumer"`
 	// If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups
-	ConsumerGroup *RequestTerminationPluginConsumerGroup `json:"consumer_group,omitempty"`
+	ConsumerGroup *RequestTerminationPluginConsumerGroup `json:"consumer_group"`
 	// A set of strings representing HTTP protocols.
 	Protocols []RequestTerminationPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *RequestTerminationPluginRoute `json:"route,omitempty"`
+	Route *RequestTerminationPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *RequestTerminationPluginService `json:"service,omitempty"`
+	Service *RequestTerminationPluginService `json:"service"`
 }
 
 func (r RequestTerminationPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/requesttransformeradvancedplugin.go
+++ b/internal/sdk/models/shared/requesttransformeradvancedplugin.go
@@ -479,15 +479,15 @@ type RequestTransformerAdvancedPlugin struct {
 	UpdatedAt *int64                                 `json:"updated_at,omitempty"`
 	Config    RequestTransformerAdvancedPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *RequestTransformerAdvancedPluginConsumer `json:"consumer,omitempty"`
+	Consumer *RequestTransformerAdvancedPluginConsumer `json:"consumer"`
 	// If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups
-	ConsumerGroup *RequestTransformerAdvancedPluginConsumerGroup `json:"consumer_group,omitempty"`
+	ConsumerGroup *RequestTransformerAdvancedPluginConsumerGroup `json:"consumer_group"`
 	// A set of strings representing HTTP protocols.
 	Protocols []RequestTransformerAdvancedPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *RequestTransformerAdvancedPluginRoute `json:"route,omitempty"`
+	Route *RequestTransformerAdvancedPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *RequestTransformerAdvancedPluginService `json:"service,omitempty"`
+	Service *RequestTransformerAdvancedPluginService `json:"service"`
 }
 
 func (r RequestTransformerAdvancedPlugin) MarshalJSON() ([]byte, error) {
@@ -608,15 +608,15 @@ type RequestTransformerAdvancedPluginInput struct {
 	Tags   []string                               `json:"tags,omitempty"`
 	Config RequestTransformerAdvancedPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *RequestTransformerAdvancedPluginConsumer `json:"consumer,omitempty"`
+	Consumer *RequestTransformerAdvancedPluginConsumer `json:"consumer"`
 	// If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups
-	ConsumerGroup *RequestTransformerAdvancedPluginConsumerGroup `json:"consumer_group,omitempty"`
+	ConsumerGroup *RequestTransformerAdvancedPluginConsumerGroup `json:"consumer_group"`
 	// A set of strings representing HTTP protocols.
 	Protocols []RequestTransformerAdvancedPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *RequestTransformerAdvancedPluginRoute `json:"route,omitempty"`
+	Route *RequestTransformerAdvancedPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *RequestTransformerAdvancedPluginService `json:"service,omitempty"`
+	Service *RequestTransformerAdvancedPluginService `json:"service"`
 }
 
 func (r RequestTransformerAdvancedPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/requesttransformerplugin.go
+++ b/internal/sdk/models/shared/requesttransformerplugin.go
@@ -359,15 +359,15 @@ type RequestTransformerPlugin struct {
 	UpdatedAt *int64                         `json:"updated_at,omitempty"`
 	Config    RequestTransformerPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *RequestTransformerPluginConsumer `json:"consumer,omitempty"`
+	Consumer *RequestTransformerPluginConsumer `json:"consumer"`
 	// If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups
-	ConsumerGroup *RequestTransformerPluginConsumerGroup `json:"consumer_group,omitempty"`
+	ConsumerGroup *RequestTransformerPluginConsumerGroup `json:"consumer_group"`
 	// A set of strings representing protocols.
 	Protocols []RequestTransformerPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *RequestTransformerPluginRoute `json:"route,omitempty"`
+	Route *RequestTransformerPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *RequestTransformerPluginService `json:"service,omitempty"`
+	Service *RequestTransformerPluginService `json:"service"`
 }
 
 func (r RequestTransformerPlugin) MarshalJSON() ([]byte, error) {
@@ -488,15 +488,15 @@ type RequestTransformerPluginInput struct {
 	Tags   []string                       `json:"tags,omitempty"`
 	Config RequestTransformerPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *RequestTransformerPluginConsumer `json:"consumer,omitempty"`
+	Consumer *RequestTransformerPluginConsumer `json:"consumer"`
 	// If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups
-	ConsumerGroup *RequestTransformerPluginConsumerGroup `json:"consumer_group,omitempty"`
+	ConsumerGroup *RequestTransformerPluginConsumerGroup `json:"consumer_group"`
 	// A set of strings representing protocols.
 	Protocols []RequestTransformerPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *RequestTransformerPluginRoute `json:"route,omitempty"`
+	Route *RequestTransformerPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *RequestTransformerPluginService `json:"service,omitempty"`
+	Service *RequestTransformerPluginService `json:"service"`
 }
 
 func (r RequestTransformerPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/requestvalidatorplugin.go
+++ b/internal/sdk/models/shared/requestvalidatorplugin.go
@@ -346,13 +346,13 @@ type RequestValidatorPlugin struct {
 	UpdatedAt *int64                       `json:"updated_at,omitempty"`
 	Config    RequestValidatorPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *RequestValidatorPluginConsumer `json:"consumer,omitempty"`
+	Consumer *RequestValidatorPluginConsumer `json:"consumer"`
 	// A set of strings representing HTTP protocols.
 	Protocols []RequestValidatorPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *RequestValidatorPluginRoute `json:"route,omitempty"`
+	Route *RequestValidatorPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *RequestValidatorPluginService `json:"service,omitempty"`
+	Service *RequestValidatorPluginService `json:"service"`
 }
 
 func (r RequestValidatorPlugin) MarshalJSON() ([]byte, error) {
@@ -466,13 +466,13 @@ type RequestValidatorPluginInput struct {
 	Tags   []string                     `json:"tags,omitempty"`
 	Config RequestValidatorPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *RequestValidatorPluginConsumer `json:"consumer,omitempty"`
+	Consumer *RequestValidatorPluginConsumer `json:"consumer"`
 	// A set of strings representing HTTP protocols.
 	Protocols []RequestValidatorPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *RequestValidatorPluginRoute `json:"route,omitempty"`
+	Route *RequestValidatorPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *RequestValidatorPluginService `json:"service,omitempty"`
+	Service *RequestValidatorPluginService `json:"service"`
 }
 
 func (r RequestValidatorPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/responseratelimitingplugin.go
+++ b/internal/sdk/models/shared/responseratelimitingplugin.go
@@ -353,13 +353,13 @@ type ResponseRatelimitingPlugin struct {
 	UpdatedAt *int64                           `json:"updated_at,omitempty"`
 	Config    ResponseRatelimitingPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *ResponseRatelimitingPluginConsumer `json:"consumer,omitempty"`
+	Consumer *ResponseRatelimitingPluginConsumer `json:"consumer"`
 	// A set of strings representing HTTP protocols.
 	Protocols []ResponseRatelimitingPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *ResponseRatelimitingPluginRoute `json:"route,omitempty"`
+	Route *ResponseRatelimitingPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *ResponseRatelimitingPluginService `json:"service,omitempty"`
+	Service *ResponseRatelimitingPluginService `json:"service"`
 }
 
 func (r ResponseRatelimitingPlugin) MarshalJSON() ([]byte, error) {
@@ -473,13 +473,13 @@ type ResponseRatelimitingPluginInput struct {
 	Tags   []string                         `json:"tags,omitempty"`
 	Config ResponseRatelimitingPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *ResponseRatelimitingPluginConsumer `json:"consumer,omitempty"`
+	Consumer *ResponseRatelimitingPluginConsumer `json:"consumer"`
 	// A set of strings representing HTTP protocols.
 	Protocols []ResponseRatelimitingPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *ResponseRatelimitingPluginRoute `json:"route,omitempty"`
+	Route *ResponseRatelimitingPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *ResponseRatelimitingPluginService `json:"service,omitempty"`
+	Service *ResponseRatelimitingPluginService `json:"service"`
 }
 
 func (r ResponseRatelimitingPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/responsetransformeradvancedplugin.go
+++ b/internal/sdk/models/shared/responsetransformeradvancedplugin.go
@@ -498,15 +498,15 @@ type ResponseTransformerAdvancedPlugin struct {
 	UpdatedAt *int64                                  `json:"updated_at,omitempty"`
 	Config    ResponseTransformerAdvancedPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *ResponseTransformerAdvancedPluginConsumer `json:"consumer,omitempty"`
+	Consumer *ResponseTransformerAdvancedPluginConsumer `json:"consumer"`
 	// If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups
-	ConsumerGroup *ResponseTransformerAdvancedPluginConsumerGroup `json:"consumer_group,omitempty"`
+	ConsumerGroup *ResponseTransformerAdvancedPluginConsumerGroup `json:"consumer_group"`
 	// A set of strings representing HTTP protocols.
 	Protocols []ResponseTransformerAdvancedPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *ResponseTransformerAdvancedPluginRoute `json:"route,omitempty"`
+	Route *ResponseTransformerAdvancedPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *ResponseTransformerAdvancedPluginService `json:"service,omitempty"`
+	Service *ResponseTransformerAdvancedPluginService `json:"service"`
 }
 
 func (r ResponseTransformerAdvancedPlugin) MarshalJSON() ([]byte, error) {
@@ -627,15 +627,15 @@ type ResponseTransformerAdvancedPluginInput struct {
 	Tags   []string                                `json:"tags,omitempty"`
 	Config ResponseTransformerAdvancedPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *ResponseTransformerAdvancedPluginConsumer `json:"consumer,omitempty"`
+	Consumer *ResponseTransformerAdvancedPluginConsumer `json:"consumer"`
 	// If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups
-	ConsumerGroup *ResponseTransformerAdvancedPluginConsumerGroup `json:"consumer_group,omitempty"`
+	ConsumerGroup *ResponseTransformerAdvancedPluginConsumerGroup `json:"consumer_group"`
 	// A set of strings representing HTTP protocols.
 	Protocols []ResponseTransformerAdvancedPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *ResponseTransformerAdvancedPluginRoute `json:"route,omitempty"`
+	Route *ResponseTransformerAdvancedPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *ResponseTransformerAdvancedPluginService `json:"service,omitempty"`
+	Service *ResponseTransformerAdvancedPluginService `json:"service"`
 }
 
 func (r ResponseTransformerAdvancedPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/responsetransformerplugin.go
+++ b/internal/sdk/models/shared/responsetransformerplugin.go
@@ -400,15 +400,15 @@ type ResponseTransformerPlugin struct {
 	UpdatedAt *int64                          `json:"updated_at,omitempty"`
 	Config    ResponseTransformerPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *ResponseTransformerPluginConsumer `json:"consumer,omitempty"`
+	Consumer *ResponseTransformerPluginConsumer `json:"consumer"`
 	// If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups
-	ConsumerGroup *ResponseTransformerPluginConsumerGroup `json:"consumer_group,omitempty"`
+	ConsumerGroup *ResponseTransformerPluginConsumerGroup `json:"consumer_group"`
 	// A set of strings representing HTTP protocols.
 	Protocols []ResponseTransformerPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *ResponseTransformerPluginRoute `json:"route,omitempty"`
+	Route *ResponseTransformerPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *ResponseTransformerPluginService `json:"service,omitempty"`
+	Service *ResponseTransformerPluginService `json:"service"`
 }
 
 func (r ResponseTransformerPlugin) MarshalJSON() ([]byte, error) {
@@ -529,15 +529,15 @@ type ResponseTransformerPluginInput struct {
 	Tags   []string                        `json:"tags,omitempty"`
 	Config ResponseTransformerPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *ResponseTransformerPluginConsumer `json:"consumer,omitempty"`
+	Consumer *ResponseTransformerPluginConsumer `json:"consumer"`
 	// If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups
-	ConsumerGroup *ResponseTransformerPluginConsumerGroup `json:"consumer_group,omitempty"`
+	ConsumerGroup *ResponseTransformerPluginConsumerGroup `json:"consumer_group"`
 	// A set of strings representing HTTP protocols.
 	Protocols []ResponseTransformerPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *ResponseTransformerPluginRoute `json:"route,omitempty"`
+	Route *ResponseTransformerPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *ResponseTransformerPluginService `json:"service,omitempty"`
+	Service *ResponseTransformerPluginService `json:"service"`
 }
 
 func (r ResponseTransformerPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/routebyheaderplugin.go
+++ b/internal/sdk/models/shared/routebyheaderplugin.go
@@ -164,13 +164,13 @@ type RouteByHeaderPlugin struct {
 	UpdatedAt *int64                    `json:"updated_at,omitempty"`
 	Config    RouteByHeaderPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *RouteByHeaderPluginConsumer `json:"consumer,omitempty"`
+	Consumer *RouteByHeaderPluginConsumer `json:"consumer"`
 	// A set of strings representing HTTP protocols.
 	Protocols []RouteByHeaderPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *RouteByHeaderPluginRoute `json:"route,omitempty"`
+	Route *RouteByHeaderPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *RouteByHeaderPluginService `json:"service,omitempty"`
+	Service *RouteByHeaderPluginService `json:"service"`
 }
 
 func (r RouteByHeaderPlugin) MarshalJSON() ([]byte, error) {
@@ -284,13 +284,13 @@ type RouteByHeaderPluginInput struct {
 	Tags   []string                  `json:"tags,omitempty"`
 	Config RouteByHeaderPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *RouteByHeaderPluginConsumer `json:"consumer,omitempty"`
+	Consumer *RouteByHeaderPluginConsumer `json:"consumer"`
 	// A set of strings representing HTTP protocols.
 	Protocols []RouteByHeaderPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *RouteByHeaderPluginRoute `json:"route,omitempty"`
+	Route *RouteByHeaderPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *RouteByHeaderPluginService `json:"service,omitempty"`
+	Service *RouteByHeaderPluginService `json:"service"`
 }
 
 func (r RouteByHeaderPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/routetransformeradvancedplugin.go
+++ b/internal/sdk/models/shared/routetransformeradvancedplugin.go
@@ -168,13 +168,13 @@ type RouteTransformerAdvancedPlugin struct {
 	UpdatedAt *int64                               `json:"updated_at,omitempty"`
 	Config    RouteTransformerAdvancedPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *RouteTransformerAdvancedPluginConsumer `json:"consumer,omitempty"`
+	Consumer *RouteTransformerAdvancedPluginConsumer `json:"consumer"`
 	// A set of strings representing HTTP protocols.
 	Protocols []RouteTransformerAdvancedPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *RouteTransformerAdvancedPluginRoute `json:"route,omitempty"`
+	Route *RouteTransformerAdvancedPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *RouteTransformerAdvancedPluginService `json:"service,omitempty"`
+	Service *RouteTransformerAdvancedPluginService `json:"service"`
 }
 
 func (r RouteTransformerAdvancedPlugin) MarshalJSON() ([]byte, error) {
@@ -288,13 +288,13 @@ type RouteTransformerAdvancedPluginInput struct {
 	Tags   []string                             `json:"tags,omitempty"`
 	Config RouteTransformerAdvancedPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *RouteTransformerAdvancedPluginConsumer `json:"consumer,omitempty"`
+	Consumer *RouteTransformerAdvancedPluginConsumer `json:"consumer"`
 	// A set of strings representing HTTP protocols.
 	Protocols []RouteTransformerAdvancedPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *RouteTransformerAdvancedPluginRoute `json:"route,omitempty"`
+	Route *RouteTransformerAdvancedPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *RouteTransformerAdvancedPluginService `json:"service,omitempty"`
+	Service *RouteTransformerAdvancedPluginService `json:"service"`
 }
 
 func (r RouteTransformerAdvancedPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/samlplugin.go
+++ b/internal/sdk/models/shared/samlplugin.go
@@ -1069,9 +1069,9 @@ type SamlPlugin struct {
 	// A set of strings representing HTTP protocols.
 	Protocols []SamlPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *SamlPluginRoute `json:"route,omitempty"`
+	Route *SamlPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *SamlPluginService `json:"service,omitempty"`
+	Service *SamlPluginService `json:"service"`
 }
 
 func (s SamlPlugin) MarshalJSON() ([]byte, error) {
@@ -1180,9 +1180,9 @@ type SamlPluginInput struct {
 	// A set of strings representing HTTP protocols.
 	Protocols []SamlPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *SamlPluginRoute `json:"route,omitempty"`
+	Route *SamlPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *SamlPluginService `json:"service,omitempty"`
+	Service *SamlPluginService `json:"service"`
 }
 
 func (s SamlPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/serviceprotectionplugin.go
+++ b/internal/sdk/models/shared/serviceprotectionplugin.go
@@ -560,7 +560,7 @@ type ServiceProtectionPlugin struct {
 	// A set of strings representing HTTP protocols.
 	Protocols []ServiceProtectionPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *ServiceProtectionPluginService `json:"service,omitempty"`
+	Service *ServiceProtectionPluginService `json:"service"`
 }
 
 func (s ServiceProtectionPlugin) MarshalJSON() ([]byte, error) {
@@ -662,7 +662,7 @@ type ServiceProtectionPluginInput struct {
 	// A set of strings representing HTTP protocols.
 	Protocols []ServiceProtectionPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *ServiceProtectionPluginService `json:"service,omitempty"`
+	Service *ServiceProtectionPluginService `json:"service"`
 }
 
 func (s ServiceProtectionPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/sessionplugin.go
+++ b/internal/sdk/models/shared/sessionplugin.go
@@ -522,9 +522,9 @@ type SessionPlugin struct {
 	// A set of strings representing protocols.
 	Protocols []SessionPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *SessionPluginRoute `json:"route,omitempty"`
+	Route *SessionPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *SessionPluginService `json:"service,omitempty"`
+	Service *SessionPluginService `json:"service"`
 }
 
 func (s SessionPlugin) MarshalJSON() ([]byte, error) {
@@ -633,9 +633,9 @@ type SessionPluginInput struct {
 	// A set of strings representing protocols.
 	Protocols []SessionPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *SessionPluginRoute `json:"route,omitempty"`
+	Route *SessionPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *SessionPluginService `json:"service,omitempty"`
+	Service *SessionPluginService `json:"service"`
 }
 
 func (s SessionPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/standardwebhooksplugin.go
+++ b/internal/sdk/models/shared/standardwebhooksplugin.go
@@ -154,13 +154,13 @@ type StandardWebhooksPlugin struct {
 	UpdatedAt *int64                       `json:"updated_at,omitempty"`
 	Config    StandardWebhooksPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups
-	ConsumerGroup *StandardWebhooksPluginConsumerGroup `json:"consumer_group,omitempty"`
+	ConsumerGroup *StandardWebhooksPluginConsumerGroup `json:"consumer_group"`
 	// A set of strings representing HTTP protocols.
 	Protocols []StandardWebhooksPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *StandardWebhooksPluginRoute `json:"route,omitempty"`
+	Route *StandardWebhooksPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *StandardWebhooksPluginService `json:"service,omitempty"`
+	Service *StandardWebhooksPluginService `json:"service"`
 }
 
 func (s StandardWebhooksPlugin) MarshalJSON() ([]byte, error) {
@@ -274,13 +274,13 @@ type StandardWebhooksPluginInput struct {
 	Tags   []string                     `json:"tags,omitempty"`
 	Config StandardWebhooksPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups
-	ConsumerGroup *StandardWebhooksPluginConsumerGroup `json:"consumer_group,omitempty"`
+	ConsumerGroup *StandardWebhooksPluginConsumerGroup `json:"consumer_group"`
 	// A set of strings representing HTTP protocols.
 	Protocols []StandardWebhooksPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *StandardWebhooksPluginRoute `json:"route,omitempty"`
+	Route *StandardWebhooksPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *StandardWebhooksPluginService `json:"service,omitempty"`
+	Service *StandardWebhooksPluginService `json:"service"`
 }
 
 func (s StandardWebhooksPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/statsdadvancedplugin.go
+++ b/internal/sdk/models/shared/statsdadvancedplugin.go
@@ -695,13 +695,13 @@ type StatsdAdvancedPlugin struct {
 	UpdatedAt *int64                     `json:"updated_at,omitempty"`
 	Config    StatsdAdvancedPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *StatsdAdvancedPluginConsumer `json:"consumer,omitempty"`
+	Consumer *StatsdAdvancedPluginConsumer `json:"consumer"`
 	// A set of strings representing protocols.
 	Protocols []StatsdAdvancedPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *StatsdAdvancedPluginRoute `json:"route,omitempty"`
+	Route *StatsdAdvancedPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *StatsdAdvancedPluginService `json:"service,omitempty"`
+	Service *StatsdAdvancedPluginService `json:"service"`
 }
 
 func (s StatsdAdvancedPlugin) MarshalJSON() ([]byte, error) {
@@ -815,13 +815,13 @@ type StatsdAdvancedPluginInput struct {
 	Tags   []string                   `json:"tags,omitempty"`
 	Config StatsdAdvancedPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *StatsdAdvancedPluginConsumer `json:"consumer,omitempty"`
+	Consumer *StatsdAdvancedPluginConsumer `json:"consumer"`
 	// A set of strings representing protocols.
 	Protocols []StatsdAdvancedPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *StatsdAdvancedPluginRoute `json:"route,omitempty"`
+	Route *StatsdAdvancedPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *StatsdAdvancedPluginService `json:"service,omitempty"`
+	Service *StatsdAdvancedPluginService `json:"service"`
 }
 
 func (s StatsdAdvancedPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/statsdplugin.go
+++ b/internal/sdk/models/shared/statsdplugin.go
@@ -761,13 +761,13 @@ type StatsdPlugin struct {
 	UpdatedAt *int64             `json:"updated_at,omitempty"`
 	Config    StatsdPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *StatsdPluginConsumer `json:"consumer,omitempty"`
+	Consumer *StatsdPluginConsumer `json:"consumer"`
 	// A set of strings representing protocols.
 	Protocols []StatsdPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *StatsdPluginRoute `json:"route,omitempty"`
+	Route *StatsdPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *StatsdPluginService `json:"service,omitempty"`
+	Service *StatsdPluginService `json:"service"`
 }
 
 func (s StatsdPlugin) MarshalJSON() ([]byte, error) {
@@ -881,13 +881,13 @@ type StatsdPluginInput struct {
 	Tags   []string           `json:"tags,omitempty"`
 	Config StatsdPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *StatsdPluginConsumer `json:"consumer,omitempty"`
+	Consumer *StatsdPluginConsumer `json:"consumer"`
 	// A set of strings representing protocols.
 	Protocols []StatsdPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *StatsdPluginRoute `json:"route,omitempty"`
+	Route *StatsdPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *StatsdPluginService `json:"service,omitempty"`
+	Service *StatsdPluginService `json:"service"`
 }
 
 func (s StatsdPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/syslogplugin.go
+++ b/internal/sdk/models/shared/syslogplugin.go
@@ -462,13 +462,13 @@ type SyslogPlugin struct {
 	UpdatedAt *int64             `json:"updated_at,omitempty"`
 	Config    SyslogPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *SyslogPluginConsumer `json:"consumer,omitempty"`
+	Consumer *SyslogPluginConsumer `json:"consumer"`
 	// A set of strings representing protocols.
 	Protocols []SyslogPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *SyslogPluginRoute `json:"route,omitempty"`
+	Route *SyslogPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *SyslogPluginService `json:"service,omitempty"`
+	Service *SyslogPluginService `json:"service"`
 }
 
 func (s SyslogPlugin) MarshalJSON() ([]byte, error) {
@@ -582,13 +582,13 @@ type SyslogPluginInput struct {
 	Tags   []string           `json:"tags,omitempty"`
 	Config SyslogPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *SyslogPluginConsumer `json:"consumer,omitempty"`
+	Consumer *SyslogPluginConsumer `json:"consumer"`
 	// A set of strings representing protocols.
 	Protocols []SyslogPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *SyslogPluginRoute `json:"route,omitempty"`
+	Route *SyslogPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *SyslogPluginService `json:"service,omitempty"`
+	Service *SyslogPluginService `json:"service"`
 }
 
 func (s SyslogPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/tcplogplugin.go
+++ b/internal/sdk/models/shared/tcplogplugin.go
@@ -218,13 +218,13 @@ type TCPLogPlugin struct {
 	UpdatedAt *int64             `json:"updated_at,omitempty"`
 	Config    TCPLogPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *TCPLogPluginConsumer `json:"consumer,omitempty"`
+	Consumer *TCPLogPluginConsumer `json:"consumer"`
 	// A set of strings representing protocols.
 	Protocols []TCPLogPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *TCPLogPluginRoute `json:"route,omitempty"`
+	Route *TCPLogPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *TCPLogPluginService `json:"service,omitempty"`
+	Service *TCPLogPluginService `json:"service"`
 }
 
 func (t TCPLogPlugin) MarshalJSON() ([]byte, error) {
@@ -338,13 +338,13 @@ type TCPLogPluginInput struct {
 	Tags   []string           `json:"tags,omitempty"`
 	Config TCPLogPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *TCPLogPluginConsumer `json:"consumer,omitempty"`
+	Consumer *TCPLogPluginConsumer `json:"consumer"`
 	// A set of strings representing protocols.
 	Protocols []TCPLogPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *TCPLogPluginRoute `json:"route,omitempty"`
+	Route *TCPLogPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *TCPLogPluginService `json:"service,omitempty"`
+	Service *TCPLogPluginService `json:"service"`
 }
 
 func (t TCPLogPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/tlshandshakemodifierplugin.go
+++ b/internal/sdk/models/shared/tlshandshakemodifierplugin.go
@@ -156,9 +156,9 @@ type TLSHandshakeModifierPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support tcp and tls.
 	Protocols []TLSHandshakeModifierPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *TLSHandshakeModifierPluginRoute `json:"route,omitempty"`
+	Route *TLSHandshakeModifierPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *TLSHandshakeModifierPluginService `json:"service,omitempty"`
+	Service *TLSHandshakeModifierPluginService `json:"service"`
 }
 
 func (t TLSHandshakeModifierPlugin) MarshalJSON() ([]byte, error) {
@@ -267,9 +267,9 @@ type TLSHandshakeModifierPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support tcp and tls.
 	Protocols []TLSHandshakeModifierPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *TLSHandshakeModifierPluginRoute `json:"route,omitempty"`
+	Route *TLSHandshakeModifierPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *TLSHandshakeModifierPluginService `json:"service,omitempty"`
+	Service *TLSHandshakeModifierPluginService `json:"service"`
 }
 
 func (t TLSHandshakeModifierPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/tlsmetadataheadersplugin.go
+++ b/internal/sdk/models/shared/tlsmetadataheadersplugin.go
@@ -177,9 +177,9 @@ type TLSMetadataHeadersPlugin struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support tcp and tls.
 	Protocols []TLSMetadataHeadersPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *TLSMetadataHeadersPluginRoute `json:"route,omitempty"`
+	Route *TLSMetadataHeadersPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *TLSMetadataHeadersPluginService `json:"service,omitempty"`
+	Service *TLSMetadataHeadersPluginService `json:"service"`
 }
 
 func (t TLSMetadataHeadersPlugin) MarshalJSON() ([]byte, error) {
@@ -288,9 +288,9 @@ type TLSMetadataHeadersPluginInput struct {
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support tcp and tls.
 	Protocols []TLSMetadataHeadersPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *TLSMetadataHeadersPluginRoute `json:"route,omitempty"`
+	Route *TLSMetadataHeadersPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *TLSMetadataHeadersPluginService `json:"service,omitempty"`
+	Service *TLSMetadataHeadersPluginService `json:"service"`
 }
 
 func (t TLSMetadataHeadersPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/udplogplugin.go
+++ b/internal/sdk/models/shared/udplogplugin.go
@@ -191,13 +191,13 @@ type UDPLogPlugin struct {
 	UpdatedAt *int64             `json:"updated_at,omitempty"`
 	Config    UDPLogPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *UDPLogPluginConsumer `json:"consumer,omitempty"`
+	Consumer *UDPLogPluginConsumer `json:"consumer"`
 	// A set of strings representing protocols.
 	Protocols []UDPLogPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *UDPLogPluginRoute `json:"route,omitempty"`
+	Route *UDPLogPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *UDPLogPluginService `json:"service,omitempty"`
+	Service *UDPLogPluginService `json:"service"`
 }
 
 func (u UDPLogPlugin) MarshalJSON() ([]byte, error) {
@@ -311,13 +311,13 @@ type UDPLogPluginInput struct {
 	Tags   []string           `json:"tags,omitempty"`
 	Config UDPLogPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *UDPLogPluginConsumer `json:"consumer,omitempty"`
+	Consumer *UDPLogPluginConsumer `json:"consumer"`
 	// A set of strings representing protocols.
 	Protocols []UDPLogPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *UDPLogPluginRoute `json:"route,omitempty"`
+	Route *UDPLogPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *UDPLogPluginService `json:"service,omitempty"`
+	Service *UDPLogPluginService `json:"service"`
 }
 
 func (u UDPLogPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/upstreamoauthplugin.go
+++ b/internal/sdk/models/shared/upstreamoauthplugin.go
@@ -868,15 +868,15 @@ type UpstreamOauthPlugin struct {
 	UpdatedAt *int64                    `json:"updated_at,omitempty"`
 	Config    UpstreamOauthPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *UpstreamOauthPluginConsumer `json:"consumer,omitempty"`
+	Consumer *UpstreamOauthPluginConsumer `json:"consumer"`
 	// If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups
-	ConsumerGroup *UpstreamOauthPluginConsumerGroup `json:"consumer_group,omitempty"`
+	ConsumerGroup *UpstreamOauthPluginConsumerGroup `json:"consumer_group"`
 	// A set of strings representing HTTP protocols.
 	Protocols []UpstreamOauthPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *UpstreamOauthPluginRoute `json:"route,omitempty"`
+	Route *UpstreamOauthPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *UpstreamOauthPluginService `json:"service,omitempty"`
+	Service *UpstreamOauthPluginService `json:"service"`
 }
 
 func (u UpstreamOauthPlugin) MarshalJSON() ([]byte, error) {
@@ -997,15 +997,15 @@ type UpstreamOauthPluginInput struct {
 	Tags   []string                  `json:"tags,omitempty"`
 	Config UpstreamOauthPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *UpstreamOauthPluginConsumer `json:"consumer,omitempty"`
+	Consumer *UpstreamOauthPluginConsumer `json:"consumer"`
 	// If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups
-	ConsumerGroup *UpstreamOauthPluginConsumerGroup `json:"consumer_group,omitempty"`
+	ConsumerGroup *UpstreamOauthPluginConsumerGroup `json:"consumer_group"`
 	// A set of strings representing HTTP protocols.
 	Protocols []UpstreamOauthPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *UpstreamOauthPluginRoute `json:"route,omitempty"`
+	Route *UpstreamOauthPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *UpstreamOauthPluginService `json:"service,omitempty"`
+	Service *UpstreamOauthPluginService `json:"service"`
 }
 
 func (u UpstreamOauthPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/upstreamtimeoutplugin.go
+++ b/internal/sdk/models/shared/upstreamtimeoutplugin.go
@@ -163,13 +163,13 @@ type UpstreamTimeoutPlugin struct {
 	UpdatedAt *int64                      `json:"updated_at,omitempty"`
 	Config    UpstreamTimeoutPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *UpstreamTimeoutPluginConsumer `json:"consumer,omitempty"`
+	Consumer *UpstreamTimeoutPluginConsumer `json:"consumer"`
 	// A set of strings representing HTTP protocols.
 	Protocols []UpstreamTimeoutPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *UpstreamTimeoutPluginRoute `json:"route,omitempty"`
+	Route *UpstreamTimeoutPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *UpstreamTimeoutPluginService `json:"service,omitempty"`
+	Service *UpstreamTimeoutPluginService `json:"service"`
 }
 
 func (u UpstreamTimeoutPlugin) MarshalJSON() ([]byte, error) {
@@ -283,13 +283,13 @@ type UpstreamTimeoutPluginInput struct {
 	Tags   []string                    `json:"tags,omitempty"`
 	Config UpstreamTimeoutPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *UpstreamTimeoutPluginConsumer `json:"consumer,omitempty"`
+	Consumer *UpstreamTimeoutPluginConsumer `json:"consumer"`
 	// A set of strings representing HTTP protocols.
 	Protocols []UpstreamTimeoutPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *UpstreamTimeoutPluginRoute `json:"route,omitempty"`
+	Route *UpstreamTimeoutPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *UpstreamTimeoutPluginService `json:"service,omitempty"`
+	Service *UpstreamTimeoutPluginService `json:"service"`
 }
 
 func (u UpstreamTimeoutPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/vaultauthplugin.go
+++ b/internal/sdk/models/shared/vaultauthplugin.go
@@ -189,9 +189,9 @@ type VaultAuthPlugin struct {
 	// A set of strings representing HTTP protocols.
 	Protocols []VaultAuthPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *VaultAuthPluginRoute `json:"route,omitempty"`
+	Route *VaultAuthPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *VaultAuthPluginService `json:"service,omitempty"`
+	Service *VaultAuthPluginService `json:"service"`
 }
 
 func (v VaultAuthPlugin) MarshalJSON() ([]byte, error) {
@@ -300,9 +300,9 @@ type VaultAuthPluginInput struct {
 	// A set of strings representing HTTP protocols.
 	Protocols []VaultAuthPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *VaultAuthPluginRoute `json:"route,omitempty"`
+	Route *VaultAuthPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *VaultAuthPluginService `json:"service,omitempty"`
+	Service *VaultAuthPluginService `json:"service"`
 }
 
 func (v VaultAuthPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/websocketsizelimitplugin.go
+++ b/internal/sdk/models/shared/websocketsizelimitplugin.go
@@ -146,13 +146,13 @@ type WebsocketSizeLimitPlugin struct {
 	UpdatedAt *int64                         `json:"updated_at,omitempty"`
 	Config    WebsocketSizeLimitPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *WebsocketSizeLimitPluginConsumer `json:"consumer,omitempty"`
+	Consumer *WebsocketSizeLimitPluginConsumer `json:"consumer"`
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support tcp and tls.
 	Protocols []WebsocketSizeLimitPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *WebsocketSizeLimitPluginRoute `json:"route,omitempty"`
+	Route *WebsocketSizeLimitPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *WebsocketSizeLimitPluginService `json:"service,omitempty"`
+	Service *WebsocketSizeLimitPluginService `json:"service"`
 }
 
 func (w WebsocketSizeLimitPlugin) MarshalJSON() ([]byte, error) {
@@ -266,13 +266,13 @@ type WebsocketSizeLimitPluginInput struct {
 	Tags   []string                       `json:"tags,omitempty"`
 	Config WebsocketSizeLimitPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *WebsocketSizeLimitPluginConsumer `json:"consumer,omitempty"`
+	Consumer *WebsocketSizeLimitPluginConsumer `json:"consumer"`
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support tcp and tls.
 	Protocols []WebsocketSizeLimitPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *WebsocketSizeLimitPluginRoute `json:"route,omitempty"`
+	Route *WebsocketSizeLimitPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *WebsocketSizeLimitPluginService `json:"service,omitempty"`
+	Service *WebsocketSizeLimitPluginService `json:"service"`
 }
 
 func (w WebsocketSizeLimitPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/websocketvalidatorplugin.go
+++ b/internal/sdk/models/shared/websocketvalidatorplugin.go
@@ -364,13 +364,13 @@ type WebsocketValidatorPlugin struct {
 	UpdatedAt *int64                         `json:"updated_at,omitempty"`
 	Config    WebsocketValidatorPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *WebsocketValidatorPluginConsumer `json:"consumer,omitempty"`
+	Consumer *WebsocketValidatorPluginConsumer `json:"consumer"`
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support tcp and tls.
 	Protocols []WebsocketValidatorPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *WebsocketValidatorPluginRoute `json:"route,omitempty"`
+	Route *WebsocketValidatorPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *WebsocketValidatorPluginService `json:"service,omitempty"`
+	Service *WebsocketValidatorPluginService `json:"service"`
 }
 
 func (w WebsocketValidatorPlugin) MarshalJSON() ([]byte, error) {
@@ -484,13 +484,13 @@ type WebsocketValidatorPluginInput struct {
 	Tags   []string                       `json:"tags,omitempty"`
 	Config WebsocketValidatorPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *WebsocketValidatorPluginConsumer `json:"consumer,omitempty"`
+	Consumer *WebsocketValidatorPluginConsumer `json:"consumer"`
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support tcp and tls.
 	Protocols []WebsocketValidatorPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *WebsocketValidatorPluginRoute `json:"route,omitempty"`
+	Route *WebsocketValidatorPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *WebsocketValidatorPluginService `json:"service,omitempty"`
+	Service *WebsocketValidatorPluginService `json:"service"`
 }
 
 func (w WebsocketValidatorPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/xmlthreatprotectionplugin.go
+++ b/internal/sdk/models/shared/xmlthreatprotectionplugin.go
@@ -343,13 +343,13 @@ type XMLThreatProtectionPlugin struct {
 	UpdatedAt *int64                          `json:"updated_at,omitempty"`
 	Config    XMLThreatProtectionPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *XMLThreatProtectionPluginConsumer `json:"consumer,omitempty"`
+	Consumer *XMLThreatProtectionPluginConsumer `json:"consumer"`
 	// A set of strings representing HTTP protocols.
 	Protocols []XMLThreatProtectionPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *XMLThreatProtectionPluginRoute `json:"route,omitempty"`
+	Route *XMLThreatProtectionPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *XMLThreatProtectionPluginService `json:"service,omitempty"`
+	Service *XMLThreatProtectionPluginService `json:"service"`
 }
 
 func (x XMLThreatProtectionPlugin) MarshalJSON() ([]byte, error) {
@@ -463,13 +463,13 @@ type XMLThreatProtectionPluginInput struct {
 	Tags   []string                        `json:"tags,omitempty"`
 	Config XMLThreatProtectionPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *XMLThreatProtectionPluginConsumer `json:"consumer,omitempty"`
+	Consumer *XMLThreatProtectionPluginConsumer `json:"consumer"`
 	// A set of strings representing HTTP protocols.
 	Protocols []XMLThreatProtectionPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *XMLThreatProtectionPluginRoute `json:"route,omitempty"`
+	Route *XMLThreatProtectionPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *XMLThreatProtectionPluginService `json:"service,omitempty"`
+	Service *XMLThreatProtectionPluginService `json:"service"`
 }
 
 func (x XMLThreatProtectionPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/models/shared/zipkinplugin.go
+++ b/internal/sdk/models/shared/zipkinplugin.go
@@ -784,13 +784,13 @@ type ZipkinPlugin struct {
 	UpdatedAt *int64             `json:"updated_at,omitempty"`
 	Config    ZipkinPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *ZipkinPluginConsumer `json:"consumer,omitempty"`
+	Consumer *ZipkinPluginConsumer `json:"consumer"`
 	// A set of strings representing protocols.
 	Protocols []ZipkinPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *ZipkinPluginRoute `json:"route,omitempty"`
+	Route *ZipkinPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *ZipkinPluginService `json:"service,omitempty"`
+	Service *ZipkinPluginService `json:"service"`
 }
 
 func (z ZipkinPlugin) MarshalJSON() ([]byte, error) {
@@ -904,13 +904,13 @@ type ZipkinPluginInput struct {
 	Tags   []string           `json:"tags,omitempty"`
 	Config ZipkinPluginConfig `json:"config"`
 	// If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.
-	Consumer *ZipkinPluginConsumer `json:"consumer,omitempty"`
+	Consumer *ZipkinPluginConsumer `json:"consumer"`
 	// A set of strings representing protocols.
 	Protocols []ZipkinPluginProtocols `json:"protocols,omitempty"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.
-	Route *ZipkinPluginRoute `json:"route,omitempty"`
+	Route *ZipkinPluginRoute `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.
-	Service *ZipkinPluginService `json:"service,omitempty"`
+	Service *ZipkinPluginService `json:"service"`
 }
 
 func (z ZipkinPluginInput) MarshalJSON() ([]byte, error) {

--- a/internal/sdk/systemaccountsteammembership.go
+++ b/internal/sdk/systemaccountsteammembership.go
@@ -55,7 +55,7 @@ func (s *SystemAccountsTeamMembership) PostTeamsTeamIDSystemAccounts(ctx context
 		OAuth2Scopes:   []string{},
 		SecuritySource: s.sdkConfiguration.Security,
 	}
-	bodyReader, reqContentType, err := utils.SerializeRequestBody(ctx, request, false, true, "AddSystemAccountToTeam", "json", `request:"mediaType=application/json"`)
+	bodyReader, reqContentType, err := utils.SerializeRequestBody(ctx, request, true, false, "AddSystemAccountToTeam", "json", `request:"mediaType=application/json"`)
 	if err != nil {
 		return nil, err
 	}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -16277,7 +16277,7 @@ components:
             id:
               type: string
           x-foreign: true
-          x-speakeasy-terraform-plan-only: true
+          x-speakeasy-param-computed: false
         created_at:
           description: Unix epoch when the resource was created.
           type: integer
@@ -16344,17 +16344,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     ACLWithoutParents:
       x-speakeasy-entity: GatewayACL
       type: object
@@ -16367,7 +16373,7 @@ components:
             id:
               type: string
           x-foreign: true
-          x-speakeasy-terraform-plan-only: true
+          x-speakeasy-param-computed: false
         created_at:
           description: Unix epoch when the resource was created.
           type: integer
@@ -16707,17 +16713,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     AiPromptDecoratorPlugin:
       x-speakeasy-entity: GatewayPluginAiPromptDecorator
       allOf:
@@ -16776,17 +16788,23 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         consumer_group:
           description: 'If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: ai-prompt-decorator
@@ -16803,17 +16821,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     AiPromptGuardPlugin:
       x-speakeasy-entity: GatewayPluginAiPromptGuard
       allOf:
@@ -16853,17 +16877,23 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         consumer_group:
           description: 'If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: ai-prompt-guard
@@ -16880,17 +16910,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     AiPromptTemplatePlugin:
       x-speakeasy-entity: GatewayPluginAiPromptTemplate
       allOf:
@@ -16929,17 +16965,23 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         consumer_group:
           description: 'If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: ai-prompt-template
@@ -16956,17 +16998,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     AiProxyAdvancedPlugin:
       x-speakeasy-entity: GatewayPluginAiProxyAdvanced
       allOf:
@@ -17454,17 +17502,23 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         consumer_group:
           description: 'If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: ai-proxy-advanced
@@ -17481,17 +17535,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     AiProxyPlugin:
       x-speakeasy-entity: GatewayPluginAiProxy
       allOf:
@@ -17690,17 +17750,23 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         consumer_group:
           description: 'If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: ai-proxy
@@ -17717,17 +17783,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     AiRateLimitingAdvancedPlugin:
       x-speakeasy-entity: GatewayPluginAiRateLimitingAdvanced
       allOf:
@@ -17956,17 +18028,23 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         consumer_group:
           description: 'If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: ai-rate-limiting-advanced
@@ -17983,17 +18061,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     AiRequestTransformerPlugin:
       x-speakeasy-entity: GatewayPluginAiRequestTransformer
       allOf:
@@ -18213,10 +18297,13 @@ components:
         consumer_group:
           description: 'If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: ai-request-transformer
@@ -18233,17 +18320,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     AiResponseTransformerPlugin:
       x-speakeasy-entity: GatewayPluginAiResponseTransformer
       allOf:
@@ -18466,17 +18559,23 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         consumer_group:
           description: 'If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: ai-response-transformer
@@ -18493,17 +18592,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     AiSemanticCachePlugin:
       x-speakeasy-entity: GatewayPluginAiSemanticCache
       allOf:
@@ -18753,17 +18858,23 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         consumer_group:
           description: 'If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: ai-semantic-cache
@@ -18780,17 +18891,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     AiSemanticPromptGuardPlugin:
       x-speakeasy-entity: GatewayPluginAiSemanticPromptGuard
       allOf:
@@ -19048,17 +19165,23 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         consumer_group:
           description: 'If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: ai-semantic-prompt-guard
@@ -19075,17 +19198,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     AwsLambdaPlugin:
       x-speakeasy-entity: GatewayPluginAwsLambda
       allOf:
@@ -19196,10 +19325,13 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: aws-lambda
@@ -19216,17 +19348,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     AzureFunctionsPlugin:
       x-speakeasy-entity: GatewayPluginAzureFunctions
       allOf:
@@ -19270,10 +19408,13 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: azure-functions
@@ -19297,17 +19438,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     BasicAuth:
       x-speakeasy-entity: GatewayBasicAuth
       type: object
@@ -19320,7 +19467,7 @@ components:
             id:
               type: string
           x-foreign: true
-          x-speakeasy-terraform-plan-only: true
+          x-speakeasy-param-computed: false
         created_at:
           description: Unix epoch when the resource was created.
           type: integer
@@ -19383,17 +19530,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     BasicAuthWithoutParents:
       x-speakeasy-entity: GatewayBasicAuth
       type: object
@@ -19406,7 +19559,7 @@ components:
             id:
               type: string
           x-foreign: true
-          x-speakeasy-terraform-plan-only: true
+          x-speakeasy-param-computed: false
         created_at:
           description: Unix epoch when the resource was created.
           type: integer
@@ -19470,17 +19623,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     CACertificate:
       x-speakeasy-entity: GatewayCACertificate
       description: A CA certificate object represents a trusted CA. These objects are used by Kong to verify the validity of a client or server certificate.
@@ -19608,17 +19767,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     Certificate:
       x-speakeasy-entity: GatewayCertificate
       description: 'A certificate object represents a public certificate, and can be optionally paired with the corresponding private key. These objects are used by Kong to handle SSL/TLS termination for encrypted requests, or for use as a trusted CA store when validating peer certificate of client/service. Certificates are optionally associated with SNI objects to tie a cert/key pair to one or more hostnames. If intermediate certificates are required in addition to the main certificate, they should be concatenated together into one string according to the following order: main certificate on the top, followed by any intermediates.'
@@ -19772,10 +19937,13 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: confluent
@@ -19792,17 +19960,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     Consumer:
       x-speakeasy-entity: GatewayConsumer
       description: 'The Consumer object represents a consumer - or a user - of a Service. You can either rely on Kong as the primary datastore, or you can map the consumer list with your database to keep consistency between Kong and your existing primary datastore.'
@@ -19894,10 +20068,13 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: correlation-id
@@ -19914,17 +20091,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     CorsPlugin:
       x-speakeasy-entity: GatewayPluginCors
       allOf:
@@ -19994,17 +20177,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     DatadogPlugin:
       x-speakeasy-entity: GatewayPluginDatadog
       allOf:
@@ -20135,10 +20324,13 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: datadog
@@ -20162,17 +20354,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     DatadogTracingPlugin:
       x-speakeasy-entity: GatewayPluginDatadogTracing
       allOf:
@@ -20208,10 +20406,13 @@ components:
         consumer_group:
           description: 'If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: datadog-tracing
@@ -20228,17 +20429,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     DegraphqlPlugin:
       x-speakeasy-entity: GatewayPluginDegraphql
       allOf:
@@ -20268,17 +20475,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     ExitTransformerPlugin:
       x-speakeasy-entity: GatewayPluginExitTransformer
       allOf:
@@ -20302,10 +20515,13 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: exit-transformer
@@ -20322,17 +20538,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     FileLogPlugin:
       x-speakeasy-entity: GatewayPluginFileLog
       allOf:
@@ -20357,10 +20579,13 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: file-log
@@ -20384,17 +20609,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     ForwardProxyPlugin:
       x-speakeasy-entity: GatewayPluginForwardProxy
       allOf:
@@ -20454,10 +20685,13 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: forward-proxy
@@ -20474,17 +20708,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     GatewayUnauthorizedError:
       type: object
       properties:
@@ -20651,10 +20891,13 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: graphql-proxy-cache-advanced
@@ -20671,17 +20914,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     GraphqlRateLimitingAdvancedPlugin:
       x-speakeasy-entity: GatewayPluginGraphqlRateLimitingAdvanced
       allOf:
@@ -20868,10 +21117,13 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: graphql-rate-limiting-advanced
@@ -20888,17 +21140,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     GrpcGatewayPlugin:
       x-speakeasy-entity: GatewayPluginGrpcGateway
       allOf:
@@ -20915,10 +21173,13 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: grpc-gateway
@@ -20942,17 +21203,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     GrpcWebPlugin:
       x-speakeasy-entity: GatewayPluginGrpcWeb
       allOf:
@@ -20975,10 +21242,13 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: grpc-web
@@ -21002,17 +21272,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     HMACAuth:
       x-speakeasy-entity: GatewayHMACAuth
       type: object
@@ -21025,7 +21301,7 @@ components:
             id:
               type: string
           x-foreign: true
-          x-speakeasy-terraform-plan-only: true
+          x-speakeasy-param-computed: false
         created_at:
           description: Unix epoch when the resource was created.
           type: integer
@@ -21063,7 +21339,7 @@ components:
             id:
               type: string
           x-foreign: true
-          x-speakeasy-terraform-plan-only: true
+          x-speakeasy-param-computed: false
         created_at:
           description: Unix epoch when the resource was created.
           type: integer
@@ -21189,17 +21465,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     HmacAuthPlugin:
       x-speakeasy-entity: GatewayPluginHmacAuth
       allOf:
@@ -21259,17 +21541,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     HttpLogPlugin:
       x-speakeasy-entity: GatewayPluginHttpLog
       allOf:
@@ -21362,10 +21650,13 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: http-log
@@ -21389,17 +21680,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     InjectionProtectionPlugin:
       x-speakeasy-entity: GatewayPluginInjectionProtection
       allOf:
@@ -21477,17 +21774,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     IpRestrictionPlugin:
       x-speakeasy-entity: GatewayPluginIpRestriction
       allOf:
@@ -21519,17 +21822,23 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         consumer_group:
           description: 'If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: ip-restriction
@@ -21553,17 +21862,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     JWT:
       x-speakeasy-entity: GatewayJWT
       type: object
@@ -21593,7 +21908,7 @@ components:
             id:
               type: string
           x-foreign: true
-          x-speakeasy-terraform-plan-only: true
+          x-speakeasy-param-computed: false
         created_at:
           description: Unix epoch when the resource was created.
           type: integer
@@ -21651,7 +21966,7 @@ components:
             id:
               type: string
           x-foreign: true
-          x-speakeasy-terraform-plan-only: true
+          x-speakeasy-param-computed: false
         created_at:
           description: Unix epoch when the resource was created.
           type: integer
@@ -21735,10 +22050,13 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: jq
@@ -21755,17 +22073,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     JsonThreatProtectionPlugin:
       x-speakeasy-entity: GatewayPluginJsonThreatProtection
       allOf:
@@ -21836,17 +22160,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     JweDecryptPlugin:
       x-speakeasy-entity: GatewayPluginJweDecrypt
       allOf:
@@ -21887,17 +22217,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     JwtPlugin:
       x-speakeasy-entity: GatewayPluginJwt
       allOf:
@@ -21967,17 +22303,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     JwtSignerPlugin:
       x-speakeasy-entity: GatewayPluginJwtSigner
       allOf:
@@ -22376,17 +22718,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     KafkaLogPlugin:
       x-speakeasy-entity: GatewayPluginKafkaLog
       allOf:
@@ -22499,10 +22847,13 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: kafka-log
@@ -22521,17 +22872,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     KafkaUpstreamPlugin:
       x-speakeasy-entity: GatewayPluginKafkaUpstream
       allOf:
@@ -22653,10 +23010,13 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: kafka-upstream
@@ -22673,17 +23033,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     Key:
       x-speakeasy-entity: GatewayKey
       description: 'A Key object holds a representation of asymmetric keys in various formats. When Kong or a Kong plugin requires a specific public or private key to perform certain operations, it can use this entity.'
@@ -22725,7 +23091,7 @@ components:
             id:
               type: string
           x-foreign: true
-          x-speakeasy-terraform-plan-only: true
+          x-speakeasy-param-computed: false
         tags:
           description: An optional set of strings associated with the Key for grouping and filtering.
           type: array
@@ -22760,7 +23126,7 @@ components:
             id:
               type: string
           x-foreign: true
-          x-speakeasy-terraform-plan-only: true
+          x-speakeasy-param-computed: false
         created_at:
           description: Unix epoch when the resource was created.
           type: integer
@@ -22837,17 +23203,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     KeyAuthPlugin:
       x-speakeasy-entity: GatewayPluginKeyAuth
       allOf:
@@ -22903,17 +23275,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     KeyAuthWithoutParents:
       x-speakeasy-entity: GatewayKeyAuth
       type: object
@@ -22926,7 +23304,7 @@ components:
             id:
               type: string
           x-foreign: true
-          x-speakeasy-terraform-plan-only: true
+          x-speakeasy-param-computed: false
         created_at:
           description: Unix epoch when the resource was created.
           type: integer
@@ -24371,17 +24749,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     LdapAuthAdvancedPlugin:
       x-speakeasy-entity: GatewayPluginLdapAuthAdvanced
       allOf:
@@ -24486,17 +24870,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     LdapAuthPlugin:
       x-speakeasy-entity: GatewayPluginLdapAuth
       allOf:
@@ -24569,17 +24959,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     LogglyPlugin:
       x-speakeasy-entity: GatewayPluginLoggly
       allOf:
@@ -24657,10 +25053,13 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: loggly
@@ -24684,17 +25083,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     MTLSAuth:
       x-speakeasy-entity: GatewayMTLSAuth
       type: object
@@ -24707,7 +25112,7 @@ components:
             id:
               type: string
           x-foreign: true
-          x-speakeasy-terraform-plan-only: true
+          x-speakeasy-param-computed: false
         consumer:
           type: object
           default: null
@@ -24716,7 +25121,7 @@ components:
             id:
               type: string
           x-foreign: true
-          x-speakeasy-terraform-plan-only: true
+          x-speakeasy-param-computed: false
         created_at:
           description: Unix epoch when the resource was created.
           type: integer
@@ -24752,7 +25157,7 @@ components:
             id:
               type: string
           x-foreign: true
-          x-speakeasy-terraform-plan-only: true
+          x-speakeasy-param-computed: false
         consumer:
           type: object
           default: null
@@ -24761,7 +25166,7 @@ components:
             id:
               type: string
           x-foreign: true
-          x-speakeasy-terraform-plan-only: true
+          x-speakeasy-param-computed: false
         created_at:
           description: Unix epoch when the resource was created.
           type: integer
@@ -24828,10 +25233,13 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: mocking
@@ -24848,17 +25256,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     MtlsAuthPlugin:
       x-speakeasy-entity: GatewayPluginMtlsAuth
       allOf:
@@ -24952,17 +25366,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     OasValidationPlugin:
       x-speakeasy-entity: GatewayPluginOasValidation
       allOf:
@@ -25021,10 +25441,13 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: oas-validation
@@ -25041,17 +25464,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     Oauth2IntrospectionPlugin:
       x-speakeasy-entity: GatewayPluginOauth2Introspection
       allOf:
@@ -25123,17 +25552,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     Oauth2Plugin:
       x-speakeasy-entity: GatewayPluginOauth2
       allOf:
@@ -25223,17 +25658,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     OpaPlugin:
       x-speakeasy-entity: GatewayPluginOpa
       allOf:
@@ -25297,17 +25738,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     OpenidConnectPlugin:
       x-speakeasy-entity: GatewayPluginOpenidConnect
       allOf:
@@ -26717,17 +27164,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     OpentelemetryPlugin:
       x-speakeasy-entity: GatewayPluginOpentelemetry
       allOf:
@@ -26889,10 +27342,13 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: opentelemetry
@@ -26909,17 +27365,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     Plugin:
       description: 'A Plugin entity represents a plugin configuration that will be executed during the HTTP request/response lifecycle. It is how you can add functionalities to Services that run behind Kong, like Authentication or Rate Limiting for example. You can find more information about how to install and what values each plugin takes by visiting the [Kong Hub](https://docs.konghq.com/hub/). When adding a Plugin Configuration to a Service, every request made by a client to that Service will run said Plugin. If a Plugin needs to be tuned to different values for some specific Consumers, you can do so by creating a separate plugin instance that specifies both the Service and the Consumer, through the `service` and `consumer` fields.'
       type: object
@@ -26937,7 +27399,7 @@ components:
             id:
               type: string
           x-foreign: true
-          x-speakeasy-terraform-plan-only: true
+          x-speakeasy-param-computed: false
         consumer_group:
           type: object
           default: null
@@ -26946,7 +27408,7 @@ components:
             id:
               type: string
           x-foreign: true
-          x-speakeasy-terraform-plan-only: true
+          x-speakeasy-param-computed: false
         created_at:
           description: Unix epoch when the resource was created.
           type: integer
@@ -27008,7 +27470,7 @@ components:
             id:
               type: string
           x-foreign: true
-          x-speakeasy-terraform-plan-only: true
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
@@ -27018,7 +27480,7 @@ components:
             id:
               type: string
           x-foreign: true
-          x-speakeasy-terraform-plan-only: true
+          x-speakeasy-param-computed: false
         tags:
           description: An optional set of strings associated with the Plugin for grouping and filtering.
           type: array
@@ -27193,17 +27655,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     PreFunctionPlugin:
       x-speakeasy-entity: GatewayPluginPreFunction
       allOf:
@@ -27277,17 +27745,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     PrometheusPlugin:
       x-speakeasy-entity: GatewayPluginPrometheus
       allOf:
@@ -27319,10 +27793,13 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: prometheus
@@ -27346,17 +27823,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     ProxyCacheAdvancedPlugin:
       x-speakeasy-entity: GatewayPluginProxyCacheAdvanced
       allOf:
@@ -27561,17 +28044,23 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         consumer_group:
           description: 'If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: proxy-cache-advanced
@@ -27588,17 +28077,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     ProxyCachePlugin:
       x-speakeasy-entity: GatewayPluginProxyCache
       allOf:
@@ -27679,17 +28174,23 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         consumer_group:
           description: 'If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: proxy-cache
@@ -27713,17 +28214,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     RateLimitingAdvancedPlugin:
       x-speakeasy-entity: GatewayPluginRateLimitingAdvanced
       allOf:
@@ -27950,17 +28457,23 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         consumer_group:
           description: 'If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: rate-limiting-advanced
@@ -27977,17 +28490,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     RateLimitingPlugin:
       x-speakeasy-entity: GatewayPluginRateLimiting
       allOf:
@@ -28120,17 +28639,23 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         consumer_group:
           description: 'If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: rate-limiting
@@ -28147,17 +28672,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     RedirectPlugin:
       x-speakeasy-entity: GatewayPluginRedirect
       allOf:
@@ -28182,17 +28713,23 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         consumer_group:
           description: 'If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: redirect
@@ -28209,17 +28746,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     RequestSizeLimitingPlugin:
       x-speakeasy-entity: GatewayPluginRequestSizeLimiting
       allOf:
@@ -28246,10 +28789,13 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: request-size-limiting
@@ -28266,17 +28812,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     RequestTerminationPlugin:
       x-speakeasy-entity: GatewayPluginRequestTermination
       allOf:
@@ -28310,17 +28862,23 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         consumer_group:
           description: 'If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: request-termination
@@ -28337,17 +28895,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     RequestTransformerAdvancedPlugin:
       x-speakeasy-entity: GatewayPluginRequestTransformerAdvanced
       allOf:
@@ -28476,17 +29040,23 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         consumer_group:
           description: 'If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: request-transformer-advanced
@@ -28503,17 +29073,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     RequestTransformerPlugin:
       x-speakeasy-entity: GatewayPluginRequestTransformer
       allOf:
@@ -28612,17 +29188,23 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         consumer_group:
           description: 'If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: request-transformer
@@ -28646,17 +29228,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     RequestValidatorPlugin:
       x-speakeasy-entity: GatewayPluginRequestValidator
       allOf:
@@ -28730,10 +29318,13 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: request-validator
@@ -28750,17 +29341,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     ResponseRatelimitingPlugin:
       x-speakeasy-entity: GatewayPluginResponseRatelimiting
       allOf:
@@ -28860,10 +29457,13 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: response-ratelimiting
@@ -28880,17 +29480,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     ResponseTransformerAdvancedPlugin:
       x-speakeasy-entity: GatewayPluginResponseTransformerAdvanced
       allOf:
@@ -29028,17 +29634,23 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         consumer_group:
           description: 'If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: response-transformer-advanced
@@ -29055,17 +29667,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     ResponseTransformerPlugin:
       x-speakeasy-entity: GatewayPluginResponseTransformer
       allOf:
@@ -29175,17 +29793,23 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         consumer_group:
           description: 'If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: response-transformer
@@ -29202,17 +29826,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     RouteByHeaderPlugin:
       x-speakeasy-entity: GatewayPluginRouteByHeader
       allOf:
@@ -29241,10 +29871,13 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: route-by-header
@@ -29261,17 +29894,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     RouteExpression:
       x-speakeasy-entity: GatewayRouteExpression
       description: 'Route entities define rules to match client requests. Each Route is associated with a Service, and a Service may have multiple Routes associated to it. Every request matching a given Route will be proxied to its associated Service. The combination of Routes and Services (and the separation of concerns between them) offers a powerful routing mechanism with which it is possible to define fine-grained entry-points in Kong leading to different upstream services of your infrastructure. You need at least one matching rule that applies to the protocol being matched by the Route.'
@@ -29350,7 +29989,7 @@ components:
             id:
               type: string
           x-foreign: true
-          x-speakeasy-terraform-plan-only: true
+          x-speakeasy-param-computed: false
         strip_path:
           description: 'When matching a Route via one of the `paths`, strip the matching prefix from the upstream request URL.'
           type: boolean
@@ -29475,7 +30114,7 @@ components:
             id:
               type: string
           x-foreign: true
-          x-speakeasy-terraform-plan-only: true
+          x-speakeasy-param-computed: false
         snis:
           description: A list of SNIs that match this Route when using stream routing.
           type: array
@@ -29539,10 +30178,13 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: route-transformer-advanced
@@ -29559,17 +30201,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     SNI:
       x-speakeasy-entity: GatewaySNI
       description: 'An SNI object represents a many-to-one mapping of hostnames to a certificate. That is, a certificate object can have many hostnames associated with it; when Kong receives an SSL request, it uses the SNI field in the Client Hello to lookup the certificate object based on the SNI associated with the certificate.'
@@ -29584,7 +30232,7 @@ components:
             id:
               type: string
           x-foreign: true
-          x-speakeasy-terraform-plan-only: true
+          x-speakeasy-param-computed: false
         created_at:
           description: Unix epoch when the resource was created.
           type: integer
@@ -30004,17 +30652,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     Service:
       x-speakeasy-entity: GatewayService
       description: 'Service entities, as the name implies, are abstractions of each of your own upstream services. Examples of Services would be a data transformation microservice, a billing API, etc. The main attribute of a Service is its URL (where Kong should proxy traffic to), which can be set as a single string or by specifying its `protocol`, `host`, `port` and `path` individually. Services are associated to Routes (a Service can have many Routes associated with it). Routes are entry-points in Kong and define rules to match client requests. Once a Route is matched, Kong proxies the request to its associated Service. See the [Proxy Reference][proxy-reference] for a detailed explanation of how Kong proxies traffic.'
@@ -30035,7 +30689,7 @@ components:
             id:
               type: string
           x-foreign: true
-          x-speakeasy-terraform-plan-only: true
+          x-speakeasy-param-computed: false
         connect_timeout:
           description: The timeout in milliseconds for establishing a connection to the upstream server.
           type: integer
@@ -30321,10 +30975,13 @@ components:
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     SessionPlugin:
       x-speakeasy-entity: GatewayPluginSession
       allOf:
@@ -30475,17 +31132,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     StandardWebhooksPlugin:
       x-speakeasy-entity: GatewayPluginStandardWebhooks
       allOf:
@@ -30506,10 +31169,13 @@ components:
         consumer_group:
           description: 'If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: standard-webhooks
@@ -30526,17 +31192,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     StatsdAdvancedPlugin:
       x-speakeasy-entity: GatewayPluginStatsdAdvanced
       allOf:
@@ -30696,10 +31368,13 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: statsd-advanced
@@ -30723,17 +31398,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     StatsdPlugin:
       x-speakeasy-entity: GatewayPluginStatsd
       allOf:
@@ -30906,10 +31587,13 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: statsd
@@ -30933,17 +31617,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     SyslogPlugin:
       x-speakeasy-entity: GatewayPluginSyslog
       allOf:
@@ -31029,10 +31719,13 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: syslog
@@ -31056,17 +31749,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     Target:
       x-speakeasy-entity: GatewayTarget
       description: 'A target is an ip address/hostname with a port that identifies an instance of a backend service. Every upstream can have many targets, and the targets can be dynamically added, modified, or deleted. Changes take effect on the fly. To disable a target, post a new one with `weight=0`; alternatively, use the `DELETE` convenience method to accomplish the same. The current target object definition is the one with the latest `created_at`.'
@@ -31100,7 +31799,7 @@ components:
             id:
               type: string
           x-foreign: true
-          x-speakeasy-terraform-plan-only: true
+          x-speakeasy-param-computed: false
         weight:
           description: 'The weight this target gets within the upstream loadbalancer (`0`-`65535`). If the hostname resolves to an SRV record, the `weight` value will be overridden by the value from the DNS record.'
           type: integer
@@ -31145,7 +31844,7 @@ components:
             id:
               type: string
           x-foreign: true
-          x-speakeasy-terraform-plan-only: true
+          x-speakeasy-param-computed: false
         weight:
           description: 'The weight this target gets within the upstream loadbalancer (`0`-`65535`). If the hostname resolves to an SRV record, the `weight` value will be overridden by the value from the DNS record.'
           type: integer
@@ -31192,10 +31891,13 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: tcp-log
@@ -31219,17 +31921,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     TlsHandshakeModifierPlugin:
       x-speakeasy-entity: GatewayPluginTlsHandshakeModifier
       allOf:
@@ -31260,17 +31968,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     TlsMetadataHeadersPlugin:
       x-speakeasy-entity: GatewayPluginTlsMetadataHeaders
       allOf:
@@ -31314,17 +32028,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     UdpLogPlugin:
       x-speakeasy-entity: GatewayPluginUdpLog
       allOf:
@@ -31353,10 +32073,13 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: udp-log
@@ -31380,17 +32103,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     Upstream:
       x-speakeasy-entity: GatewayUpstream
       description: 'The upstream object represents a virtual hostname and can be used to loadbalance incoming requests over multiple services (targets). So for example an upstream named `service.v1.xyz` for a Service object whose `host` is `service.v1.xyz`. Requests for this Service would be proxied to the targets defined within the upstream. An upstream also includes a [health checker][healthchecks], which is able to enable and disable targets based on their ability or inability to serve requests. The configuration for the health checker is stored in the upstream object, and applies to all of its targets.'
@@ -31414,7 +32143,7 @@ components:
             id:
               type: string
           x-foreign: true
-          x-speakeasy-terraform-plan-only: true
+          x-speakeasy-param-computed: false
         created_at:
           description: Unix epoch when the resource was created.
           type: integer
@@ -31935,17 +32664,23 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         consumer_group:
           description: 'If set, the plugin will activate only for requests where the specified consumer group has been authenticated. (Note that some plugins can not be restricted to consumers groups this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer Groups'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: upstream-oauth
@@ -31962,17 +32697,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     UpstreamTimeoutPlugin:
       x-speakeasy-entity: GatewayPluginUpstreamTimeout
       allOf:
@@ -32001,10 +32742,13 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: upstream-timeout
@@ -32021,17 +32765,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     Vault:
       x-speakeasy-entity: GatewayVault
       description: 'Vault entities are used to configure different Vault connectors. Examples of Vaults are Environment Variables, Hashicorp Vault and AWS Secrets Manager. Configuring a Vault allows referencing the secrets with other entities. For example a certificate entity can store a reference to a certificate and key, stored in a vault, instead of storing the certificate and key within the entity. This allows a proper separation of secrets and configuration and prevents secret sprawl.'
@@ -32136,17 +32886,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     WebsocketSizeLimitPlugin:
       x-speakeasy-entity: GatewayPluginWebsocketSizeLimit
       allOf:
@@ -32168,10 +32924,13 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: websocket-size-limit
@@ -32186,17 +32945,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     WebsocketValidatorPlugin:
       x-speakeasy-entity: GatewayPluginWebsocketValidator
       allOf:
@@ -32272,10 +33037,13 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: websocket-validator
@@ -32290,17 +33058,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     XmlThreatProtectionPlugin:
       x-speakeasy-entity: GatewayPluginXmlThreatProtection
       allOf:
@@ -32408,10 +33182,13 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: xml-threat-protection
@@ -32428,17 +33205,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
     ZipkinPlugin:
       x-speakeasy-entity: GatewayPluginZipkin
       allOf:
@@ -32650,10 +33433,13 @@ components:
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         name:
           type: string
           const: zipkin
@@ -32677,17 +33463,23 @@ components:
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the route being used.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
         service:
           description: 'If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.'
           type: object
+          default: null
           additionalProperties: false
+          nullable: true
           properties:
             id:
               type: string
+          x-speakeasy-param-computed: false
   requestBodies:
     GroupMembershipAdd:
       content:
@@ -33012,6 +33804,9 @@ components:
                 type: string
                 format: uuid
                 x-speakeasy-name-override: account_id
+            default: null
+            nullable: true
+            x-speakeasy-param-computed: false
       description: The request schema for adding a system account to a team.
     UpdateAuditLogWebhook:
       description: The request schema to modify an audit log webhook.


### PR DESCRIPTION
Given a resource that has a foreign key reference (e.g. `route.id`):

```hcl
resource "konnect_gateway_plugin_rate_limiting" "my_rate_limiting_plugin" {
  enabled = true
  config = {
    minute = 5
    policy = "local"
  }

  protocols        = ["http", "https"]
  control_plane_id = konnect_gateway_control_plane.tfdemo.id
  route = {
    id = konnect_gateway_route.anything.id
  }
}
```

When the `route` entry is removed, Terraform does not detect a change as the `route` config is still populated from the state file

```diff
--- tests/wip/main.tf	2025-02-25 14:19:09
+++ tests/wip/new.tf	2025-02-25 14:19:34
@@ -7,7 +7,4 @@

   protocols        = ["http", "https"]
   control_plane_id = konnect_gateway_control_plane.tfdemo.id
-  route = {
-    id = konnect_gateway_route.anything.id
-  }
 }
```

To solve this, foreign key references (which I've inferred to be "any object that is not required") now have `default: null` and `x-speakeasy-param-computed: false` set.

This results in the correct `terraform apply` behaviour.

```
      - route            = {
          - id = "2c77223b-1be6-4865-8a3e-487414cdadaa" -> null
        } -> null
```

This previously worked by looking for the presence of `x-foreign` on an entity, but we lost that marker when we switched to per-plugin foreign keys in #123 

Platform API changes for this branch can be seen in https://github.com/Kong/platform-api/pull/1038