### PR TITLE
Make instance_name optional on konnect_gateway_custom_plugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 ### Bug Fixes
 * Fixed false diff on the output of `terraform plan` for `konnect_api` resource
+* Made `instance_name` optional on `konnect_gateway_custom_plugin`
 
 ## 3.0.0
 > Released on 2025/08/23

--- a/src/custom_plugin_model.go
+++ b/src/custom_plugin_model.go
@@ -51,7 +51,7 @@ func (r *CustomPluginResourceModel) ToSharedPluginInput() (shared.Plugin, error)
 		pluginInput.Enabled = sdk.Bool(r.Enabled.ValueBool())
 	}
 
-	if r.InstanceName.ValueStringPointer() != nil {
+	if r.InstanceName.ValueStringPointer() != nil && r.InstanceName.ValueString() != "" {
 		pluginInput.InstanceName = sdk.String(r.InstanceName.ValueString())
 	}
 

--- a/tests/resources/gateway_custom_plugin_test.go
+++ b/tests/resources/gateway_custom_plugin_test.go
@@ -22,6 +22,7 @@ func TestGatewayCustomPlugin(t *testing.T) {
 					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestCheckResourceAttr("konnect_gateway_custom_plugin.custom_basic_auth", "instance_name", "custom-plugin-test"),
 						resource.TestCheckResourceAttr("konnect_gateway_custom_plugin.custom_basic_auth_nested", "instance_name", "custom-nested-plugin-test"),
+						resource.TestCheckNoResourceAttr("konnect_gateway_custom_plugin.custom_no_instance_name", "instance_name"),
 					),
 				},
 			},

--- a/tests/resources/testdata/TestGatewayCustomPlugin/smoke/main.tf
+++ b/tests/resources/testdata/TestGatewayCustomPlugin/smoke/main.tf
@@ -29,3 +29,9 @@ resource "konnect_gateway_custom_plugin" "custom_basic_auth_nested" {
     id = konnect_gateway_service.httpbin.id
   }
 }
+
+resource "konnect_gateway_custom_plugin" "custom_no_instance_name" {
+  name             = "key-auth"
+  config           = {}
+  control_plane_id = konnect_gateway_control_plane.tfdemo.id
+}


### PR DESCRIPTION
### Summary

```
=== RUN   TestGatewayCustomPlugin/smoke
    gateway_custom_plugin_test.go:16: Step 1/1 error: Error running apply: exit status 1

        Error: failure to invoke API

          with konnect_gateway_custom_plugin.custom_no_instance_name,
          on main.tf line 33, in resource "konnect_gateway_custom_plugin" "custom_no_instance_name":
          33: resource "konnect_gateway_custom_plugin" "custom_no_instance_name" {

        unknown status code returned: Status 400
        {"code":3,"details":[{"@type":"type.googleapis.com/kong.admin.model.v1.ErrorDetail","field":"instance_name","messages":["length
        must be \u003e= 1, but got
        0"],"type":"ERROR_TYPE_FIELD"}],"message":"validation error: length must be
        \u003e= 1, but got 0"}
--- FAIL: TestGatewayCustomPlugin (2.48s)
    --- FAIL: TestGatewayCustomPlugin/smoke (2.48s)
```

`instance_name` was being sent even if it's an empty string

### Checklist ✅ 
- [x] Clean commit history (reset to the current release (`release/x.y.z`) and `git cherry-pick` if necessary)
- [ ] Added/updated examples (if applicable)  
- [x] Added acceptance tests (if applicable)  
- [x] Updated `CHANGELOG.md`  
