### PR TITLE
Fix API product false diffs using custom types [PR 2/2]

### DIFF
--- a/.github/workflows/provider-tests.yaml
+++ b/.github/workflows/provider-tests.yaml
@@ -32,3 +32,19 @@ jobs:
       - env:
           KONNECT_SPAT: ${{ secrets.KONNECT_SPAT }}
         run: make acceptance
+  unit:
+    name: Unit Tests (Terraform ${{ matrix.terraform-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Only test against one version for now as these tests are not
+        # namespaced and will conflict
+        terraform-version:
+          - "1.11.*"
+    steps:
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+      - uses: actions/setup-go@cd53bc84d5e2fd85362f4cb840513e06427082d3 # v4
+        with:
+          go-version-file: "go.mod"
+      - run: make test-unit

--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,7 +1,7 @@
 lockVersion: 2.0.0
 id: 9d20c53e-7836-4ea8-88b8-a75fb7dce3a2
 management:
-  docChecksum: bfcc9e7b83455b8d1c1ee983e65dc8b1
+  docChecksum: 04b25dea284f23d839457e13b7857573
   docVersion: 2.0.0
   speakeasyVersion: 1.531.0
   generationVersion: 2.568.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.7.1  
+> Released on ?
+
+### Bug fixes
+
+* The perpetual diff seen in `konnect_api_product_document` and `konnect_api_product_specification` is now fixed
+
 ## 2.7.0  
 > Released on 2025/04/30
 

--- a/Makefile
+++ b/Makefile
@@ -34,3 +34,6 @@ test-cleanup:
 
 acceptance:
 	@TF_ACC=1 go test -v ./tests/resources
+	
+test-unit:
+	go test -v -tags=unit ./...

--- a/customtypes/encodedstring/base64_input_type.go
+++ b/customtypes/encodedstring/base64_input_type.go
@@ -1,0 +1,73 @@
+package encodedstring
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+var (
+	_ basetypes.StringTypable = (*Base64InputType)(nil)
+)
+
+// Base64InputType is an attribute type that represents a string that is base64 encoded, but only in configuration and state, not in the response. It has
+// custom semantic equality defined in the Value type, which decodes the string and compares it with the response after create / update.
+type Base64InputType struct {
+	basetypes.StringType
+}
+
+// String returns a human readable string of the type name.
+func (t Base64InputType) String() string {
+	return "customtypes.encodedstring.Base64InputType"
+}
+
+// ValueType returns the Value type.
+func (t Base64InputType) ValueType(ctx context.Context) attr.Value {
+	return Base64Input{}
+}
+
+// Equal returns true if the given type is equivalent.
+func (t Base64InputType) Equal(o attr.Type) bool {
+	other, ok := o.(Base64InputType)
+
+	if !ok {
+		return false
+	}
+
+	return t.StringType.Equal(other.StringType)
+}
+
+// ValueFromString returns a StringValuable type given a StringValue.
+func (t Base64InputType) ValueFromString(ctx context.Context, in basetypes.StringValue) (basetypes.StringValuable, diag.Diagnostics) {
+	return Base64Input{
+		StringValue: in,
+	}, nil
+}
+
+// ValueFromTerraform returns a Value given a tftypes.Value.  This is meant to convert the tftypes.Value into a more convenient Go type
+// for the provider to consume the data with.
+func (t Base64InputType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	attrValue, err := t.StringType.ValueFromTerraform(ctx, in)
+
+	if err != nil {
+		return nil, err
+	}
+
+	stringValue, ok := attrValue.(basetypes.StringValue)
+
+	if !ok {
+		return nil, fmt.Errorf("unexpected value type of %T", attrValue)
+	}
+
+	stringValuable, diags := t.ValueFromString(ctx, stringValue)
+
+	if diags.HasError() {
+		return nil, fmt.Errorf("unexpected error converting StringValue to StringValuable: %v", diags)
+	}
+
+	return stringValuable, nil
+}

--- a/customtypes/encodedstring/base64_input_value.go
+++ b/customtypes/encodedstring/base64_input_value.go
@@ -1,0 +1,108 @@
+package encodedstring
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+var (
+	_ basetypes.StringValuableWithSemanticEquals = (*Base64Input)(nil)
+)
+
+// Base64Input represents a valid base64 encoded string. Custom semantic equality
+// logic is defined for Base64Input, where the encoded value is decoded, and then compared to the value received in response from Read / Create / Update.
+type Base64Input struct {
+	basetypes.StringValue
+}
+
+// Type returns an Base64InputType.
+func (v Base64Input) Type(_ context.Context) attr.Type {
+	return Base64InputType{}
+}
+
+// Equal returns true if the given value is equivalent.
+func (v Base64Input) Equal(o attr.Value) bool {
+	other, ok := o.(Base64Input)
+
+	if !ok {
+		return false
+	}
+
+	return v.StringValue.Equal(other.StringValue)
+}
+
+// NewBase64InputNull creates an Base64Input with a null value. Determine whether the value is null via IsNull method.
+func NewBase64InputNull() Base64Input {
+	return Base64Input{
+		StringValue: basetypes.NewStringNull(),
+	}
+}
+
+// NewBase64InputUnknown creates an Base64Input with an unknown value. Determine whether the value is unknown via IsUnknown method.
+func NewBase64InputUnknown() Base64Input {
+	return Base64Input{
+		StringValue: basetypes.NewStringUnknown(),
+	}
+}
+
+// NewBase64InputValue creates an Base64Input with a known value. Access the value via ValueString method.
+func NewBase64InputValue(value string) Base64Input {
+	return Base64Input{
+		StringValue: basetypes.NewStringValue(value),
+	}
+}
+
+// NewBase64InputPointerValue creates an Base64Input with a null value if nil or a known value. Access the value via ValueStringPointer method.
+func NewBase64InputPointerValue(value *string) Base64Input {
+	return Base64Input{
+		StringValue: basetypes.NewStringPointerValue(value),
+	}
+}
+
+// StringSemanticEquals decodes givenValuable, compares it with the receiver string value and returns whether they are inconsequentially equal.
+// Semantic equality is checked during planning phase, and after receiving response in apply phase. In planning phase, givenValuable comes from the state, and v
+// is the current value - from Read method response. In the apply phase, givenValuable is from the plan, and v is from response of Create / Update.
+func (v Base64Input) StringSemanticEquals(ctx context.Context, givenValuable basetypes.StringValuable) (bool, diag.Diagnostics) {
+	var diags diag.Diagnostics
+	// The framework should always pass the correct value type, but always check
+	_, ok := givenValuable.(Base64Input)
+
+	if !ok {
+		diags.AddError(
+			"Semantic Equality Check Error",
+			"An unexpected value type was received while performing semantic equality checks. "+
+				"Please report this to the provider developers.\n\n"+
+				"Expected Value Type: "+fmt.Sprintf("%T", v)+"\n"+
+				"Got Value Type: "+fmt.Sprintf("%T", givenValuable),
+		)
+
+		return false, diags
+	}
+
+	givenStringValue, err := givenValuable.ToStringValue(ctx)
+	if err != nil {
+		// Not a StringValue type.
+		diags.AddError(
+			"Custom String Conversion Error",
+			"An unexpected error was encountered trying to convert a custom string. This is always an error in the provider. Please report the following to the provider developer:\n\n",
+		)
+		return false, diags
+	}
+
+	decodedGivenStringBytes, errors := base64.StdEncoding.DecodeString(givenStringValue.ValueString())
+	if errors != nil {
+		// Not base64 encoded, return false so value from response is used in plan to compare with config.
+		diags.AddError(
+			"Custom String Decode Error",
+			"An unexpected error was encountered trying to decode a custom string. This is always an error in the provider. Please report the following to the provider developer:\n\n",
+		)
+		return false, diags
+	}
+
+	return string(decodedGivenStringBytes) == v.ValueString(), diags
+}

--- a/customtypes/encodedstring/base64_input_value_test.go
+++ b/customtypes/encodedstring/base64_input_value_test.go
@@ -1,0 +1,49 @@
+//go:build unit
+
+package encodedstring
+
+import (
+	"context"
+	"testing"
+)
+
+func TestBase64InputValue(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name                           string
+		stateOrConfigValue             string
+		currentValue                   string
+		expectedSemanticEqualityOutput bool
+	}{
+		{
+			name:                           "semantically equal values",
+			stateOrConfigValue:             "c2FtcGxlIHZhbHVl",
+			currentValue:                   "sample value",
+			expectedSemanticEqualityOutput: true,
+		},
+		{
+			name:                           "semantically unequal values",
+			stateOrConfigValue:             "c2FtcGxlIHZhbHVl",
+			currentValue:                   "not sample value",
+			expectedSemanticEqualityOutput: false,
+		},
+	}
+
+	ctx := context.Background()
+
+	for _, testCase := range testCases {
+
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			givenValue := NewBase64InputValue(testCase.stateOrConfigValue)
+			currentValue := NewBase64InputValue(testCase.currentValue)
+
+			areEqual, _ := currentValue.StringSemanticEquals(ctx, givenValue)
+
+			if areEqual != testCase.expectedSemanticEqualityOutput {
+				t.Errorf("Unexpected difference in Base64Input semantic equality, got: %t, expected: %t", areEqual, testCase.expectedSemanticEqualityOutput)
+			}
+		})
+	}
+}

--- a/customtypes/encodedstring/base64_or_plain_input_type.go
+++ b/customtypes/encodedstring/base64_or_plain_input_type.go
@@ -1,0 +1,76 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package encodedstring
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+)
+
+var (
+	_ basetypes.StringTypable = (*Base64OrPlainInputType)(nil)
+)
+
+// Base64OrPlainInputType is an attribute type that represents a string that is optionally base64 encoded, but only in configuration and state, not in the response. It has
+// custom semantic equality defined in the Value type, which does a double comparison with the value in response of Read/Create/Update - with and without decoding.
+type Base64OrPlainInputType struct {
+	basetypes.StringType
+}
+
+// String returns a human readable string of the type name.
+func (t Base64OrPlainInputType) String() string {
+	return "customtypes.encodedstring.Base64OrPlainInputType"
+}
+
+// ValueType returns the Value type.
+func (t Base64OrPlainInputType) ValueType(ctx context.Context) attr.Value {
+	return Base64OrPlainInput{}
+}
+
+// Equal returns true if the given type is equivalent.
+func (t Base64OrPlainInputType) Equal(o attr.Type) bool {
+	other, ok := o.(Base64OrPlainInputType)
+
+	if !ok {
+		return false
+	}
+
+	return t.StringType.Equal(other.StringType)
+}
+
+// ValueFromString returns a StringValuable type given a StringValue.
+func (t Base64OrPlainInputType) ValueFromString(ctx context.Context, in basetypes.StringValue) (basetypes.StringValuable, diag.Diagnostics) {
+	return Base64OrPlainInput{
+		StringValue: in,
+	}, nil
+}
+
+// ValueFromTerraform returns a Value given a tftypes.Value.  This is meant to convert the tftypes.Value into a more convenient Go type
+// for the provider to consume the data with.
+func (t Base64OrPlainInputType) ValueFromTerraform(ctx context.Context, in tftypes.Value) (attr.Value, error) {
+	attrValue, err := t.StringType.ValueFromTerraform(ctx, in)
+
+	if err != nil {
+		return nil, err
+	}
+
+	stringValue, ok := attrValue.(basetypes.StringValue)
+
+	if !ok {
+		return nil, fmt.Errorf("unexpected value type of %T", attrValue)
+	}
+
+	stringValuable, diags := t.ValueFromString(ctx, stringValue)
+
+	if diags.HasError() {
+		return nil, fmt.Errorf("unexpected error converting StringValue to StringValuable: %v", diags)
+	}
+
+	return stringValuable, nil
+}

--- a/customtypes/encodedstring/base64_or_plain_input_value.go
+++ b/customtypes/encodedstring/base64_or_plain_input_value.go
@@ -1,0 +1,118 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package encodedstring
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/diag"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+)
+
+var (
+	_ basetypes.StringValuable = (*Base64OrPlainInput)(nil)
+)
+
+// Base64OrPlainInput represents a valid IPv4 address string (dotted decimal, no leading zeroes). No semantic equality
+// logic is defined for Base64OrPlainInput, so it will follow Terraform's data-consistency rules for strings, which must match byte-for-byte.
+type Base64OrPlainInput struct {
+	basetypes.StringValue
+}
+
+// Type returns an Base64OrPlainInputType.
+func (v Base64OrPlainInput) Type(_ context.Context) attr.Type {
+	return Base64OrPlainInputType{}
+}
+
+// Equal returns true if the given value is equivalent.
+func (v Base64OrPlainInput) Equal(o attr.Value) bool {
+	other, ok := o.(Base64OrPlainInput)
+
+	if !ok {
+		return false
+	}
+
+	return v.StringValue.Equal(other.StringValue)
+}
+
+// NewBase64OrPlainInputNull creates an Base64OrPlainInput with a null value. Determine whether the value is null via IsNull method.
+func NewBase64OrPlainInputNull() Base64OrPlainInput {
+	return Base64OrPlainInput{
+		StringValue: basetypes.NewStringNull(),
+	}
+}
+
+// NewBase64OrPlainInputUnknown creates an Base64OrPlainInput with an unknown value. Determine whether the value is unknown via IsUnknown method.
+func NewBase64OrPlainInputUnknown() Base64OrPlainInput {
+	return Base64OrPlainInput{
+		StringValue: basetypes.NewStringUnknown(),
+	}
+}
+
+// NewBase64OrPlainInputValue creates an Base64OrPlainInput with a known value. Access the value via ValueString method.
+func NewBase64OrPlainInputValue(value string) Base64OrPlainInput {
+	return Base64OrPlainInput{
+		StringValue: basetypes.NewStringValue(value),
+	}
+}
+
+// NewBase64OrPlainInputPointerValue creates an Base64OrPlainInput with a null value if nil or a known value. Access the value via ValueStringPointer method.
+func NewBase64OrPlainInputPointerValue(value *string) Base64OrPlainInput {
+	return Base64OrPlainInput{
+		StringValue: basetypes.NewStringPointerValue(value),
+	}
+}
+
+// StringSemanticEquals decodes givenValuable, compares it with the receiver string value and returns whether they are inconsequentially equal.
+// Semantic equality is checked during planning phase, and after receiving response in apply phase.
+// In planning phase, givenValuable comes from the state, and v
+// is the current value - from Read method response. In the apply phase, givenValuable is from the plan, and v is from response of Create / Update.
+func (v Base64OrPlainInput) StringSemanticEquals(ctx context.Context, givenValuable basetypes.StringValuable) (bool, diag.Diagnostics) {
+	var diags diag.Diagnostics
+
+	// The framework should always pass the correct value type, but always check
+	_, ok := givenValuable.(Base64OrPlainInput)
+
+	if !ok {
+		diags.AddError(
+			"Semantic Equality Check Error",
+			"An unexpected value type was received while performing semantic equality checks. "+
+				"Please report this to the provider developers.\n\n"+
+				"Expected Value Type: "+fmt.Sprintf("%T", v)+"\n"+
+				"Got Value Type: "+fmt.Sprintf("%T", givenValuable),
+		)
+
+		return false, diags
+	}
+
+	givenStringValue, err := givenValuable.ToStringValue(ctx)
+	if err != nil {
+		// Not a StringValue type.
+		diags.AddError(
+			"Custom String Conversion Error",
+			"An unexpected error was encountered trying to convert a custom string. This is always an error in the provider. Please report the following to the provider developer:\n\n",
+		)
+		return false, diags
+	}
+
+	if v.ValueString() == givenStringValue.ValueString() {
+		// given value is a plain string, and equal to v, so do nothing else.
+		return true, diags
+	}
+
+	decodedGivenValueBytes, errors := base64.StdEncoding.DecodeString(givenStringValue.ValueString())
+	if errors != nil {
+		// Error while decoding, return false so value from response is used in plan to compare with config.
+		diags.AddError(
+			"Custom String Decode Error",
+			"An unexpected error was encountered trying to decode a custom string. This is always an error in the provider. Please report the following to the provider developer:\n\n",
+		)
+		return false, diags
+	}
+
+	return string(decodedGivenValueBytes) == v.ValueString(), diags
+}

--- a/customtypes/encodedstring/base64_or_plain_input_value_test.go
+++ b/customtypes/encodedstring/base64_or_plain_input_value_test.go
@@ -1,0 +1,61 @@
+//go:build unit
+
+package encodedstring
+
+import (
+	"context"
+	"testing"
+)
+
+func TestBase64OrPlainInputValue(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name                           string
+		stateOrConfigValue             string
+		currentValue                   string
+		expectedSemanticEqualityOutput bool
+	}{
+		{
+			name:                           "semantically equal values with encoded config/state value",
+			stateOrConfigValue:             "c2FtcGxlIHZhbHVl",
+			currentValue:                   "sample value",
+			expectedSemanticEqualityOutput: true,
+		},
+		{
+			name:                           "semantically unequal values",
+			stateOrConfigValue:             "c2FtcGxlIHZhbHVl",
+			currentValue:                   "not sample value",
+			expectedSemanticEqualityOutput: false,
+		},
+		{
+			name:                           "semantically equal plain values",
+			stateOrConfigValue:             "#My document",
+			currentValue:                   "#My document",
+			expectedSemanticEqualityOutput: true,
+		},
+		{
+			name:                           "semantically unequal plain values",
+			stateOrConfigValue:             "#My document",
+			currentValue:                   "#Not My document",
+			expectedSemanticEqualityOutput: false,
+		},
+	}
+
+	ctx := context.Background()
+
+	for _, testCase := range testCases {
+
+		t.Run(testCase.name, func(t *testing.T) {
+			t.Parallel()
+			givenValue := NewBase64OrPlainInputValue(testCase.stateOrConfigValue)
+			currentValue := NewBase64OrPlainInputValue(testCase.currentValue)
+
+			areEqual, _ := currentValue.StringSemanticEquals(ctx, givenValue)
+
+			if areEqual != testCase.expectedSemanticEqualityOutput {
+				t.Errorf("Unexpected difference in Base64OrPlainInput semantic equality, got: %t, expected: %t", areEqual, testCase.expectedSemanticEqualityOutput)
+			}
+		})
+	}
+}

--- a/docs/resources/gateway_control_plane.md
+++ b/docs/resources/gateway_control_plane.md
@@ -43,7 +43,7 @@ resource "konnect_gateway_control_plane" "my_gatewaycontrolplane" {
 
 - `auth_type` (String) The auth type value of the cluster associated with the Runtime Group. must be one of ["pinned_client_certs", "pki_client_certs"]
 - `cloud_gateway` (Boolean) Whether this control-plane can be used for cloud-gateways. Requires replacement if changed.
-- `cluster_type` (String) The ClusterType value of the cluster associated with the Control Plane. must be one of ["CLUSTER_TYPE_CONTROL_PLANE", "CLUSTER_TYPE_K8S_INGRESS_CONTROLLER", "CLUSTER_TYPE_CONTROL_PLANE_GROUP", "CLUSTER_TYPE_SERVERLESS", "CLUSTER_TYPE_HYBRID"]; Requires replacement if changed.
+- `cluster_type` (String) The ClusterType value of the cluster associated with the Control Plane. must be one of ["CLUSTER_TYPE_CONTROL_PLANE", "CLUSTER_TYPE_K8S_INGRESS_CONTROLLER", "CLUSTER_TYPE_CONTROL_PLANE_GROUP", "CLUSTER_TYPE_SERVERLESS", "CLUSTER_TYPE_KAFKA_NATIVE_EVENT_PROXY", "CLUSTER_TYPE_HYBRID"]; Requires replacement if changed.
 - `description` (String) The description of the control plane in Konnect.
 - `labels` (Map of String) Labels store metadata of an entity that can be used for filtering an entity list or for searching across entity types. 
 
@@ -72,7 +72,7 @@ Read-Only:
 
 - `auth_type` (String) The auth type value of the cluster associated with the Runtime Group. must be one of ["pinned_client_certs", "pki_client_certs"]
 - `cloud_gateway` (Boolean) Whether the Control Plane can be used for cloud-gateways.
-- `cluster_type` (String) The ClusterType value of the cluster associated with the Control Plane. must be one of ["CLUSTER_TYPE_CONTROL_PLANE", "CLUSTER_TYPE_K8S_INGRESS_CONTROLLER", "CLUSTER_TYPE_CONTROL_PLANE_GROUP", "CLUSTER_TYPE_SERVERLESS", "CLUSTER_TYPE_HYBRID"]
+- `cluster_type` (String) The ClusterType value of the cluster associated with the Control Plane. must be one of ["CLUSTER_TYPE_CONTROL_PLANE", "CLUSTER_TYPE_K8S_INGRESS_CONTROLLER", "CLUSTER_TYPE_CONTROL_PLANE_GROUP", "CLUSTER_TYPE_SERVERLESS", "CLUSTER_TYPE_KAFKA_NATIVE_EVENT_PROXY", "CLUSTER_TYPE_HYBRID"]
 - `control_plane_endpoint` (String) Control Plane Endpoint.
 - `proxy_urls` (Attributes Set) Array of proxy URLs associated with reaching the data-planes connected to a control-plane. (see [below for nested schema](#nestedatt--config--proxy_urls))
 - `telemetry_endpoint` (String) Telemetry Endpoint.

--- a/internal/provider/apiproductdocument_resource.go
+++ b/internal/provider/apiproductdocument_resource.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/kong/terraform-provider-konnect/v2/customtypes/encodedstring"
 	tfTypes "github.com/kong/terraform-provider-konnect/v2/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect/v2/internal/sdk"
 	"github.com/kong/terraform-provider-konnect/v2/internal/sdk/models/operations"
@@ -36,16 +37,16 @@ type APIProductDocumentResource struct {
 
 // APIProductDocumentResourceModel describes the resource data model.
 type APIProductDocumentResourceModel struct {
-	APIProductID     types.String      `tfsdk:"api_product_id"`
-	Content          types.String      `tfsdk:"content"`
-	CreatedAt        types.String      `tfsdk:"created_at"`
-	ID               types.String      `tfsdk:"id"`
-	Metadata         *tfTypes.Metadata `tfsdk:"metadata"`
-	ParentDocumentID types.String      `tfsdk:"parent_document_id"`
-	Slug             types.String      `tfsdk:"slug"`
-	Status           types.String      `tfsdk:"status"`
-	Title            types.String      `tfsdk:"title"`
-	UpdatedAt        types.String      `tfsdk:"updated_at"`
+	APIProductID     types.String                     `tfsdk:"api_product_id"`
+	Content          encodedstring.Base64OrPlainInput `tfsdk:"content"`
+	CreatedAt        types.String                     `tfsdk:"created_at"`
+	ID               types.String                     `tfsdk:"id"`
+	Metadata         *tfTypes.Metadata                `tfsdk:"metadata"`
+	ParentDocumentID types.String                     `tfsdk:"parent_document_id"`
+	Slug             types.String                     `tfsdk:"slug"`
+	Status           types.String                     `tfsdk:"status"`
+	Title            types.String                     `tfsdk:"title"`
+	UpdatedAt        types.String                     `tfsdk:"updated_at"`
 }
 
 func (r *APIProductDocumentResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -61,6 +62,7 @@ func (r *APIProductDocumentResource) Schema(ctx context.Context, req resource.Sc
 				Description: `The API product identifier`,
 			},
 			"content": schema.StringAttribute{
+				CustomType:  encodedstring.Base64OrPlainInputType{},
 				Computed:    true,
 				Optional:    true,
 				Description: `Can be markdown string content or base64 encoded string`,

--- a/internal/provider/apiproductdocument_resource_sdk.go
+++ b/internal/provider/apiproductdocument_resource_sdk.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/kong/terraform-provider-konnect/v2/customtypes/encodedstring"
 	"github.com/kong/terraform-provider-konnect/v2/internal/provider/typeconvert"
 	tfTypes "github.com/kong/terraform-provider-konnect/v2/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect/v2/internal/sdk/models/shared"
@@ -50,7 +51,9 @@ func (r *APIProductDocumentResourceModel) RefreshFromSharedAPIProductDocument(ct
 	var diags diag.Diagnostics
 
 	if resp != nil {
-		r.Content = types.StringValue(resp.Content)
+		contentValuable, contentDiags := encodedstring.Base64OrPlainInputType{}.ValueFromString(ctx, types.StringValue(resp.Content))
+		diags.Append(contentDiags...)
+		r.Content, _ = contentValuable.(encodedstring.Base64OrPlainInput)
 		r.CreatedAt = types.StringValue(typeconvert.TimeToString(resp.CreatedAt))
 		r.ID = types.StringValue(resp.ID)
 		if r.Metadata == nil {

--- a/internal/provider/apiproductspecification_resource.go
+++ b/internal/provider/apiproductspecification_resource.go
@@ -14,6 +14,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	"github.com/kong/terraform-provider-konnect/v2/customtypes/encodedstring"
 	"github.com/kong/terraform-provider-konnect/v2/internal/sdk"
 	"github.com/kong/terraform-provider-konnect/v2/internal/sdk/models/operations"
 	"github.com/kong/terraform-provider-konnect/v2/internal/validators"
@@ -35,13 +36,13 @@ type APIProductSpecificationResource struct {
 
 // APIProductSpecificationResourceModel describes the resource data model.
 type APIProductSpecificationResourceModel struct {
-	APIProductID        types.String `tfsdk:"api_product_id"`
-	APIProductVersionID types.String `tfsdk:"api_product_version_id"`
-	Content             types.String `tfsdk:"content"`
-	CreatedAt           types.String `tfsdk:"created_at"`
-	ID                  types.String `tfsdk:"id"`
-	Name                types.String `tfsdk:"name"`
-	UpdatedAt           types.String `tfsdk:"updated_at"`
+	APIProductID        types.String              `tfsdk:"api_product_id"`
+	APIProductVersionID types.String              `tfsdk:"api_product_version_id"`
+	Content             encodedstring.Base64Input `tfsdk:"content"`
+	CreatedAt           types.String              `tfsdk:"created_at"`
+	ID                  types.String              `tfsdk:"id"`
+	Name                types.String              `tfsdk:"name"`
+	UpdatedAt           types.String              `tfsdk:"updated_at"`
 }
 
 func (r *APIProductSpecificationResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -61,6 +62,7 @@ func (r *APIProductSpecificationResource) Schema(ctx context.Context, req resour
 				Description: `The API product version identifier`,
 			},
 			"content": schema.StringAttribute{
+				CustomType:  encodedstring.Base64InputType{},
 				Required:    true,
 				Description: `The base64 encoded contents of the API product version specification`,
 				Validators: []validator.String{

--- a/internal/provider/apiproductspecification_resource_sdk.go
+++ b/internal/provider/apiproductspecification_resource_sdk.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"github.com/hashicorp/terraform-plugin-framework/diag"
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/kong/terraform-provider-konnect/v2/customtypes/encodedstring"
 	"github.com/kong/terraform-provider-konnect/v2/internal/provider/typeconvert"
 	"github.com/kong/terraform-provider-konnect/v2/internal/sdk/models/shared"
 )
@@ -28,7 +29,9 @@ func (r *APIProductSpecificationResourceModel) RefreshFromSharedAPIProductVersio
 	var diags diag.Diagnostics
 
 	if resp != nil {
-		r.Content = types.StringValue(resp.Content)
+		contentValuable, contentDiags := encodedstring.Base64InputType{}.ValueFromString(ctx, types.StringValue(resp.Content))
+		diags.Append(contentDiags...)
+		r.Content, _ = contentValuable.(encodedstring.Base64Input)
 		r.CreatedAt = types.StringValue(typeconvert.TimeToString(resp.CreatedAt))
 		r.ID = types.StringValue(resp.ID)
 		r.Name = types.StringValue(resp.Name)

--- a/internal/provider/gatewaycontrolplane_resource.go
+++ b/internal/provider/gatewaycontrolplane_resource.go
@@ -77,13 +77,14 @@ func (r *GatewayControlPlaneResource) Schema(ctx context.Context, req resource.S
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplaceIfConfigured(),
 				},
-				Description: `The ClusterType value of the cluster associated with the Control Plane. must be one of ["CLUSTER_TYPE_CONTROL_PLANE", "CLUSTER_TYPE_K8S_INGRESS_CONTROLLER", "CLUSTER_TYPE_CONTROL_PLANE_GROUP", "CLUSTER_TYPE_SERVERLESS", "CLUSTER_TYPE_HYBRID"]; Requires replacement if changed.`,
+				Description: `The ClusterType value of the cluster associated with the Control Plane. must be one of ["CLUSTER_TYPE_CONTROL_PLANE", "CLUSTER_TYPE_K8S_INGRESS_CONTROLLER", "CLUSTER_TYPE_CONTROL_PLANE_GROUP", "CLUSTER_TYPE_SERVERLESS", "CLUSTER_TYPE_KAFKA_NATIVE_EVENT_PROXY", "CLUSTER_TYPE_HYBRID"]; Requires replacement if changed.`,
 				Validators: []validator.String{
 					stringvalidator.OneOf(
 						"CLUSTER_TYPE_CONTROL_PLANE",
 						"CLUSTER_TYPE_K8S_INGRESS_CONTROLLER",
 						"CLUSTER_TYPE_CONTROL_PLANE_GROUP",
 						"CLUSTER_TYPE_SERVERLESS",
+						"CLUSTER_TYPE_KAFKA_NATIVE_EVENT_PROXY",
 						"CLUSTER_TYPE_HYBRID",
 					),
 				},
@@ -107,13 +108,14 @@ func (r *GatewayControlPlaneResource) Schema(ctx context.Context, req resource.S
 					},
 					"cluster_type": schema.StringAttribute{
 						Computed:    true,
-						Description: `The ClusterType value of the cluster associated with the Control Plane. must be one of ["CLUSTER_TYPE_CONTROL_PLANE", "CLUSTER_TYPE_K8S_INGRESS_CONTROLLER", "CLUSTER_TYPE_CONTROL_PLANE_GROUP", "CLUSTER_TYPE_SERVERLESS", "CLUSTER_TYPE_HYBRID"]`,
+						Description: `The ClusterType value of the cluster associated with the Control Plane. must be one of ["CLUSTER_TYPE_CONTROL_PLANE", "CLUSTER_TYPE_K8S_INGRESS_CONTROLLER", "CLUSTER_TYPE_CONTROL_PLANE_GROUP", "CLUSTER_TYPE_SERVERLESS", "CLUSTER_TYPE_KAFKA_NATIVE_EVENT_PROXY", "CLUSTER_TYPE_HYBRID"]`,
 						Validators: []validator.String{
 							stringvalidator.OneOf(
 								"CLUSTER_TYPE_CONTROL_PLANE",
 								"CLUSTER_TYPE_K8S_INGRESS_CONTROLLER",
 								"CLUSTER_TYPE_CONTROL_PLANE_GROUP",
 								"CLUSTER_TYPE_SERVERLESS",
+								"CLUSTER_TYPE_KAFKA_NATIVE_EVENT_PROXY",
 								"CLUSTER_TYPE_HYBRID",
 							),
 						},

--- a/internal/sdk/models/shared/controlplane.go
+++ b/internal/sdk/models/shared/controlplane.go
@@ -13,11 +13,12 @@ import (
 type ControlPlaneClusterType string
 
 const (
-	ControlPlaneClusterTypeClusterTypeControlPlane         ControlPlaneClusterType = "CLUSTER_TYPE_CONTROL_PLANE"
-	ControlPlaneClusterTypeClusterTypeK8SIngressController ControlPlaneClusterType = "CLUSTER_TYPE_K8S_INGRESS_CONTROLLER"
-	ControlPlaneClusterTypeClusterTypeControlPlaneGroup    ControlPlaneClusterType = "CLUSTER_TYPE_CONTROL_PLANE_GROUP"
-	ControlPlaneClusterTypeClusterTypeServerless           ControlPlaneClusterType = "CLUSTER_TYPE_SERVERLESS"
-	ControlPlaneClusterTypeClusterTypeHybrid               ControlPlaneClusterType = "CLUSTER_TYPE_HYBRID"
+	ControlPlaneClusterTypeClusterTypeControlPlane          ControlPlaneClusterType = "CLUSTER_TYPE_CONTROL_PLANE"
+	ControlPlaneClusterTypeClusterTypeK8SIngressController  ControlPlaneClusterType = "CLUSTER_TYPE_K8S_INGRESS_CONTROLLER"
+	ControlPlaneClusterTypeClusterTypeControlPlaneGroup     ControlPlaneClusterType = "CLUSTER_TYPE_CONTROL_PLANE_GROUP"
+	ControlPlaneClusterTypeClusterTypeServerless            ControlPlaneClusterType = "CLUSTER_TYPE_SERVERLESS"
+	ControlPlaneClusterTypeClusterTypeKafkaNativeEventProxy ControlPlaneClusterType = "CLUSTER_TYPE_KAFKA_NATIVE_EVENT_PROXY"
+	ControlPlaneClusterTypeClusterTypeHybrid                ControlPlaneClusterType = "CLUSTER_TYPE_HYBRID"
 )
 
 func (e ControlPlaneClusterType) ToPointer() *ControlPlaneClusterType {
@@ -36,6 +37,8 @@ func (e *ControlPlaneClusterType) UnmarshalJSON(data []byte) error {
 	case "CLUSTER_TYPE_CONTROL_PLANE_GROUP":
 		fallthrough
 	case "CLUSTER_TYPE_SERVERLESS":
+		fallthrough
+	case "CLUSTER_TYPE_KAFKA_NATIVE_EVENT_PROXY":
 		fallthrough
 	case "CLUSTER_TYPE_HYBRID":
 		*e = ControlPlaneClusterType(v)

--- a/internal/sdk/models/shared/createcontrolplanerequest.go
+++ b/internal/sdk/models/shared/createcontrolplanerequest.go
@@ -11,11 +11,12 @@ import (
 type CreateControlPlaneRequestClusterType string
 
 const (
-	CreateControlPlaneRequestClusterTypeClusterTypeControlPlane         CreateControlPlaneRequestClusterType = "CLUSTER_TYPE_CONTROL_PLANE"
-	CreateControlPlaneRequestClusterTypeClusterTypeK8SIngressController CreateControlPlaneRequestClusterType = "CLUSTER_TYPE_K8S_INGRESS_CONTROLLER"
-	CreateControlPlaneRequestClusterTypeClusterTypeControlPlaneGroup    CreateControlPlaneRequestClusterType = "CLUSTER_TYPE_CONTROL_PLANE_GROUP"
-	CreateControlPlaneRequestClusterTypeClusterTypeServerless           CreateControlPlaneRequestClusterType = "CLUSTER_TYPE_SERVERLESS"
-	CreateControlPlaneRequestClusterTypeClusterTypeHybrid               CreateControlPlaneRequestClusterType = "CLUSTER_TYPE_HYBRID"
+	CreateControlPlaneRequestClusterTypeClusterTypeControlPlane          CreateControlPlaneRequestClusterType = "CLUSTER_TYPE_CONTROL_PLANE"
+	CreateControlPlaneRequestClusterTypeClusterTypeK8SIngressController  CreateControlPlaneRequestClusterType = "CLUSTER_TYPE_K8S_INGRESS_CONTROLLER"
+	CreateControlPlaneRequestClusterTypeClusterTypeControlPlaneGroup     CreateControlPlaneRequestClusterType = "CLUSTER_TYPE_CONTROL_PLANE_GROUP"
+	CreateControlPlaneRequestClusterTypeClusterTypeServerless            CreateControlPlaneRequestClusterType = "CLUSTER_TYPE_SERVERLESS"
+	CreateControlPlaneRequestClusterTypeClusterTypeKafkaNativeEventProxy CreateControlPlaneRequestClusterType = "CLUSTER_TYPE_KAFKA_NATIVE_EVENT_PROXY"
+	CreateControlPlaneRequestClusterTypeClusterTypeHybrid                CreateControlPlaneRequestClusterType = "CLUSTER_TYPE_HYBRID"
 )
 
 func (e CreateControlPlaneRequestClusterType) ToPointer() *CreateControlPlaneRequestClusterType {
@@ -34,6 +35,8 @@ func (e *CreateControlPlaneRequestClusterType) UnmarshalJSON(data []byte) error 
 	case "CLUSTER_TYPE_CONTROL_PLANE_GROUP":
 		fallthrough
 	case "CLUSTER_TYPE_SERVERLESS":
+		fallthrough
+	case "CLUSTER_TYPE_KAFKA_NATIVE_EVENT_PROXY":
 		fallthrough
 	case "CLUSTER_TYPE_HYBRID":
 		*e = CreateControlPlaneRequestClusterType(v)

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -12529,6 +12529,7 @@ components:
             - CLUSTER_TYPE_K8S_INGRESS_CONTROLLER
             - CLUSTER_TYPE_CONTROL_PLANE_GROUP
             - CLUSTER_TYPE_SERVERLESS
+            - CLUSTER_TYPE_KAFKA_NATIVE_EVENT_PROXY
             - CLUSTER_TYPE_HYBRID
         auth_type:
           description: The auth type value of the cluster associated with the Runtime Group.
@@ -12622,6 +12623,7 @@ components:
                 - CLUSTER_TYPE_K8S_INGRESS_CONTROLLER
                 - CLUSTER_TYPE_CONTROL_PLANE_GROUP
                 - CLUSTER_TYPE_SERVERLESS
+                - CLUSTER_TYPE_KAFKA_NATIVE_EVENT_PROXY
                 - CLUSTER_TYPE_HYBRID
               readOnly: true
             auth_type:
@@ -14708,6 +14710,11 @@ components:
           format: byte
           minLength: 1
           type: string
+          x-speakeasy-terraform-custom-type:
+            imports:
+              - github.com/kong/terraform-provider-konnect/v2/customtypes/encodedstring
+            schemaType: 'encodedstring.Base64InputType{}'
+            valueType: encodedstring.Base64Input
       additionalProperties: false
       required:
         - name
@@ -14740,6 +14747,11 @@ components:
           description: Can be markdown string content or base64 encoded string
           example: '## My Markdown'
           type: string
+          x-speakeasy-terraform-custom-type:
+            imports:
+              - github.com/kong/terraform-provider-konnect/v2/customtypes/encodedstring
+            schemaType: 'encodedstring.Base64OrPlainInputType{}'
+            valueType: encodedstring.Base64OrPlainInput
         metadata:
           description: metadata of the document
           type: object
@@ -14780,6 +14792,11 @@ components:
           description: Can be markdown string content or base64 encoded string
           example: YmFzZTY0LWVuY29kZWQgdGV4dCBzdHJpbmc=
           type: string
+          x-speakeasy-terraform-custom-type:
+            imports:
+              - github.com/kong/terraform-provider-konnect/v2/customtypes/encodedstring
+            schemaType: 'encodedstring.Base64OrPlainInputType{}'
+            valueType: encodedstring.Base64OrPlainInput
         metadata:
           type: object
           nullable: false
@@ -14845,6 +14862,11 @@ components:
           format: byte
           minLength: 1
           type: string
+          x-speakeasy-terraform-custom-type:
+            imports:
+              - github.com/kong/terraform-provider-konnect/v2/customtypes/encodedstring
+            schemaType: 'encodedstring.Base64InputType{}'
+            valueType: encodedstring.Base64Input
       additionalProperties: false
       title: Update API Product Version Specification Request
     LegacyGatewayServicePayload:


### PR DESCRIPTION
We are making use of terraform custom types to fix false diffs for `API Product Document` and `API Product Specification` resources. 
This PR is intended to be merged into the [first PR](https://github.com/Kong/terraform-provider-konnect/pull/164/files) which adds acceptance tests for the same resources.

Fixes https://github.com/Kong/terraform-provider-konnect/issues/85
Short document explaining the solution: https://konghq.atlassian.net/wiki/spaces/A/pages/4604264449/Terraform+custom+types

Corresponding PR on platform API: https://github.com/Kong/platform-api/pull/1254

How I have tested this:
- [x] Build provider on local
- [x] Run e2e tests
- [x] Run acceptance tests
- [x] Run unit tests
- [x] Manual tests for different scenarios of CRUD for each resource


