### PR TITLE
Sync with platform api 8 april 2025

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,7 +1,7 @@
 lockVersion: 2.0.0
 id: 9d20c53e-7836-4ea8-88b8-a75fb7dce3a2
 management:
-  docChecksum: 50dbd66f06bb921dc5258a1a732895bc
+  docChecksum: b89b0d537cdef4d7100070bf8d09b24a
   docVersion: 2.0.0
   speakeasyVersion: 1.517.3
   generationVersion: 2.548.6

--- a/internal/sdk/serverlesscloudgateways.go
+++ b/internal/sdk/serverlesscloudgateways.go
@@ -26,6 +26,9 @@ func newServerlessCloudGateways(sdkConfig sdkConfiguration) *ServerlessCloudGate
 }
 
 // CreateServerlessCloudGateway - Create a new serverless cloud gateway
+// **Pre-release Endpoint**
+// This endpoint is currently in beta and is subject to change.
+//
 // Create a new serverless cloud gateway
 func (s *ServerlessCloudGateways) CreateServerlessCloudGateway(ctx context.Context, request shared.CreateServerlessCloudGatewayRequest, opts ...operations.Option) (*operations.CreateServerlessCloudGatewayResponse, error) {
 	o := operations.Options{}
@@ -229,6 +232,9 @@ func (s *ServerlessCloudGateways) CreateServerlessCloudGateway(ctx context.Conte
 }
 
 // GetServerlessCloudGateway - Get the serverless cloud gateway
+// **Pre-release Endpoint**
+// This endpoint is currently in beta and is subject to change.
+//
 // Get the serverless cloud gateway
 func (s *ServerlessCloudGateways) GetServerlessCloudGateway(ctx context.Context, request operations.GetServerlessCloudGatewayRequest, opts ...operations.Option) (*operations.GetServerlessCloudGatewayResponse, error) {
 	o := operations.Options{}
@@ -425,6 +431,9 @@ func (s *ServerlessCloudGateways) GetServerlessCloudGateway(ctx context.Context,
 }
 
 // DeleteServerlessCloudGateway - Delete the serverless cloud gateway
+// **Pre-release Endpoint**
+// This endpoint is currently in beta and is subject to change.
+//
 // Delete the serverless cloud gateway
 func (s *ServerlessCloudGateways) DeleteServerlessCloudGateway(ctx context.Context, request operations.DeleteServerlessCloudGatewayRequest, opts ...operations.Option) (*operations.DeleteServerlessCloudGatewayResponse, error) {
 	o := operations.Options{}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -23,7 +23,11 @@ paths:
       x-speakeasy-entity-operation: ServerlessCloudGateway#create
       operationId: create-serverless-cloud-gateway
       summary: Create a new serverless cloud gateway
-      description: Create a new serverless cloud gateway
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Create a new serverless cloud gateway
       requestBody:
         required: true
         content:
@@ -58,7 +62,11 @@ paths:
       x-speakeasy-entity-operation: ServerlessCloudGateway#read
       operationId: get-serverless-cloud-gateway
       summary: Get the serverless cloud gateway
-      description: Get the serverless cloud gateway
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Get the serverless cloud gateway
       responses:
         '200':
           $ref: '#/components/responses/RetrieveServerlessCloudGatewayResponse'
@@ -76,7 +84,11 @@ paths:
       x-speakeasy-entity-operation: ServerlessCloudGateway#delete
       operationId: delete-serverless-cloud-gateway
       summary: Delete the serverless cloud gateway
-      description: Delete the serverless cloud gateway
+      description: |-
+        **Pre-release Endpoint**
+        This endpoint is currently in beta and is subject to change.
+
+        Delete the serverless cloud gateway
       responses:
         '204':
           description: No Content
@@ -13150,6 +13162,8 @@ components:
       properties:
         id:
           $ref: '#/components/schemas/TransitGatewayId'
+        dns_config:
+          $ref: '#/components/schemas/TransitGatewayDnsConfig'
         state:
           $ref: '#/components/schemas/TransitGatewayState'
         entity_version:


### PR DESCRIPTION
Changes:
- Descriptions for serverless cloud gateway mention they are beta endpoints
- dns_config added to BaseTransitGateway response

No changes to the generated provider except comments. So, I have not updated changelog.

How I have tested this - 
- [x] Run generated provider on local
- [x] Run e2e tests