### PR TITLE
Fix Upstream OAuth plugin scopes

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,7 +1,7 @@
 lockVersion: 2.0.0
 id: 9d20c53e-7836-4ea8-88b8-a75fb7dce3a2
 management:
-  docChecksum: e2ba33eead485a4d1bfb3c4d0e6593fa
+  docChecksum: 29e10025471a93554c99da80e83fd08d
   docVersion: 2.0.0
   speakeasyVersion: 1.531.0
   generationVersion: 2.568.2
@@ -7779,10 +7779,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"hosts": ["foo.example.com", "foo.example.us"], "id": "56c4566c-14cc-4132-9011-4139fcbbe50a", "name": "example-route", "paths": ["/v1", "/v2"], "service": {"id": "bd380f99-659d-415e-b0e7-72ea05df3218"}}
+        application/json: {"hosts": ["foo.example.com", "foo.example.us"], "id": "56c4566c-14cc-4132-9011-4139fcbbe50a", "name": "example-route", "paths": ["/v1", "/v2"], "protocols": ["http", "https"], "service": {"id": "bd380f99-659d-415e-b0e7-72ea05df3218"}}
       responses:
         "201":
-          application/json: {"hosts": ["foo.example.com", "foo.example.us"], "id": "56c4566c-14cc-4132-9011-4139fcbbe50a", "name": "example-route", "paths": ["/v1", "/v2"], "service": {"id": "bd380f99-659d-415e-b0e7-72ea05df3218"}}
+          application/json: {"hosts": ["foo.example.com", "foo.example.us"], "id": "56c4566c-14cc-4132-9011-4139fcbbe50a", "name": "example-route", "paths": ["/v1", "/v2"], "protocols": ["http", "https"], "service": {"id": "bd380f99-659d-415e-b0e7-72ea05df3218"}}
         "401":
           application/json: {"message": "<value>", "status": 811488}
   delete-route:
@@ -7802,7 +7802,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"hosts": ["foo.example.com", "foo.example.us"], "id": "56c4566c-14cc-4132-9011-4139fcbbe50a", "name": "example-route", "paths": ["/v1", "/v2"], "service": {"id": "bd380f99-659d-415e-b0e7-72ea05df3218"}}
+          application/json: {"hosts": ["foo.example.com", "foo.example.us"], "id": "56c4566c-14cc-4132-9011-4139fcbbe50a", "name": "example-route", "paths": ["/v1", "/v2"], "protocols": ["http", "https"], "service": {"id": "bd380f99-659d-415e-b0e7-72ea05df3218"}}
         "401":
           application/json: {"message": "<value>", "status": 248766}
   upsert-route:
@@ -7812,10 +7812,10 @@ examples:
           RouteId: "a4326a41-aa12-44e3-93e4-6b6e58bfb9d7"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"hosts": ["foo.example.com", "foo.example.us"], "id": "56c4566c-14cc-4132-9011-4139fcbbe50a", "name": "example-route", "paths": ["/v1", "/v2"], "service": {"id": "bd380f99-659d-415e-b0e7-72ea05df3218"}}
+        application/json: {"hosts": ["foo.example.com", "foo.example.us"], "id": "56c4566c-14cc-4132-9011-4139fcbbe50a", "name": "example-route", "paths": ["/v1", "/v2"], "protocols": ["http", "https"], "service": {"id": "bd380f99-659d-415e-b0e7-72ea05df3218"}}
       responses:
         "200":
-          application/json: {"hosts": ["foo.example.com", "foo.example.us"], "id": "56c4566c-14cc-4132-9011-4139fcbbe50a", "name": "example-route", "paths": ["/v1", "/v2"], "service": {"id": "bd380f99-659d-415e-b0e7-72ea05df3218"}}
+          application/json: {"hosts": ["foo.example.com", "foo.example.us"], "id": "56c4566c-14cc-4132-9011-4139fcbbe50a", "name": "example-route", "paths": ["/v1", "/v2"], "protocols": ["http", "https"], "service": {"id": "bd380f99-659d-415e-b0e7-72ea05df3218"}}
         "401":
           application/json: {"message": "<value>", "status": 298474}
   delete-route-RouteExpression:
@@ -7835,7 +7835,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       responses:
         "200":
-          application/json: {"service": null}
+          application/json: {"protocols": ["http", "https"], "service": null}
         "401":
           application/json: {"message": "<value>", "status": 419229}
   upsert-route-RouteExpression:
@@ -7845,10 +7845,10 @@ examples:
           RouteId: "a4326a41-aa12-44e3-93e4-6b6e58bfb9d7"
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"service": null}
+        application/json: {"protocols": ["http", "https"], "service": null}
       responses:
         "200":
-          application/json: {"service": null}
+          application/json: {"protocols": ["http", "https"], "service": null}
         "401":
           application/json: {"message": "<value>", "status": 578176}
   create-route-RouteExpression:
@@ -7857,10 +7857,10 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"service": null}
+        application/json: {"protocols": ["http", "https"], "service": null}
       responses:
         "201":
-          application/json: {"service": null}
+          application/json: {"protocols": ["http", "https"], "service": null}
         "401":
           application/json: {"message": "<value>", "status": 468015}
   create-service:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.6.0
+> Released on 2025/??/??
+
+### Bug fixes
+
+* The `scopes` property in `konnect_gateway_plugin_upstream_oauth` can now be set to an empty array
+
 ## 2.5.0
 > Released on 2025/04/15
 

--- a/internal/provider/gatewaypluginupstreamoauth_data_source_sdk.go
+++ b/internal/provider/gatewaypluginupstreamoauth_data_source_sdk.go
@@ -149,9 +149,11 @@ func (r *GatewayPluginUpstreamOauthDataSourceModel) RefreshFromSharedUpstreamOau
 					r.Config.Oauth.GrantType = types.StringNull()
 				}
 				r.Config.Oauth.Password = types.StringPointerValue(resp.Config.Oauth.Password)
-				r.Config.Oauth.Scopes = make([]types.String, 0, len(resp.Config.Oauth.Scopes))
-				for _, v := range resp.Config.Oauth.Scopes {
-					r.Config.Oauth.Scopes = append(r.Config.Oauth.Scopes, types.StringValue(v))
+				if resp.Config.Oauth.Scopes != nil {
+					r.Config.Oauth.Scopes = make([]types.String, 0, len(resp.Config.Oauth.Scopes))
+					for _, v := range resp.Config.Oauth.Scopes {
+						r.Config.Oauth.Scopes = append(r.Config.Oauth.Scopes, types.StringValue(v))
+					}
 				}
 				r.Config.Oauth.TokenEndpoint = types.StringPointerValue(resp.Config.Oauth.TokenEndpoint)
 				if len(resp.Config.Oauth.TokenHeaders) > 0 {

--- a/internal/provider/gatewaypluginupstreamoauth_resource.go
+++ b/internal/provider/gatewaypluginupstreamoauth_resource.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/listdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/objectdefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
@@ -441,6 +442,7 @@ func (r *GatewayPluginUpstreamOauthResource) Schema(ctx context.Context, req res
 							"scopes": schema.ListAttribute{
 								Computed:    true,
 								Optional:    true,
+								Default:     listdefault.StaticValue(types.ListValueMust(types.StringType, []attr.Value{})),
 								ElementType: types.StringType,
 								Description: `List of scopes to request from the IdP when obtaining a new token.`,
 							},

--- a/internal/provider/gatewaypluginupstreamoauth_resource_sdk.go
+++ b/internal/provider/gatewaypluginupstreamoauth_resource_sdk.go
@@ -706,9 +706,11 @@ func (r *GatewayPluginUpstreamOauthResourceModel) RefreshFromSharedUpstreamOauth
 					r.Config.Oauth.GrantType = types.StringNull()
 				}
 				r.Config.Oauth.Password = types.StringPointerValue(resp.Config.Oauth.Password)
-				r.Config.Oauth.Scopes = make([]types.String, 0, len(resp.Config.Oauth.Scopes))
-				for _, v := range resp.Config.Oauth.Scopes {
-					r.Config.Oauth.Scopes = append(r.Config.Oauth.Scopes, types.StringValue(v))
+				if resp.Config.Oauth.Scopes != nil {
+					r.Config.Oauth.Scopes = make([]types.String, 0, len(resp.Config.Oauth.Scopes))
+					for _, v := range resp.Config.Oauth.Scopes {
+						r.Config.Oauth.Scopes = append(r.Config.Oauth.Scopes, types.StringValue(v))
+					}
 				}
 				r.Config.Oauth.TokenEndpoint = types.StringPointerValue(resp.Config.Oauth.TokenEndpoint)
 				if len(resp.Config.Oauth.TokenHeaders) > 0 {

--- a/internal/sdk/models/shared/plugin.go
+++ b/internal/sdk/models/shared/plugin.go
@@ -162,7 +162,7 @@ type Plugin struct {
 	Name     string    `json:"name"`
 	Ordering *Ordering `json:"ordering,omitempty"`
 	// A list of the request protocols that will trigger this plugin. The default value, as well as the possible values allowed on this field, may change depending on the plugin type. For example, plugins that only work in stream mode will only support `"tcp"` and `"tls"`.
-	Protocols []Protocols `json:"protocols,omitempty"`
+	Protocols []Protocols `json:"protocols"`
 	// If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.
 	Route *Route `json:"route"`
 	// If set, the plugin will only activate when receiving requests via one of the routes belonging to the specified Service. Leave unset for the plugin to activate regardless of the Service being matched.

--- a/internal/sdk/models/shared/routeexpression.go
+++ b/internal/sdk/models/shared/routeexpression.go
@@ -149,7 +149,7 @@ type RouteExpression struct {
 	PreserveHost *bool  `json:"preserve_host,omitempty"`
 	Priority     *int64 `json:"priority,omitempty"`
 	// An array of the protocols this Route should allow. See the [Route Object](#route-object) section for a list of accepted protocols. When set to only `"https"`, HTTP requests are answered with an upgrade error. When set to only `"http"`, HTTPS requests are answered with an error.
-	Protocols []RouteExpressionProtocols `json:"protocols,omitempty"`
+	Protocols []RouteExpressionProtocols `json:"protocols"`
 	// Whether to enable request body buffering or not. With HTTP 1.1, it may make sense to turn this off on services that receive data with chunked transfer encoding.
 	RequestBuffering *bool `json:"request_buffering,omitempty"`
 	// Whether to enable response body buffering or not. With HTTP 1.1, it may make sense to turn this off on services that send data with chunked transfer encoding.

--- a/internal/sdk/models/shared/routejson.go
+++ b/internal/sdk/models/shared/routejson.go
@@ -194,7 +194,7 @@ type RouteJSON struct {
 	// When matching a Route via one of the `hosts` domain names, use the request `Host` header in the upstream request headers. If set to `false`, the upstream `Host` header will be that of the Service's `host`.
 	PreserveHost *bool `json:"preserve_host,omitempty"`
 	// An array of the protocols this Route should allow. See the [Route Object](#route-object) section for a list of accepted protocols. When set to only `"https"`, HTTP requests are answered with an upgrade error. When set to only `"http"`, HTTPS requests are answered with an error.
-	Protocols []RouteJSONProtocols `json:"protocols,omitempty"`
+	Protocols []RouteJSONProtocols `json:"protocols"`
 	// A number used to choose which route resolves a given request when several routes match it using regexes simultaneously. When two routes match the path and have the same `regex_priority`, the older one (lowest `created_at`) is used. Note that the priority for non-regex routes is different (longer non-regex routes are matched before shorter ones).
 	RegexPriority *int64 `json:"regex_priority,omitempty"`
 	// Whether to enable request body buffering or not. With HTTP 1.1, it may make sense to turn this off on services that receive data with chunked transfer encoding.

--- a/internal/sdk/models/shared/upstreamoauthplugin.go
+++ b/internal/sdk/models/shared/upstreamoauthplugin.go
@@ -656,7 +656,7 @@ type Oauth struct {
 	// The password to use if `config.oauth.grant_type` is set to `password`.
 	Password *string `json:"password,omitempty"`
 	// List of scopes to request from the IdP when obtaining a new token.
-	Scopes []string `json:"scopes,omitempty"`
+	Scopes []string `json:"scopes"`
 	// The token endpoint URI.
 	TokenEndpoint *string `json:"token_endpoint,omitempty"`
 	// Extra headers to be passed in the token endpoint request.

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -26253,6 +26253,11 @@ components:
               - ws
               - wss
             type: string
+          default:
+            - grpc
+            - grpcs
+            - http
+            - https
           nullable: true
         route:
           description: 'If set, the plugin will only activate when receiving requests via the specified route. Leave unset for the plugin to activate regardless of the Route being used.'
@@ -28762,6 +28767,9 @@ components:
               - ws
               - wss
             type: string
+          default:
+            - http
+            - https
           nullable: true
         request_buffering:
           description: 'Whether to enable request body buffering or not. With HTTP 1.1, it may make sense to turn this off on services that receive data with chunked transfer encoding.'
@@ -28885,6 +28893,9 @@ components:
               - ws
               - wss
             type: string
+          default:
+            - http
+            - https
           nullable: true
         regex_priority:
           description: 'A number used to choose which route resolves a given request when several routes match it using regexes simultaneously. When two routes match the path and have the same `regex_priority`, the older one (lowest `created_at`) is used. Note that the priority for non-regex routes is different (longer non-regex routes are matched before shorter ones).'
@@ -31440,6 +31451,8 @@ components:
                   type: array
                   items:
                     type: string
+                  default: []
+                  nullable: true
                 token_endpoint:
                   description: The token endpoint URI.
                   type: string

--- a/tests/resources/gateway_plugin_upstream_oauth_test.go
+++ b/tests/resources/gateway_plugin_upstream_oauth_test.go
@@ -1,0 +1,28 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+)
+
+func TestGatewayPluginUpstreamOauth(t *testing.T) {
+	t.Parallel()
+
+	// OIDC scopes must be optional, and default to an empty array
+	t.Run("empty scopes", func(t *testing.T) {
+		resource.Test(t, resource.TestCase{
+			ProtoV6ProviderFactories: providerFactory,
+			Steps: []resource.TestStep{
+				{
+					Config:          providerConfigUs,
+					ConfigDirectory: config.TestNameDirectory(),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("konnect_gateway_plugin_upstream_oauth.test", "config.oauth.scopes.#", "0"),
+					),
+				},
+			},
+		})
+	})
+}

--- a/tests/resources/testdata/TestGatewayPluginUpstreamOauth/empty_scopes/main.tf
+++ b/tests/resources/testdata/TestGatewayPluginUpstreamOauth/empty_scopes/main.tf
@@ -1,0 +1,22 @@
+resource "konnect_gateway_control_plane" "tfdemo" {
+  name         = "Upstream OAuth Test CP"
+  cluster_type = "CLUSTER_TYPE_CONTROL_PLANE"
+}
+
+resource "konnect_gateway_plugin_upstream_oauth" "test" {
+  enabled = true
+
+  config = {
+    oauth = {
+      token_endpoint = "http://test.test"
+      grant_type = "client_credentials"
+      client_id = "CLIENT_CREDENTIALS_GRANT_POST_AUTH_CLIENT_ID"
+      client_secret = "CLIENT_CREDENTIALS_GRANT_POST_AUTH_CLIENT_SECRET"
+    }
+    behavior = {
+      upstream_access_token_header_name = "X-Custom-Auth"
+    }
+  }
+
+  control_plane_id = konnect_gateway_control_plane.tfdemo.id
+}


### PR DESCRIPTION
There is a small (positive) side effect in this PR, where all array properties that are nullable now contain a `default`.