### PR TITLE
tests: add acceptance test for basic-auth false diff

### DIFF
--- a/tests/resources/basic_auth_test.go
+++ b/tests/resources/basic_auth_test.go
@@ -1,0 +1,35 @@
+package tests
+
+import (
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-testing/config"
+	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
+)
+
+func TestBasicAuth(t *testing.T) {
+	t.Run("plan-diff", func(t *testing.T) {
+		resource.Test(t, resource.TestCase{
+			ProtoV6ProviderFactories: providerFactory,
+			Steps: []resource.TestStep{
+				{
+					Config:          providerConfigUs,
+					ConfigDirectory: config.TestNameDirectory(),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("konnect_gateway_basic_auth.alice_basicauth", "username", "alice-test"),
+					),
+				},
+				{
+					Config:          providerConfigUs,
+					ConfigDirectory: config.TestNameDirectory(),
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PreApply: []plancheck.PlanCheck{
+							plancheck.ExpectEmptyPlan(),
+						},
+					},
+				},
+			},
+		})
+	})
+}

--- a/tests/resources/testdata/TestBasicAuth/plan-diff/main.tf
+++ b/tests/resources/testdata/TestBasicAuth/plan-diff/main.tf
@@ -1,0 +1,27 @@
+resource "konnect_gateway_consumer" "alice" {
+  username         = "alice"
+  custom_id        = "alice"
+  control_plane_id = konnect_gateway_control_plane.tfdemo.id
+}
+
+resource "konnect_gateway_basic_auth" "alice_basicauth" {
+  username = "alice-test"
+  password = "mysamplepassword"
+
+  consumer_id      = konnect_gateway_consumer.alice.id
+  control_plane_id = konnect_gateway_control_plane.tfdemo.id
+}
+
+resource "konnect_gateway_control_plane" "tfdemo" {
+  name         = "Terraform Control Plane - Basic auth consumer"
+  description  = "This is a sample description"
+  cluster_type = "CLUSTER_TYPE_CONTROL_PLANE"
+
+  proxy_urls = [
+    {
+      host     = "example.com",
+      port     = 443,
+      protocol = "https"
+    }
+  ]
+}


### PR DESCRIPTION
This PR adds a test to verify basic auth resource does not have false diff.
Pending: After https://github.com/Kong/platform-api/pull/1501 is merged, provider needs to be re generated for tests to pass.

