### PR TITLE
Chore: sync platform api 2025-06-23

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,7 +1,7 @@
 lockVersion: 2.0.0
 id: 9d20c53e-7836-4ea8-88b8-a75fb7dce3a2
 management:
-  docChecksum: cfc86e4bd0f5e21d649efa102accfb3a
+  docChecksum: ad3dfd05ec09b53b64e534cb192728cf
   docVersion: 2.0.0
   speakeasyVersion: 1.567.3
   generationVersion: 2.632.2
@@ -4248,7 +4248,7 @@ examples:
         path:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
       requestBody:
-        application/json: {"lua_schema": "return { name = \\\"myplugin\\\", fields = { { config = { type = \\\"record\\\", fields = { } } } } }"}
+        application/json: {"lua_schema": "return { name = \"myplugin\", fields = { { config = { type = \"record\", fields = { } } } } }"}
       responses:
         "201":
           application/json: {"item": {"lua_schema": "return { name = \\\"myplugin\\\", fields = { { config = { type = \\\"record\\\", fields = { } } } } }", "name": "myplugin", "created_at": 1422386534, "updated_at": 1422412345}}
@@ -4305,7 +4305,7 @@ examples:
           controlPlaneId: "9524ec7d-36d9-465d-a8c5-83a3c9390458"
           name: "myplugin"
       requestBody:
-        application/json: {"lua_schema": "return { name = \\\"myplugin\\\", fields = { { config = { type = \\\"record\\\", fields = { } } } } }"}
+        application/json: {"lua_schema": "return { name = \"myplugin\", fields = { { config = { type = \"record\", fields = { } } } } }"}
       responses:
         "200":
           application/json: {"item": {"lua_schema": "return { name = \\\"myplugin\\\", fields = { { config = { type = \\\"record\\\", fields = { } } } } }", "name": "myplugin", "created_at": 1422386534, "updated_at": 1422412345}}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2.11.0  
+> Released on ?
+
+### Bug fixes
+
+* Fixed error while creating openid-connect strategy in `konnect_application_auth_strategy` resource
+
 ## 2.10.0  
 > Released on 2025/06/19
 

--- a/docs/resources/application_auth_strategy.md
+++ b/docs/resources/application_auth_strategy.md
@@ -40,9 +40,6 @@ resource "konnect_application_auth_strategy" "my_applicationauthstrategy" {
           "..."
         ]
         issuer = "...my_issuer..."
-        labels = {
-          key = "value"
-        }
         scopes = [
           "..."
         ]
@@ -170,10 +167,6 @@ Optional:
 - `auth_methods` (List of String) Not Null; Requires replacement if changed.
 - `credential_claim` (List of String) Not Null; Requires replacement if changed.
 - `issuer` (String) Not Null; Requires replacement if changed.
-- `labels` (Map of String) Labels store metadata of an entity that can be used for filtering an entity list or for searching across entity types. 
-
-Keys must be of length 1-63 characters, and cannot start with "kong", "konnect", "mesh", "kic", or "_".
-Requires replacement if changed.
 - `scopes` (List of String) Not Null; Requires replacement if changed.
 
 

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,8 @@
 module github.com/kong/terraform-provider-konnect/v2
 
-go 1.24.2
+go 1.23.4
 
-toolchain go1.24.2
+toolchain go1.24.3
 
 require (
 	github.com/Kong/shared-speakeasy/customtypes v0.2.3

--- a/internal/provider/applicationauthstrategy_data_source.go
+++ b/internal/provider/applicationauthstrategy_data_source.go
@@ -170,13 +170,6 @@ func (r *ApplicationAuthStrategyDataSource) Schema(ctx context.Context, req data
 									"issuer": schema.StringAttribute{
 										Computed: true,
 									},
-									"labels": schema.MapAttribute{
-										Computed:    true,
-										ElementType: types.StringType,
-										MarkdownDescription: `Labels store metadata of an entity that can be used for filtering an entity list or for searching across entity types. ` + "\n" +
-											`` + "\n" +
-											`Keys must be of length 1-63 characters, and cannot start with "kong", "konnect", "mesh", "kic", or "_".`,
-									},
 									"scopes": schema.ListAttribute{
 										Computed:    true,
 										ElementType: types.StringType,

--- a/internal/provider/applicationauthstrategy_data_source_sdk.go
+++ b/internal/provider/applicationauthstrategy_data_source_sdk.go
@@ -82,12 +82,6 @@ func (r *ApplicationAuthStrategyDataSourceModel) RefreshFromSharedCreateAppAuthS
 				r.OpenidConnect.Configs.OpenidConnect.CredentialClaim = append(r.OpenidConnect.Configs.OpenidConnect.CredentialClaim, types.StringValue(v))
 			}
 			r.OpenidConnect.Configs.OpenidConnect.Issuer = types.StringValue(resp.AppAuthStrategyOpenIDConnectResponse.Configs.OpenidConnect.Issuer)
-			if len(resp.AppAuthStrategyOpenIDConnectResponse.Configs.OpenidConnect.Labels) > 0 {
-				r.OpenidConnect.Configs.OpenidConnect.Labels = make(map[string]types.String, len(resp.AppAuthStrategyOpenIDConnectResponse.Configs.OpenidConnect.Labels))
-				for key1, value1 := range resp.AppAuthStrategyOpenIDConnectResponse.Configs.OpenidConnect.Labels {
-					r.OpenidConnect.Configs.OpenidConnect.Labels[key1] = types.StringPointerValue(value1)
-				}
-			}
 			r.OpenidConnect.Configs.OpenidConnect.Scopes = make([]types.String, 0, len(resp.AppAuthStrategyOpenIDConnectResponse.Configs.OpenidConnect.Scopes))
 			for _, v := range resp.AppAuthStrategyOpenIDConnectResponse.Configs.OpenidConnect.Scopes {
 				r.OpenidConnect.Configs.OpenidConnect.Scopes = append(r.OpenidConnect.Configs.OpenidConnect.Scopes, types.StringValue(v))
@@ -108,8 +102,8 @@ func (r *ApplicationAuthStrategyDataSourceModel) RefreshFromSharedCreateAppAuthS
 			r.ID = r.OpenidConnect.ID
 			if len(resp.AppAuthStrategyOpenIDConnectResponse.Labels) > 0 {
 				r.OpenidConnect.Labels = make(map[string]types.String, len(resp.AppAuthStrategyOpenIDConnectResponse.Labels))
-				for key2, value2 := range resp.AppAuthStrategyOpenIDConnectResponse.Labels {
-					r.OpenidConnect.Labels[key2] = types.StringPointerValue(value2)
+				for key1, value1 := range resp.AppAuthStrategyOpenIDConnectResponse.Labels {
+					r.OpenidConnect.Labels[key1] = types.StringPointerValue(value1)
 				}
 			}
 			r.OpenidConnect.Name = types.StringValue(resp.AppAuthStrategyOpenIDConnectResponse.Name)

--- a/internal/provider/applicationauthstrategy_resource.go
+++ b/internal/provider/applicationauthstrategy_resource.go
@@ -363,19 +363,6 @@ func (r *ApplicationAuthStrategyResource) Schema(ctx context.Context, req resour
 											stringvalidator.UTF8LengthAtMost(256),
 										},
 									},
-									"labels": schema.MapAttribute{
-										Computed: true,
-										Optional: true,
-										PlanModifiers: []planmodifier.Map{
-											mapplanmodifier.RequiresReplaceIfConfigured(),
-											speakeasy_mapplanmodifier.SuppressDiff(speakeasy_mapplanmodifier.ExplicitSuppress),
-										},
-										ElementType: types.StringType,
-										MarkdownDescription: `Labels store metadata of an entity that can be used for filtering an entity list or for searching across entity types. ` + "\n" +
-											`` + "\n" +
-											`Keys must be of length 1-63 characters, and cannot start with "kong", "konnect", "mesh", "kic", or "_".` + "\n" +
-											`Requires replacement if changed.`,
-									},
 									"scopes": schema.ListAttribute{
 										Computed: true,
 										Optional: true,

--- a/internal/provider/applicationauthstrategy_resource_sdk.go
+++ b/internal/provider/applicationauthstrategy_resource_sdk.go
@@ -83,16 +83,6 @@ func (r *ApplicationAuthStrategyResourceModel) ToSharedCreateAppAuthStrategyRequ
 		for _, authMethodsItem := range r.OpenidConnect.Configs.OpenidConnect.AuthMethods {
 			authMethods = append(authMethods, authMethodsItem.ValueString())
 		}
-		labels1 := make(map[string]*string)
-		for labelsKey1, labelsValue1 := range r.OpenidConnect.Configs.OpenidConnect.Labels {
-			labelsInst1 := new(string)
-			if !labelsValue1.IsUnknown() && !labelsValue1.IsNull() {
-				*labelsInst1 = labelsValue1.ValueString()
-			} else {
-				labelsInst1 = nil
-			}
-			labels1[labelsKey1] = labelsInst1
-		}
 		var additionalProperties interface{}
 		if !r.OpenidConnect.Configs.OpenidConnect.AdditionalProperties.IsUnknown() && !r.OpenidConnect.Configs.OpenidConnect.AdditionalProperties.IsNull() {
 			_ = json.Unmarshal([]byte(r.OpenidConnect.Configs.OpenidConnect.AdditionalProperties.ValueString()), &additionalProperties)
@@ -102,7 +92,6 @@ func (r *ApplicationAuthStrategyResourceModel) ToSharedCreateAppAuthStrategyRequ
 			CredentialClaim:      credentialClaim,
 			Scopes:               scopes,
 			AuthMethods:          authMethods,
-			Labels:               labels1,
 			AdditionalProperties: additionalProperties,
 		}
 		configs1 := shared.AppAuthStrategyOpenIDConnectRequestConfigs{
@@ -114,15 +103,15 @@ func (r *ApplicationAuthStrategyResourceModel) ToSharedCreateAppAuthStrategyRequ
 		} else {
 			dcrProviderID = nil
 		}
-		labels2 := make(map[string]*string)
-		for labelsKey2, labelsValue2 := range r.OpenidConnect.Labels {
-			labelsInst2 := new(string)
-			if !labelsValue2.IsUnknown() && !labelsValue2.IsNull() {
-				*labelsInst2 = labelsValue2.ValueString()
+		labels1 := make(map[string]*string)
+		for labelsKey1, labelsValue1 := range r.OpenidConnect.Labels {
+			labelsInst1 := new(string)
+			if !labelsValue1.IsUnknown() && !labelsValue1.IsNull() {
+				*labelsInst1 = labelsValue1.ValueString()
 			} else {
-				labelsInst2 = nil
+				labelsInst1 = nil
 			}
-			labels2[labelsKey2] = labelsInst2
+			labels1[labelsKey1] = labelsInst1
 		}
 		appAuthStrategyOpenIDConnectRequest = &shared.AppAuthStrategyOpenIDConnectRequest{
 			Name:          name1,
@@ -130,7 +119,7 @@ func (r *ApplicationAuthStrategyResourceModel) ToSharedCreateAppAuthStrategyRequ
 			StrategyType:  strategyType1,
 			Configs:       configs1,
 			DcrProviderID: dcrProviderID,
-			Labels:        labels2,
+			Labels:        labels1,
 		}
 	}
 	if appAuthStrategyOpenIDConnectRequest != nil {
@@ -268,12 +257,6 @@ func (r *ApplicationAuthStrategyResourceModel) RefreshFromSharedCreateAppAuthStr
 				r.OpenidConnect.Configs.OpenidConnect.CredentialClaim = append(r.OpenidConnect.Configs.OpenidConnect.CredentialClaim, types.StringValue(v))
 			}
 			r.OpenidConnect.Configs.OpenidConnect.Issuer = types.StringValue(resp.AppAuthStrategyOpenIDConnectResponse.Configs.OpenidConnect.Issuer)
-			if len(resp.AppAuthStrategyOpenIDConnectResponse.Configs.OpenidConnect.Labels) > 0 {
-				r.OpenidConnect.Configs.OpenidConnect.Labels = make(map[string]types.String, len(resp.AppAuthStrategyOpenIDConnectResponse.Configs.OpenidConnect.Labels))
-				for key1, value1 := range resp.AppAuthStrategyOpenIDConnectResponse.Configs.OpenidConnect.Labels {
-					r.OpenidConnect.Configs.OpenidConnect.Labels[key1] = types.StringPointerValue(value1)
-				}
-			}
 			r.OpenidConnect.Configs.OpenidConnect.Scopes = make([]types.String, 0, len(resp.AppAuthStrategyOpenIDConnectResponse.Configs.OpenidConnect.Scopes))
 			for _, v := range resp.AppAuthStrategyOpenIDConnectResponse.Configs.OpenidConnect.Scopes {
 				r.OpenidConnect.Configs.OpenidConnect.Scopes = append(r.OpenidConnect.Configs.OpenidConnect.Scopes, types.StringValue(v))
@@ -294,8 +277,8 @@ func (r *ApplicationAuthStrategyResourceModel) RefreshFromSharedCreateAppAuthStr
 			r.ID = r.OpenidConnect.ID
 			if len(resp.AppAuthStrategyOpenIDConnectResponse.Labels) > 0 {
 				r.OpenidConnect.Labels = make(map[string]types.String, len(resp.AppAuthStrategyOpenIDConnectResponse.Labels))
-				for key2, value2 := range resp.AppAuthStrategyOpenIDConnectResponse.Labels {
-					r.OpenidConnect.Labels[key2] = types.StringPointerValue(value2)
+				for key1, value1 := range resp.AppAuthStrategyOpenIDConnectResponse.Labels {
+					r.OpenidConnect.Labels[key1] = types.StringPointerValue(value1)
 				}
 			}
 			r.OpenidConnect.Name = types.StringValue(resp.AppAuthStrategyOpenIDConnectResponse.Name)

--- a/internal/provider/types/app_auth_strategy_config_open_id_connect.go
+++ b/internal/provider/types/app_auth_strategy_config_open_id_connect.go
@@ -7,10 +7,9 @@ import (
 )
 
 type AppAuthStrategyConfigOpenIDConnect struct {
-	AdditionalProperties types.String            `tfsdk:"additional_properties"`
-	AuthMethods          []types.String          `tfsdk:"auth_methods"`
-	CredentialClaim      []types.String          `tfsdk:"credential_claim"`
-	Issuer               types.String            `tfsdk:"issuer"`
-	Labels               map[string]types.String `tfsdk:"labels"`
-	Scopes               []types.String          `tfsdk:"scopes"`
+	AdditionalProperties types.String   `tfsdk:"additional_properties"`
+	AuthMethods          []types.String `tfsdk:"auth_methods"`
+	CredentialClaim      []types.String `tfsdk:"credential_claim"`
+	Issuer               types.String   `tfsdk:"issuer"`
+	Scopes               []types.String `tfsdk:"scopes"`
 }

--- a/internal/sdk/models/shared/appauthstrategyconfigopenidconnect.go
+++ b/internal/sdk/models/shared/appauthstrategyconfigopenidconnect.go
@@ -11,16 +11,11 @@ import (
 // Once authenticated, an application will be granted access to any Product Version it is registered for that is configured for the same Auth Strategy.
 // An OIDC strategy may be used in conjunction with a DCR provider to automatically create the IdP application.
 type AppAuthStrategyConfigOpenIDConnect struct {
-	Issuer          string   `json:"issuer"`
-	CredentialClaim []string `json:"credential_claim"`
-	Scopes          []string `json:"scopes"`
-	AuthMethods     []string `json:"auth_methods"`
-	// Labels store metadata of an entity that can be used for filtering an entity list or for searching across entity types.
-	//
-	// Keys must be of length 1-63 characters, and cannot start with "kong", "konnect", "mesh", "kic", or "_".
-	//
-	Labels               map[string]*string `json:"labels,omitempty"`
-	AdditionalProperties any                `additionalProperties:"true" json:"-"`
+	Issuer               string   `json:"issuer"`
+	CredentialClaim      []string `json:"credential_claim"`
+	Scopes               []string `json:"scopes"`
+	AuthMethods          []string `json:"auth_methods"`
+	AdditionalProperties any      `additionalProperties:"true" json:"-"`
 }
 
 func (a AppAuthStrategyConfigOpenIDConnect) MarshalJSON() ([]byte, error) {
@@ -60,13 +55,6 @@ func (o *AppAuthStrategyConfigOpenIDConnect) GetAuthMethods() []string {
 		return []string{}
 	}
 	return o.AuthMethods
-}
-
-func (o *AppAuthStrategyConfigOpenIDConnect) GetLabels() map[string]*string {
-	if o == nil {
-		return nil
-	}
-	return o.Labels
 }
 
 func (o *AppAuthStrategyConfigOpenIDConnect) GetAdditionalProperties() any {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -16946,8 +16946,6 @@ components:
             type: string
             maxLength: 64
           maxItems: 10
-        labels:
-          $ref: '#/components/schemas/Labels'
       additionalProperties: true
       required:
         - issuer


### PR DESCRIPTION
Changes in this PR:
1. Remove invalid `labels` property within openid-connect strategy ([platform-api PR](https://github.com/Kong/platform-api/pull/1431))
2. Revert go to v1.23.4 - generated by speakeasy (speakeasy overwrites the go.mod file)

How I have tested:
- [x] e2e tests
- [x] CRUD on `konnect_application_auth_strategy` resource for both key auth and openid-connect