### PR TITLE
Update speakeasy generation to 1.517.3

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -3,8 +3,8 @@ id: 9d20c53e-7836-4ea8-88b8-a75fb7dce3a2
 management:
   docChecksum: 0e87d02b4401149d149dbdee074a2f46
   docVersion: 2.0.0
-  speakeasyVersion: 1.503.0
-  generationVersion: 2.526.1
+  speakeasyVersion: 1.517.3
+  generationVersion: 2.548.6
   releaseVersion: 2.4.0
   configChecksum: d433cfd8474eb5e235c092f1aff57e21
 features:
@@ -12,7 +12,7 @@ features:
     additionalDependencies: 0.1.0
     additionalProperties: 0.1.2
     constsAndDefaults: 0.2.1
-    core: 3.33.0
+    core: 3.36.1
     deprecations: 2.82.0
     envVarSecurityUsage: 0.1.0
     globalSecurity: 2.81.10

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -1,4 +1,4 @@
-speakeasyVersion: 1.503.0
+speakeasyVersion: 1.517.3
 sources:
     kong:
         sourceNamespace: kong
@@ -15,7 +15,7 @@ targets:
         sourceBlobDigest: sha256:fe7d9348a81627bd7708751e55cd5c4ef15b7c2b748c058ce7dd03298e8a92fa
 workflow:
     workflowVersion: 1.0.0
-    speakeasyVersion: 1.503.0
+    speakeasyVersion: 1.517.3
     sources:
         kong:
             inputs:

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -1,5 +1,5 @@
 workflowVersion: 1.0.0
-speakeasyVersion: 1.503.0
+speakeasyVersion: 1.517.3
 sources:
     kong:
         inputs:

--- a/docs/resources/cloud_gateway_configuration.md
+++ b/docs/resources/cloud_gateway_configuration.md
@@ -20,11 +20,6 @@ resource "konnect_cloud_gateway_configuration" "my_cloudgatewayconfiguration" {
   dataplane_groups = [
     {
       autoscale = {
-        configuration_data_plane_group_autoscale_autopilot = {
-          base_rps = 1
-          kind     = "autopilot"
-          max_rps  = 1000
-        }
         configuration_data_plane_group_autoscale_static = {
           instance_type       = "medium"
           kind                = "static"

--- a/internal/sdk/konnect.go
+++ b/internal/sdk/konnect.go
@@ -296,8 +296,8 @@ func New(opts ...SDKOption) *Konnect {
 			Language:          "go",
 			OpenAPIDocVersion: "2.0.0",
 			SDKVersion:        "2.4.0",
-			GenVersion:        "2.526.1",
-			UserAgent:         "speakeasy-sdk/terraform 2.4.0 2.526.1 2.0.0 github.com/kong/terraform-provider-konnect/v2/internal/sdk",
+			GenVersion:        "2.548.6",
+			UserAgent:         "speakeasy-sdk/terraform 2.4.0 2.548.6 2.0.0 github.com/kong/terraform-provider-konnect/v2/internal/sdk",
 			Hooks:             hooks.New(),
 		},
 	}


### PR DESCRIPTION
The removed doc example is accurate. You can only set `autopilot` or `static`, not both at the same time