### PR TITLE
Add ability to customize complete domain for testing

### DIFF
--- a/internal/sdk/internal/hooks/registration.go
+++ b/internal/sdk/internal/hooks/registration.go
@@ -13,7 +13,11 @@ import "os"
 func initHooks(h *Hooks) {
 
 	// Domain customization - enable usage with non-prod domains
-	h.registerBeforeRequestHook(&CustomizeKongDomainHook{})
+	h.registerBeforeRequestHook(&CustomizeKongDomainHook{
+		Enabled:           os.Getenv("KONG_CUSTOM_DOMAIN") != "",
+		Domain:            os.Getenv("KONG_CUSTOM_DOMAIN"),
+		ReplaceFullDomain: os.Getenv("KONG_CUSTOM_DOMAIN_REPLACE_FULL_DOMAIN") == "true",
+	})
 
 	// Debug hooks - dump request/response
 	h.registerBeforeRequestHook(&HTTPDumpRequestHook{


### PR DESCRIPTION
We allow users to switch to dev using `KONG_CUSTOM_DOMAIN`. This PR refactors the hook to reduce the number of `os.getenv()` calls, and adds the `KONG_CUSTOM_DOMAIN_REPLACE_FULL_DOMAIN` env variable to replace the host rather than doing a string replacement