### PR TITLE
fix(custom-domain): set both url and host

### DIFF
--- a/internal/sdk/internal/hooks/customize_domain.go
+++ b/internal/sdk/internal/hooks/customize_domain.go
@@ -12,7 +12,9 @@ type CustomizeKongDomainHook struct{}
 func (i *CustomizeKongDomainHook) BeforeRequest(hookCtx BeforeRequestContext, req *http.Request) (*http.Request, error) {
 	customDomain := os.Getenv("KONG_CUSTOM_DOMAIN")
 	if customDomain != "" {
-		req.URL.Host = strings.Replace(req.URL.Host, ".konghq.com", "."+customDomain, 1)
+		host := strings.Replace(req.URL.Host, ".konghq.com", "."+customDomain, 1)
+		req.URL.Host = host
+		req.Host = host
 	}
 
 	return req, nil


### PR DESCRIPTION
Otherwise we're getting errors on creating system accounts:

```hcl
terraform {
  required_providers {
    konnect = {
      source = "kong/konnect"
      version = "2.7.2"
    }
    konnect-beta = {
      source  = "kong/konnect-beta"
      version = "0.2.1"
    }
    time = {
      source  = "hashicorp/time"
      version = "0.12.1"
    }
  }
}

provider "time" {}

provider "konnect" {
}

provider "konnect-beta" {
}

resource "konnect_system_account" "zone_system_account" {
  name            = "mesh_system_account"
  description     = "Terraform generated system account for testing"
  konnect_managed = false
}
```

```
$ terraform apply

Terraform used the selected providers to generate the following execution plan. Resource actions are indicated with the following symbols:
  + create

Terraform will perform the following actions:

  # konnect_system_account.zone_system_account will be created
  + resource "konnect_system_account" "zone_system_account" {
      + created_at      = (known after apply)
      + description     = "Terraform generated system account for testing"
      + id              = (known after apply)
      + konnect_managed = false
      + name            = "mesh_system_account"
      + updated_at      = (known after apply)
    }

Plan: 1 to add, 0 to change, 0 to destroy.

Do you want to perform these actions?
  Terraform will perform the actions described above.
  Only 'yes' will be accepted to approve.

  Enter a value: yes

konnect_system_account.zone_system_account: Creating...
╷
│ Error: failure to invoke API
│
│   with konnect_system_account.zone_system_account,
│   on main.tf line 36, in resource "konnect_system_account" "zone_system_account":
│   36: resource "konnect_system_account" "zone_system_account" {
│
│ unknown status code returned: Status 404
│ {"type": "https://kongapi.info/konnect/not-found","status": 404,"title": "Not Found","detail": "The resource requested was not found."}
╵
```

---

After this change the creation is successful.