### PR TITLE
chore: bump speakeasy to v1.665.0 and generate

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -3,16 +3,16 @@ id: 9d20c53e-7836-4ea8-88b8-a75fb7dce3a2
 management:
   docChecksum: e7392e5d8a8e1e0b5b4badc690f268cc
   docVersion: 2.0.0
-  speakeasyVersion: 1.653.0
-  generationVersion: 2.748.0
+  speakeasyVersion: 1.665.0
+  generationVersion: 2.767.2
   releaseVersion: 3.4.2
-  configChecksum: cfb915c7dc80cc8d70a4426dfaaeb588
+  configChecksum: 790546caf4d562915a0ddd528cf70599
 features:
   terraform:
     additionalDependencies: 0.1.0
     additionalProperties: 0.1.3
     constsAndDefaults: 0.3.0
-    core: 3.46.8
+    core: 3.46.18
     deepObjectParams: 0.1.0
     deprecations: 2.82.0
     globalSecurity: 2.82.1
@@ -23,11 +23,11 @@ features:
     methodServerURLs: 2.83.0
     nameOverrides: 2.81.3
     nullables: 0.0.0
-    pagination: 2.83.4
+    pagination: 2.83.5
     retries: 2.81.4
     sets: 0.1.2
     typeOverrides: 2.81.1
-    unions: 2.82.2
+    unions: 2.82.5
 generatedFiles:
   - .gitattributes
   - USAGE.md

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -1,4 +1,4 @@
-speakeasyVersion: 1.653.0
+speakeasyVersion: 1.665.0
 sources:
     kong:
         sourceNamespace: kong
@@ -15,7 +15,7 @@ targets:
         sourceBlobDigest: sha256:fe7d9348a81627bd7708751e55cd5c4ef15b7c2b748c058ce7dd03298e8a92fa
 workflow:
     workflowVersion: 1.0.0
-    speakeasyVersion: 1.653.0
+    speakeasyVersion: 1.665.0
     sources:
         kong:
             inputs:

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -1,5 +1,5 @@
 workflowVersion: 1.0.0
-speakeasyVersion: 1.653.0
+speakeasyVersion: 1.665.0
 sources:
   kong:
     inputs:

--- a/docs/resources/api_product_version.md
+++ b/docs/resources/api_product_version.md
@@ -75,7 +75,7 @@ Read-Only:
 - `portal_id` (String)
 - `portal_name` (String)
 - `portal_product_version_id` (String)
-- `publish_status` (String) must be one of ["published", "unpublished"]
+- `publish_status` (String)
 
 <a id="nestedatt--portals--auth_strategies"></a>
 ### Nested Schema for `portals.auth_strategies`

--- a/docs/resources/api_version.md
+++ b/docs/resources/api_version.md
@@ -49,7 +49,7 @@ Optional:
 
 Read-Only:
 
-- `type` (String) The type of specification being stored. This allows us to render the specification correctly. must be one of ["oas2", "oas3", "asyncapi"]
+- `type` (String) The type of specification being stored. This allows us to render the specification correctly.
 - `validation_messages` (Attributes List) The errors that occurred while parsing the API version spec. (see [below for nested schema](#nestedatt--spec--validation_messages))
 
 <a id="nestedatt--spec--validation_messages"></a>

--- a/docs/resources/application_auth_strategy.md
+++ b/docs/resources/application_auth_strategy.md
@@ -96,7 +96,7 @@ Read-Only:
 - `display_name` (String) The display name of the DCR provider. This is used to identify the DCR provider in the Portal UI.
 - `id` (String) Contains a unique identifier used for this resource.
 - `name` (String)
-- `provider_type` (String) The type of DCR provider. must be one of ["auth0", "azureAd", "curity", "okta", "http"]
+- `provider_type` (String) The type of DCR provider.
 
 
 
@@ -155,7 +155,7 @@ Read-Only:
 - `display_name` (String) The display name of the DCR provider. This is used to identify the DCR provider in the Portal UI.
 - `id` (String) Contains a unique identifier used for this resource.
 - `name` (String)
-- `provider_type` (String) The type of DCR provider. must be one of ["auth0", "azureAd", "curity", "okta", "http"]
+- `provider_type` (String) The type of DCR provider.
 
 ## Import
 

--- a/docs/resources/cloud_gateway_configuration.md
+++ b/docs/resources/cloud_gateway_configuration.md
@@ -79,7 +79,7 @@ Read-Only:
 - `egress_ip_addresses` (List of String) List of egress IP addresses for the network that this data-plane group runs on.
 - `id` (String) ID of the data-plane group that represents a deployment target for a set of data-planes.
 - `private_ip_addresses` (List of String) List of private IP addresses of the internal load balancer that proxies traffic to this data-plane group.
-- `state` (String) State of the data-plane group. must be one of ["created", "initializing", "ready", "terminating", "terminated"]
+- `state` (String) State of the data-plane group.
 - `updated_at` (String) An RFC-3339 timestamp representation of data-plane group update date.
 
 <a id="nestedatt--dataplane_groups--autoscale"></a>

--- a/docs/resources/cloud_gateway_custom_domain.md
+++ b/docs/resources/cloud_gateway_custom_domain.md
@@ -39,7 +39,7 @@ domain.
 - `id` (String) The ID of this resource.
 - `sni_id` (String) Server Name Indication ID for this domain and stored on data-planes for this control-plane. Can be retrieved
 via the control-planes API for this custom domain's control-plane.
-- `state` (String) State of the custom domain. must be one of ["created", "initializing", "ready", "terminating", "terminated", "error"]
+- `state` (String) State of the custom domain.
 - `state_metadata` (Attributes) Metadata describing the backing state of the custom domain and why it may be in an erroneous state. (see [below for nested schema](#nestedatt--state_metadata))
 - `updated_at` (String) An RFC-3339 timestamp representation of custom domain update date.
 

--- a/docs/resources/cloud_gateway_private_dns.md
+++ b/docs/resources/cloud_gateway_private_dns.md
@@ -112,7 +112,6 @@ Private DNS.
 - `error` - The attachment is in an error state, and is not operational.
 - `terminating` - The attachment is in the process of being deleted.
 - `terminated` - The attachment has been fully deleted and is no longer available.
-must be one of ["created", "initializing", "pending-association", "ready", "error", "terminating", "terminated"]
 - `state_metadata` (Attributes) Metadata describing the backing state of the Private Dns and why it may be in an erroneous state. (see [below for nested schema](#nestedatt--aws_private_dns_resolver_response--state_metadata))
 - `updated_at` (String) An RFC-3339 timestamp representation of Private DNS update date.
 
@@ -122,7 +121,7 @@ must be one of ["created", "initializing", "pending-association", "ready", "erro
 Read-Only:
 
 - `dns_config` (Attributes Map) Object that contains mappings from proxied internal domains to remote DNS server IP address for a Private DNS Resolver. (see [below for nested schema](#nestedatt--aws_private_dns_resolver_response--private_dns_attachment_config--dns_config))
-- `kind` (String) must be "aws-outbound-resolver"
+- `kind` (String)
 
 <a id="nestedatt--aws_private_dns_resolver_response--private_dns_attachment_config--dns_config"></a>
 ### Nested Schema for `aws_private_dns_resolver_response.private_dns_attachment_config.dns_config`
@@ -162,7 +161,6 @@ Private DNS.
 - `error` - The attachment is in an error state, and is not operational.
 - `terminating` - The attachment is in the process of being deleted.
 - `terminated` - The attachment has been fully deleted and is no longer available.
-must be one of ["created", "initializing", "pending-association", "ready", "error", "terminating", "terminated"]
 - `state_metadata` (Attributes) Metadata describing the backing state of the Private Dns and why it may be in an erroneous state. (see [below for nested schema](#nestedatt--aws_private_hosted_zone_response--state_metadata))
 - `updated_at` (String) An RFC-3339 timestamp representation of Private DNS update date.
 
@@ -172,7 +170,7 @@ must be one of ["created", "initializing", "pending-association", "ready", "erro
 Read-Only:
 
 - `hosted_zone_id` (String) AWS Hosted Zone to create attachment to.
-- `kind` (String) must be "aws-private-hosted-zone-attachment"
+- `kind` (String)
 
 
 <a id="nestedatt--aws_private_hosted_zone_response--state_metadata"></a>
@@ -204,7 +202,6 @@ Private DNS.
 - `error` - The attachment is in an error state, and is not operational.
 - `terminating` - The attachment is in the process of being deleted.
 - `terminated` - The attachment has been fully deleted and is no longer available.
-must be one of ["created", "initializing", "pending-association", "ready", "error", "terminating", "terminated"]
 - `state_metadata` (Attributes) Metadata describing the backing state of the Private Dns and why it may be in an erroneous state. (see [below for nested schema](#nestedatt--gcp_private_hosted_zone_response--state_metadata))
 - `updated_at` (String) An RFC-3339 timestamp representation of Private DNS update date.
 
@@ -214,7 +211,7 @@ must be one of ["created", "initializing", "pending-association", "ready", "erro
 Read-Only:
 
 - `domain_name` (String) Domain name to create attachment to.
-- `kind` (String) must be "gcp-private-hosted-zone-attachment"
+- `kind` (String)
 - `peer_project_id` (String) Customer's GCP Project ID.
 - `peer_vpc_name` (String) Customer's GCP VPC ID.
 

--- a/docs/resources/cloud_gateway_transit_gateway.md
+++ b/docs/resources/cloud_gateway_transit_gateway.md
@@ -374,7 +374,6 @@ transit gateway.
 - `ready` - The transit gateway attachment is fully operational and can route traffic as configured.
 - `terminating` - The attachment is in the process of being deleted and is no longer accepting new traffic.
 - `terminated` - The attachment has been fully deleted and is no longer available.
-must be one of ["created", "initializing", "pending-acceptance", "pending-user-action", "ready", "terminating", "terminated"]
 - `state_metadata` (Attributes) Metadata describing the backing state of the transit gateway and why it may be in an erroneous state. (see [below for nested schema](#nestedatt--aws_resource_endpoint_gateway_response--state_metadata))
 - `transit_gateway_attachment_config` (Attributes) (see [below for nested schema](#nestedatt--aws_resource_endpoint_gateway_response--transit_gateway_attachment_config))
 - `updated_at` (String) An RFC-3339 timestamp representation of transit gateway update date.
@@ -403,7 +402,7 @@ Read-Only:
 
 Read-Only:
 
-- `kind` (String) must be "aws-resource-endpoint-attachment"
+- `kind` (String)
 - `ram_share_arn` (String) Resource Share ARN to verify request to create transit gateway attachment.
 - `resource_config` (Attributes List) List of unique resource config mapping for aws resource endpoint. (see [below for nested schema](#nestedatt--aws_resource_endpoint_gateway_response--transit_gateway_attachment_config--resource_config))
 
@@ -420,7 +419,6 @@ Read-Only:
 - `ready` - The config is fully operational and can route traffic as configured.
 - `error` - The config is in an error state, and is not operational.
 - `terminating` - The config is in the process of being deleted and is no longer accepting new traffic.
-must be one of ["initializing", "missing", "ready", "error", "terminating"]
 
 
 
@@ -447,7 +445,6 @@ transit gateway.
 - `ready` - The transit gateway attachment is fully operational and can route traffic as configured.
 - `terminating` - The attachment is in the process of being deleted and is no longer accepting new traffic.
 - `terminated` - The attachment has been fully deleted and is no longer available.
-must be one of ["created", "initializing", "pending-acceptance", "pending-user-action", "ready", "terminating", "terminated"]
 - `state_metadata` (Attributes) Metadata describing the backing state of the transit gateway and why it may be in an erroneous state. (see [below for nested schema](#nestedatt--aws_transit_gateway_response--state_metadata))
 - `transit_gateway_attachment_config` (Attributes) (see [below for nested schema](#nestedatt--aws_transit_gateway_response--transit_gateway_attachment_config))
 - `updated_at` (String) An RFC-3339 timestamp representation of transit gateway update date.
@@ -476,7 +473,7 @@ Read-Only:
 
 Read-Only:
 
-- `kind` (String) must be "aws-transit-gateway-attachment"
+- `kind` (String)
 - `ram_share_arn` (String) Resource Share ARN to verify request to create transit gateway attachment.
 - `transit_gateway_id` (String) AWS Transit Gateway ID to create attachment to.
 
@@ -504,7 +501,6 @@ transit gateway.
 - `ready` - The transit gateway attachment is fully operational and can route traffic as configured.
 - `terminating` - The attachment is in the process of being deleted and is no longer accepting new traffic.
 - `terminated` - The attachment has been fully deleted and is no longer available.
-must be one of ["created", "initializing", "pending-acceptance", "pending-user-action", "ready", "terminating", "terminated"]
 - `state_metadata` (Attributes) Metadata describing the backing state of the transit gateway and why it may be in an erroneous state. (see [below for nested schema](#nestedatt--aws_vpc_peering_gateway_response--state_metadata))
 - `transit_gateway_attachment_config` (Attributes) (see [below for nested schema](#nestedatt--aws_vpc_peering_gateway_response--transit_gateway_attachment_config))
 - `updated_at` (String) An RFC-3339 timestamp representation of transit gateway update date.
@@ -533,7 +529,7 @@ Read-Only:
 
 Read-Only:
 
-- `kind` (String) must be "aws-vpc-peering-attachment"
+- `kind` (String)
 - `peer_account_id` (String)
 - `peer_vpc_id` (String)
 - `peer_vpc_region` (String)
@@ -560,7 +556,6 @@ transit gateway.
 - `ready` - The transit gateway attachment is fully operational and can route traffic as configured.
 - `terminating` - The attachment is in the process of being deleted and is no longer accepting new traffic.
 - `terminated` - The attachment has been fully deleted and is no longer available.
-must be one of ["created", "initializing", "pending-acceptance", "pending-user-action", "ready", "terminating", "terminated"]
 - `state_metadata` (Attributes) Metadata describing the backing state of the transit gateway and why it may be in an erroneous state. (see [below for nested schema](#nestedatt--azure_transit_gateway_response--state_metadata))
 - `transit_gateway_attachment_config` (Attributes) (see [below for nested schema](#nestedatt--azure_transit_gateway_response--transit_gateway_attachment_config))
 - `updated_at` (String) An RFC-3339 timestamp representation of transit gateway update date.
@@ -589,7 +584,7 @@ Read-Only:
 
 Read-Only:
 
-- `kind` (String) must be "azure-vnet-peering-attachment"
+- `kind` (String)
 - `resource_group_name` (String) Resource Group Name for the Azure VNET Peering attachment.
 - `subscription_id` (String) Subscription ID for the Azure VNET Peering attachment.
 - `tenant_id` (String) Tenant ID for the Azure VNET Peering attachment.
@@ -617,7 +612,6 @@ transit gateway.
 - `ready` - The transit gateway attachment is fully operational and can route traffic as configured.
 - `terminating` - The attachment is in the process of being deleted and is no longer accepting new traffic.
 - `terminated` - The attachment has been fully deleted and is no longer available.
-must be one of ["created", "initializing", "pending-acceptance", "pending-user-action", "ready", "terminating", "terminated"]
 - `state_metadata` (Attributes) Metadata describing the backing state of the transit gateway and why it may be in an erroneous state. (see [below for nested schema](#nestedatt--gcpvpc_peering_gateway_response--state_metadata))
 - `transit_gateway_attachment_config` (Attributes) (see [below for nested schema](#nestedatt--gcpvpc_peering_gateway_response--transit_gateway_attachment_config))
 - `updated_at` (String) An RFC-3339 timestamp representation of transit gateway update date.
@@ -646,7 +640,7 @@ Read-Only:
 
 Read-Only:
 
-- `kind` (String) must be "gcp-vpc-peering-attachment"
+- `kind` (String)
 - `peer_project_id` (String) GCP Project ID of the peer account to create attachment to.
 - `peer_vpc_name` (String) GCP VPC Name of the peer account to create attachment to.
 

--- a/docs/resources/gateway_control_plane.md
+++ b/docs/resources/gateway_control_plane.md
@@ -70,9 +70,9 @@ Required:
 
 Read-Only:
 
-- `auth_type` (String) The auth type value of the cluster associated with the Runtime Group. must be one of ["pinned_client_certs", "pki_client_certs"]
+- `auth_type` (String) The auth type value of the cluster associated with the Runtime Group.
 - `cloud_gateway` (Boolean) Whether the Control Plane can be used for cloud-gateways.
-- `cluster_type` (String) The ClusterType value of the cluster associated with the Control Plane. must be one of ["CLUSTER_TYPE_CONTROL_PLANE", "CLUSTER_TYPE_K8S_INGRESS_CONTROLLER", "CLUSTER_TYPE_CONTROL_PLANE_GROUP", "CLUSTER_TYPE_SERVERLESS", "CLUSTER_TYPE_HYBRID"]
+- `cluster_type` (String) The ClusterType value of the cluster associated with the Control Plane.
 - `control_plane_endpoint` (String) Control Plane Endpoint.
 - `proxy_urls` (Attributes Set) Array of proxy URLs associated with reaching the data-planes connected to a control-plane. (see [below for nested schema](#nestedatt--config--proxy_urls))
 - `telemetry_endpoint` (String) Telemetry Endpoint.

--- a/docs/resources/portal_custom_domain.md
+++ b/docs/resources/portal_custom_domain.md
@@ -38,7 +38,7 @@ resource "konnect_portal_custom_domain" "my_portalcustomdomain" {
 
 ### Read-Only
 
-- `cname_status` (String) must be one of ["verified", "pending"]
+- `cname_status` (String)
 - `created_at` (String) An ISO-8601 timestamp representation of entity creation date.
 - `updated_at` (String) An ISO-8601 timestamp representation of entity update date.
 
@@ -57,7 +57,7 @@ Read-Only:
 - `expires_at` (String) An ISO-8601 timestamp representation of the ssl certificate expiration date.
 - `uploaded_at` (String) An ISO-8601 timestamp representation of the ssl certificate upload date.
 - `validation_errors` (List of String)
-- `verification_status` (String) must be one of ["verified", "pending", "error"]
+- `verification_status` (String)
 
 ## Import
 

--- a/docs/resources/portal_product_version.md
+++ b/docs/resources/portal_product_version.md
@@ -65,7 +65,7 @@ Read-Only:
 
 - `auth_methods` (List of String)
 - `available_scopes` (List of String) Possible developer selectable scopes for an application. Only present when using DCR Provider that supports it.
-- `credential_type` (String) must be one of ["client_credentials", "self_managed_client_credentials"]
+- `credential_type` (String)
 - `id` (String) The Application Auth Strategy ID.
 - `name` (String) Default: "name"
 
@@ -75,7 +75,7 @@ Read-Only:
 
 Read-Only:
 
-- `credential_type` (String) must be "key_auth"
+- `credential_type` (String)
 - `id` (String) The Application Auth Strategy ID.
 - `key_names` (List of String)
 - `name` (String) Default: "name"

--- a/gen.yaml
+++ b/gen.yaml
@@ -40,6 +40,7 @@ terraform:
   author: kong
   baseErrorName: KonnectError
   defaultErrorName: SDKError
+  enableCustomCodeRegions: false
   enableOperationSecurity: false
   enableOperationServers: false
   enableTypeDeduplication: true
@@ -50,6 +51,7 @@ terraform:
       providerAttribute: system_account_access_token
     - env: KONNECT_SERVER_URL
       providerAttribute: server_url
+  excludeEmptyObjectSchemas: false
   imports:
     option: openapi
     paths:
@@ -59,5 +61,6 @@ terraform:
       shared: shared
       webhooks: webhooks
   includeEmptyObjects: false
+  inferUnionDiscriminators: false
   packageName: konnect
-  unionDeserializationStrategy: populated-fields
+  unionStrategy: populated-fields

--- a/internal/provider/api_resource_sdk.go
+++ b/internal/provider/api_resource_sdk.go
@@ -129,10 +129,10 @@ func (r *APIResourceModel) ToSharedCreateAPIRequest(ctx context.Context) (*share
 		slug = nil
 	}
 	labels := make(map[string]*string)
-	for labelsKey, labelsValue := range r.Labels {
+	for labelsKey := range r.Labels {
 		labelsInst := new(string)
-		if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-			*labelsInst = labelsValue.ValueString()
+		if !r.Labels[labelsKey].IsUnknown() && !r.Labels[labelsKey].IsNull() {
+			*labelsInst = r.Labels[labelsKey].ValueString()
 		} else {
 			labelsInst = nil
 		}
@@ -191,10 +191,10 @@ func (r *APIResourceModel) ToSharedUpdateAPIRequest(ctx context.Context) (*share
 	var labels map[string]*string
 	if r.Labels != nil {
 		labels = make(map[string]*string)
-		for labelsKey, labelsValue := range r.Labels {
+		for labelsKey := range r.Labels {
 			labelsInst := new(string)
-			if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-				*labelsInst = labelsValue.ValueString()
+			if !r.Labels[labelsKey].IsUnknown() && !r.Labels[labelsKey].IsNull() {
+				*labelsInst = r.Labels[labelsKey].ValueString()
 			} else {
 				labelsInst = nil
 			}

--- a/internal/provider/apiproduct_resource.go
+++ b/internal/provider/apiproduct_resource.go
@@ -17,7 +17,6 @@ import (
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect/v3/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect/v3/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect/v3/internal/sdk"
-	"github.com/kong/terraform-provider-konnect/v3/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -62,9 +61,6 @@ func (r *APIProductResource) Schema(ctx context.Context, req resource.SchemaRequ
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity creation date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"description": schema.StringAttribute{
 				Optional:    true,
@@ -131,9 +127,6 @@ func (r *APIProductResource) Schema(ctx context.Context, req resource.SchemaRequ
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity update date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"version_count": schema.Float64Attribute{
 				Computed:    true,
@@ -373,7 +366,10 @@ func (r *APIProductResource) Delete(ctx context.Context, req resource.DeleteRequ
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/apiproduct_resource_sdk.go
+++ b/internal/provider/apiproduct_resource_sdk.go
@@ -113,25 +113,25 @@ func (r *APIProductResourceModel) ToSharedCreateAPIProductDTO(ctx context.Contex
 		description = nil
 	}
 	labels := make(map[string]*string)
-	for labelsKey, labelsValue := range r.Labels {
+	for labelsKey := range r.Labels {
 		labelsInst := new(string)
-		if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-			*labelsInst = labelsValue.ValueString()
+		if !r.Labels[labelsKey].IsUnknown() && !r.Labels[labelsKey].IsNull() {
+			*labelsInst = r.Labels[labelsKey].ValueString()
 		} else {
 			labelsInst = nil
 		}
 		labels[labelsKey] = labelsInst
 	}
 	publicLabels := make(map[string]string)
-	for publicLabelsKey, publicLabelsValue := range r.PublicLabels {
+	for publicLabelsKey := range r.PublicLabels {
 		var publicLabelsInst string
-		publicLabelsInst = publicLabelsValue.ValueString()
+		publicLabelsInst = r.PublicLabels[publicLabelsKey].ValueString()
 
 		publicLabels[publicLabelsKey] = publicLabelsInst
 	}
 	portalIds := make([]string, 0, len(r.PortalIds))
-	for _, portalIdsItem := range r.PortalIds {
-		portalIds = append(portalIds, portalIdsItem.ValueString())
+	for portalIdsIndex := range r.PortalIds {
+		portalIds = append(portalIds, r.PortalIds[portalIdsIndex].ValueString())
 	}
 	out := shared.CreateAPIProductDTO{
 		Name:         name,
@@ -162,10 +162,10 @@ func (r *APIProductResourceModel) ToSharedUpdateAPIProductDTO(ctx context.Contex
 	var labels map[string]*string
 	if r.Labels != nil {
 		labels = make(map[string]*string)
-		for labelsKey, labelsValue := range r.Labels {
+		for labelsKey := range r.Labels {
 			labelsInst := new(string)
-			if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-				*labelsInst = labelsValue.ValueString()
+			if !r.Labels[labelsKey].IsUnknown() && !r.Labels[labelsKey].IsNull() {
+				*labelsInst = r.Labels[labelsKey].ValueString()
 			} else {
 				labelsInst = nil
 			}
@@ -173,18 +173,18 @@ func (r *APIProductResourceModel) ToSharedUpdateAPIProductDTO(ctx context.Contex
 		}
 	}
 	publicLabels := make(map[string]*string)
-	for publicLabelsKey, publicLabelsValue := range r.PublicLabels {
+	for publicLabelsKey := range r.PublicLabels {
 		publicLabelsInst := new(string)
-		if !publicLabelsValue.IsUnknown() && !publicLabelsValue.IsNull() {
-			*publicLabelsInst = publicLabelsValue.ValueString()
+		if !r.PublicLabels[publicLabelsKey].IsUnknown() && !r.PublicLabels[publicLabelsKey].IsNull() {
+			*publicLabelsInst = r.PublicLabels[publicLabelsKey].ValueString()
 		} else {
 			publicLabelsInst = nil
 		}
 		publicLabels[publicLabelsKey] = publicLabelsInst
 	}
 	portalIds := make([]string, 0, len(r.PortalIds))
-	for _, portalIdsItem := range r.PortalIds {
-		portalIds = append(portalIds, portalIdsItem.ValueString())
+	for portalIdsIndex := range r.PortalIds {
+		portalIds = append(portalIds, r.PortalIds[portalIdsIndex].ValueString())
 	}
 	out := shared.UpdateAPIProductDTO{
 		Name:         name,

--- a/internal/provider/apiproductspecification_resource.go
+++ b/internal/provider/apiproductspecification_resource.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect/v3/internal/planmodifiers/stringplanmodifier"
 	"github.com/kong/terraform-provider-konnect/v3/internal/sdk"
-	"github.com/kong/terraform-provider-konnect/v3/internal/validators"
 	"regexp"
 )
 
@@ -77,9 +76,6 @@ func (r *APIProductSpecificationResource) Schema(ctx context.Context, req resour
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity creation date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"id": schema.StringAttribute{
 				Computed: true,
@@ -102,9 +98,6 @@ func (r *APIProductSpecificationResource) Schema(ctx context.Context, req resour
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity update date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 		},
 	}
@@ -164,6 +157,13 @@ func (r *APIProductSpecificationResource) Create(ctx context.Context, req resour
 	}
 	if res == nil {
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
+		return
+	}
+	if res.StatusCode == 409 {
+		resp.Diagnostics.AddError(
+			"Resource Already Exists",
+			"When creating this resource, the API indicated that this resource already exists. You can bring the existing resource under management using Terraform import functionality or retry with a unique configuration.",
+		)
 		return
 	}
 	if res.StatusCode != 201 {
@@ -340,7 +340,10 @@ func (r *APIProductSpecificationResource) Delete(ctx context.Context, req resour
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/apiproductversion_resource_sdk.go
+++ b/internal/provider/apiproductversion_resource_sdk.go
@@ -158,10 +158,10 @@ func (r *APIProductVersionResourceModel) ToSharedCreateAPIProductVersionDTO(ctx 
 		deprecated = nil
 	}
 	labels := make(map[string]*string)
-	for labelsKey, labelsValue := range r.Labels {
+	for labelsKey := range r.Labels {
 		labelsInst := new(string)
-		if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-			*labelsInst = labelsValue.ValueString()
+		if !r.Labels[labelsKey].IsUnknown() && !r.Labels[labelsKey].IsNull() {
+			*labelsInst = r.Labels[labelsKey].ValueString()
 		} else {
 			labelsInst = nil
 		}
@@ -221,10 +221,10 @@ func (r *APIProductVersionResourceModel) ToSharedUpdateAPIProductVersionDTO(ctx 
 	var labels map[string]*string
 	if r.Labels != nil {
 		labels = make(map[string]*string)
-		for labelsKey, labelsValue := range r.Labels {
+		for labelsKey := range r.Labels {
 			labelsInst := new(string)
-			if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-				*labelsInst = labelsValue.ValueString()
+			if !r.Labels[labelsKey].IsUnknown() && !r.Labels[labelsKey].IsNull() {
+				*labelsInst = r.Labels[labelsKey].ValueString()
 			} else {
 				labelsInst = nil
 			}

--- a/internal/provider/apipublication_resource.go
+++ b/internal/provider/apipublication_resource.go
@@ -19,7 +19,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect/v3/internal/planmodifiers/stringplanmodifier"
 	"github.com/kong/terraform-provider-konnect/v3/internal/sdk"
-	"github.com/kong/terraform-provider-konnect/v3/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -82,9 +81,6 @@ func (r *APIPublicationResource) Schema(ctx context.Context, req resource.Schema
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity creation date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"portal_id": schema.StringAttribute{
 				Required:    true,
@@ -96,9 +92,6 @@ func (r *APIPublicationResource) Schema(ctx context.Context, req resource.Schema
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity update date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"visibility": schema.StringAttribute{
 				Computed: true,
@@ -349,7 +342,10 @@ func (r *APIPublicationResource) Delete(ctx context.Context, req resource.Delete
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/apipublication_resource_sdk.go
+++ b/internal/provider/apipublication_resource_sdk.go
@@ -105,8 +105,8 @@ func (r *APIPublicationResourceModel) ToSharedAPIPublication(ctx context.Context
 	var authStrategyIds []string
 	if r.AuthStrategyIds != nil {
 		authStrategyIds = make([]string, 0, len(r.AuthStrategyIds))
-		for _, authStrategyIdsItem := range r.AuthStrategyIds {
-			authStrategyIds = append(authStrategyIds, authStrategyIdsItem.ValueString())
+		for authStrategyIdsIndex := range r.AuthStrategyIds {
+			authStrategyIds = append(authStrategyIds, r.AuthStrategyIds[authStrategyIdsIndex].ValueString())
 		}
 	}
 	visibility := new(shared.APIPublicationVisibility)

--- a/internal/provider/apispecification_resource.go
+++ b/internal/provider/apispecification_resource.go
@@ -20,7 +20,6 @@ import (
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect/v3/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect/v3/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect/v3/internal/sdk"
-	"github.com/kong/terraform-provider-konnect/v3/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -70,9 +69,6 @@ func (r *APISpecificationResource) Schema(ctx context.Context, req resource.Sche
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity creation date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"id": schema.StringAttribute{
 				Computed: true,
@@ -99,9 +95,6 @@ func (r *APISpecificationResource) Schema(ctx context.Context, req resource.Sche
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity update date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"validation_messages": schema.ListNestedAttribute{
 				Computed: true,
@@ -181,6 +174,13 @@ func (r *APISpecificationResource) Create(ctx context.Context, req resource.Crea
 	}
 	if res == nil {
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
+		return
+	}
+	if res.StatusCode == 409 {
+		resp.Diagnostics.AddError(
+			"Resource Already Exists",
+			"When creating this resource, the API indicated that this resource already exists. You can bring the existing resource under management using Terraform import functionality or retry with a unique configuration.",
+		)
 		return
 	}
 	if res.StatusCode != 201 {
@@ -357,7 +357,10 @@ func (r *APISpecificationResource) Delete(ctx context.Context, req resource.Dele
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/applicationauthstrategy_resource.go
+++ b/internal/provider/applicationauthstrategy_resource.go
@@ -22,14 +22,9 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	speakeasy_boolplanmodifier "github.com/kong/terraform-provider-konnect/v3/internal/planmodifiers/boolplanmodifier"
-	speakeasy_listplanmodifier "github.com/kong/terraform-provider-konnect/v3/internal/planmodifiers/listplanmodifier"
-	speakeasy_mapplanmodifier "github.com/kong/terraform-provider-konnect/v3/internal/planmodifiers/mapplanmodifier"
-	speakeasy_objectplanmodifier "github.com/kong/terraform-provider-konnect/v3/internal/planmodifiers/objectplanmodifier"
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect/v3/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect/v3/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect/v3/internal/sdk"
-	"github.com/kong/terraform-provider-konnect/v3/internal/validators"
 	speakeasy_listvalidators "github.com/kong/terraform-provider-konnect/v3/internal/validators/listvalidators"
 	speakeasy_objectvalidators "github.com/kong/terraform-provider-konnect/v3/internal/validators/objectvalidators"
 	speakeasy_stringvalidators "github.com/kong/terraform-provider-konnect/v3/internal/validators/stringvalidators"
@@ -74,9 +69,6 @@ func (r *ApplicationAuthStrategyResource) Schema(ctx context.Context, req resour
 			"display_name": schema.StringAttribute{
 				Computed:    true,
 				Description: `The display name of the Auth strategy. This is used to identify the Auth strategy in the Portal UI.`,
-				Validators: []validator.String{
-					stringvalidator.UTF8LengthAtMost(256),
-				},
 			},
 			"id": schema.StringAttribute{
 				Computed: true,
@@ -86,18 +78,13 @@ func (r *ApplicationAuthStrategyResource) Schema(ctx context.Context, req resour
 				Description: `Contains a unique identifier used for this resource.`,
 			},
 			"key_auth": schema.SingleNestedAttribute{
-				Computed: true,
 				Optional: true,
 				PlanModifiers: []planmodifier.Object{
 					objectplanmodifier.RequiresReplaceIfConfigured(),
-					speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
 				},
 				Attributes: map[string]schema.Attribute{
 					"active": schema.BoolAttribute{
-						Computed: true,
-						PlanModifiers: []planmodifier.Bool{
-							speakeasy_boolplanmodifier.SuppressDiff(speakeasy_boolplanmodifier.ExplicitSuppress),
-						},
+						Computed:    true,
 						Description: `At least one published entity is using this auth strategy.`,
 					},
 					"configs": schema.SingleNestedAttribute{
@@ -105,7 +92,6 @@ func (r *ApplicationAuthStrategyResource) Schema(ctx context.Context, req resour
 						Optional: true,
 						PlanModifiers: []planmodifier.Object{
 							objectplanmodifier.RequiresReplaceIfConfigured(),
-							speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
 						},
 						Attributes: map[string]schema.Attribute{
 							"key_auth": schema.SingleNestedAttribute{
@@ -113,7 +99,6 @@ func (r *ApplicationAuthStrategyResource) Schema(ctx context.Context, req resour
 								Optional: true,
 								PlanModifiers: []planmodifier.Object{
 									objectplanmodifier.RequiresReplaceIfConfigured(),
-									speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
 								},
 								Attributes: map[string]schema.Attribute{
 									"key_names": schema.ListAttribute{
@@ -149,9 +134,6 @@ func (r *ApplicationAuthStrategyResource) Schema(ctx context.Context, req resour
 							speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 						},
 						Description: `An ISO-8601 timestamp representation of entity creation date.`,
-						Validators: []validator.String{
-							validators.IsRFC3339(),
-						},
 					},
 					"dcr_provider": schema.SingleNestedAttribute{
 						Computed: true,
@@ -168,9 +150,6 @@ func (r *ApplicationAuthStrategyResource) Schema(ctx context.Context, req resour
 									speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 								},
 								Description: `The display name of the DCR provider. This is used to identify the DCR provider in the Portal UI.`,
-								Validators: []validator.String{
-									stringvalidator.UTF8LengthBetween(1, 256),
-								},
 							},
 							"id": schema.StringAttribute{
 								Computed: true,
@@ -190,16 +169,7 @@ func (r *ApplicationAuthStrategyResource) Schema(ctx context.Context, req resour
 								PlanModifiers: []planmodifier.String{
 									speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 								},
-								Description: `The type of DCR provider. must be one of ["auth0", "azureAd", "curity", "okta", "http"]`,
-								Validators: []validator.String{
-									stringvalidator.OneOf(
-										"auth0",
-										"azureAd",
-										"curity",
-										"okta",
-										"http",
-									),
-								},
+								Description: `The type of DCR provider.`,
 							},
 						},
 					},
@@ -208,7 +178,6 @@ func (r *ApplicationAuthStrategyResource) Schema(ctx context.Context, req resour
 						Optional: true,
 						PlanModifiers: []planmodifier.String{
 							stringplanmodifier.RequiresReplaceIfConfigured(),
-							speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 						},
 						Description: `The display name of the Auth strategy. This is used to identify the Auth strategy in the Portal UI. Not Null; Requires replacement if changed.`,
 						Validators: []validator.String{
@@ -228,7 +197,6 @@ func (r *ApplicationAuthStrategyResource) Schema(ctx context.Context, req resour
 						Optional: true,
 						PlanModifiers: []planmodifier.Map{
 							mapplanmodifier.RequiresReplaceIfConfigured(),
-							speakeasy_mapplanmodifier.SuppressDiff(speakeasy_mapplanmodifier.ExplicitSuppress),
 						},
 						ElementType: types.StringType,
 						MarkdownDescription: `Labels store metadata of an entity that can be used for filtering an entity list or for searching across entity types. ` + "\n" +
@@ -241,7 +209,6 @@ func (r *ApplicationAuthStrategyResource) Schema(ctx context.Context, req resour
 						Optional: true,
 						PlanModifiers: []planmodifier.String{
 							stringplanmodifier.RequiresReplaceIfConfigured(),
-							speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 						},
 						Description: `The name of the auth strategy. This is used to identify the auth strategy in the Konnect UI. Not Null; Requires replacement if changed.`,
 						Validators: []validator.String{
@@ -254,7 +221,6 @@ func (r *ApplicationAuthStrategyResource) Schema(ctx context.Context, req resour
 						Optional: true,
 						PlanModifiers: []planmodifier.String{
 							stringplanmodifier.RequiresReplaceIfConfigured(),
-							speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 						},
 						Description: `Not Null; must be "key_auth"; Requires replacement if changed.`,
 						Validators: []validator.String{
@@ -268,9 +234,6 @@ func (r *ApplicationAuthStrategyResource) Schema(ctx context.Context, req resour
 							speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 						},
 						Description: `An ISO-8601 timestamp representation of entity update date.`,
-						Validators: []validator.String{
-							validators.IsRFC3339(),
-						},
 					},
 				},
 				Description: `Response payload from creating or updating a Key Auth Application Auth Strategy. Requires replacement if changed.`,
@@ -283,23 +246,15 @@ func (r *ApplicationAuthStrategyResource) Schema(ctx context.Context, req resour
 			"name": schema.StringAttribute{
 				Computed:    true,
 				Description: `The name of the auth strategy. This is used to identify the auth strategy in the Konnect UI.`,
-				Validators: []validator.String{
-					stringvalidator.UTF8LengthBetween(1, 256),
-				},
 			},
 			"openid_connect": schema.SingleNestedAttribute{
-				Computed: true,
 				Optional: true,
 				PlanModifiers: []planmodifier.Object{
 					objectplanmodifier.RequiresReplaceIfConfigured(),
-					speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
 				},
 				Attributes: map[string]schema.Attribute{
 					"active": schema.BoolAttribute{
-						Computed: true,
-						PlanModifiers: []planmodifier.Bool{
-							speakeasy_boolplanmodifier.SuppressDiff(speakeasy_boolplanmodifier.ExplicitSuppress),
-						},
+						Computed:    true,
 						Description: `At least one published entity is using this auth strategy.`,
 					},
 					"configs": schema.SingleNestedAttribute{
@@ -307,7 +262,6 @@ func (r *ApplicationAuthStrategyResource) Schema(ctx context.Context, req resour
 						Optional: true,
 						PlanModifiers: []planmodifier.Object{
 							objectplanmodifier.RequiresReplaceIfConfigured(),
-							speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
 						},
 						Attributes: map[string]schema.Attribute{
 							"openid_connect": schema.SingleNestedAttribute{
@@ -315,7 +269,6 @@ func (r *ApplicationAuthStrategyResource) Schema(ctx context.Context, req resour
 								Optional: true,
 								PlanModifiers: []planmodifier.Object{
 									objectplanmodifier.RequiresReplaceIfConfigured(),
-									speakeasy_objectplanmodifier.SuppressDiff(speakeasy_objectplanmodifier.ExplicitSuppress),
 								},
 								Attributes: map[string]schema.Attribute{
 									"additional_properties": schema.StringAttribute{
@@ -324,7 +277,6 @@ func (r *ApplicationAuthStrategyResource) Schema(ctx context.Context, req resour
 										Optional:   true,
 										PlanModifiers: []planmodifier.String{
 											stringplanmodifier.RequiresReplaceIfConfigured(),
-											speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 										},
 										Description: `Requires replacement if changed.; Parsed as JSON.`,
 									},
@@ -333,7 +285,6 @@ func (r *ApplicationAuthStrategyResource) Schema(ctx context.Context, req resour
 										Optional: true,
 										PlanModifiers: []planmodifier.List{
 											listplanmodifier.RequiresReplaceIfConfigured(),
-											speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
 										},
 										ElementType: types.StringType,
 										Description: `Not Null; Requires replacement if changed.`,
@@ -347,7 +298,6 @@ func (r *ApplicationAuthStrategyResource) Schema(ctx context.Context, req resour
 										Optional: true,
 										PlanModifiers: []planmodifier.List{
 											listplanmodifier.RequiresReplaceIfConfigured(),
-											speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
 										},
 										ElementType: types.StringType,
 										Description: `Not Null; Requires replacement if changed.`,
@@ -361,7 +311,6 @@ func (r *ApplicationAuthStrategyResource) Schema(ctx context.Context, req resour
 										Optional: true,
 										PlanModifiers: []planmodifier.String{
 											stringplanmodifier.RequiresReplaceIfConfigured(),
-											speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 										},
 										Description: `Not Null; Requires replacement if changed.`,
 										Validators: []validator.String{
@@ -374,7 +323,6 @@ func (r *ApplicationAuthStrategyResource) Schema(ctx context.Context, req resour
 										Optional: true,
 										PlanModifiers: []planmodifier.List{
 											listplanmodifier.RequiresReplaceIfConfigured(),
-											speakeasy_listplanmodifier.SuppressDiff(speakeasy_listplanmodifier.ExplicitSuppress),
 										},
 										ElementType: types.StringType,
 										Description: `Not Null; Requires replacement if changed.`,
@@ -405,9 +353,6 @@ func (r *ApplicationAuthStrategyResource) Schema(ctx context.Context, req resour
 							speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 						},
 						Description: `An ISO-8601 timestamp representation of entity creation date.`,
-						Validators: []validator.String{
-							validators.IsRFC3339(),
-						},
 					},
 					"dcr_provider": schema.SingleNestedAttribute{
 						Computed: true,
@@ -424,9 +369,6 @@ func (r *ApplicationAuthStrategyResource) Schema(ctx context.Context, req resour
 									speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 								},
 								Description: `The display name of the DCR provider. This is used to identify the DCR provider in the Portal UI.`,
-								Validators: []validator.String{
-									stringvalidator.UTF8LengthBetween(1, 256),
-								},
 							},
 							"id": schema.StringAttribute{
 								Computed: true,
@@ -446,16 +388,7 @@ func (r *ApplicationAuthStrategyResource) Schema(ctx context.Context, req resour
 								PlanModifiers: []planmodifier.String{
 									speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 								},
-								Description: `The type of DCR provider. must be one of ["auth0", "azureAd", "curity", "okta", "http"]`,
-								Validators: []validator.String{
-									stringvalidator.OneOf(
-										"auth0",
-										"azureAd",
-										"curity",
-										"okta",
-										"http",
-									),
-								},
+								Description: `The type of DCR provider.`,
 							},
 						},
 					},
@@ -471,7 +404,6 @@ func (r *ApplicationAuthStrategyResource) Schema(ctx context.Context, req resour
 						Optional: true,
 						PlanModifiers: []planmodifier.String{
 							stringplanmodifier.RequiresReplaceIfConfigured(),
-							speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 						},
 						Description: `The display name of the Auth strategy. This is used to identify the Auth strategy in the Portal UI. Not Null; Requires replacement if changed.`,
 						Validators: []validator.String{
@@ -491,7 +423,6 @@ func (r *ApplicationAuthStrategyResource) Schema(ctx context.Context, req resour
 						Optional: true,
 						PlanModifiers: []planmodifier.Map{
 							mapplanmodifier.RequiresReplaceIfConfigured(),
-							speakeasy_mapplanmodifier.SuppressDiff(speakeasy_mapplanmodifier.ExplicitSuppress),
 						},
 						ElementType: types.StringType,
 						MarkdownDescription: `Labels store metadata of an entity that can be used for filtering an entity list or for searching across entity types. ` + "\n" +
@@ -504,7 +435,6 @@ func (r *ApplicationAuthStrategyResource) Schema(ctx context.Context, req resour
 						Optional: true,
 						PlanModifiers: []planmodifier.String{
 							stringplanmodifier.RequiresReplaceIfConfigured(),
-							speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 						},
 						Description: `The name of the auth strategy. This is used to identify the auth strategy in the Konnect UI. Not Null; Requires replacement if changed.`,
 						Validators: []validator.String{
@@ -517,7 +447,6 @@ func (r *ApplicationAuthStrategyResource) Schema(ctx context.Context, req resour
 						Optional: true,
 						PlanModifiers: []planmodifier.String{
 							stringplanmodifier.RequiresReplaceIfConfigured(),
-							speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 						},
 						Description: `Not Null; must be "openid_connect"; Requires replacement if changed.`,
 						Validators: []validator.String{
@@ -533,9 +462,6 @@ func (r *ApplicationAuthStrategyResource) Schema(ctx context.Context, req resour
 							speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 						},
 						Description: `An ISO-8601 timestamp representation of entity update date.`,
-						Validators: []validator.String{
-							validators.IsRFC3339(),
-						},
 					},
 				},
 				Description: `Response payload from creating an OIDC Application Auth Strategy. Requires replacement if changed.`,
@@ -853,7 +779,10 @@ func (r *ApplicationAuthStrategyResource) Delete(ctx context.Context, req resour
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/applicationauthstrategy_resource_sdk.go
+++ b/internal/provider/applicationauthstrategy_resource_sdk.go
@@ -169,8 +169,8 @@ func (r *ApplicationAuthStrategyResourceModel) ToSharedCreateAppAuthStrategyRequ
 		var keyNames []string
 		if r.KeyAuth.Configs.KeyAuth.KeyNames != nil {
 			keyNames = make([]string, 0, len(r.KeyAuth.Configs.KeyAuth.KeyNames))
-			for _, keyNamesItem := range r.KeyAuth.Configs.KeyAuth.KeyNames {
-				keyNames = append(keyNames, keyNamesItem.ValueString())
+			for keyNamesIndex := range r.KeyAuth.Configs.KeyAuth.KeyNames {
+				keyNames = append(keyNames, r.KeyAuth.Configs.KeyAuth.KeyNames[keyNamesIndex].ValueString())
 			}
 		}
 		keyAuth := shared.AppAuthStrategyConfigKeyAuth{
@@ -180,10 +180,10 @@ func (r *ApplicationAuthStrategyResourceModel) ToSharedCreateAppAuthStrategyRequ
 			KeyAuth: keyAuth,
 		}
 		labels := make(map[string]*string)
-		for labelsKey, labelsValue := range r.KeyAuth.Labels {
+		for labelsKey := range r.KeyAuth.Labels {
 			labelsInst := new(string)
-			if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-				*labelsInst = labelsValue.ValueString()
+			if !r.KeyAuth.Labels[labelsKey].IsUnknown() && !r.KeyAuth.Labels[labelsKey].IsNull() {
+				*labelsInst = r.KeyAuth.Labels[labelsKey].ValueString()
 			} else {
 				labelsInst = nil
 			}
@@ -215,16 +215,16 @@ func (r *ApplicationAuthStrategyResourceModel) ToSharedCreateAppAuthStrategyRequ
 		issuer = r.OpenidConnect.Configs.OpenidConnect.Issuer.ValueString()
 
 		credentialClaim := make([]string, 0, len(r.OpenidConnect.Configs.OpenidConnect.CredentialClaim))
-		for _, credentialClaimItem := range r.OpenidConnect.Configs.OpenidConnect.CredentialClaim {
-			credentialClaim = append(credentialClaim, credentialClaimItem.ValueString())
+		for credentialClaimIndex := range r.OpenidConnect.Configs.OpenidConnect.CredentialClaim {
+			credentialClaim = append(credentialClaim, r.OpenidConnect.Configs.OpenidConnect.CredentialClaim[credentialClaimIndex].ValueString())
 		}
 		scopes := make([]string, 0, len(r.OpenidConnect.Configs.OpenidConnect.Scopes))
-		for _, scopesItem := range r.OpenidConnect.Configs.OpenidConnect.Scopes {
-			scopes = append(scopes, scopesItem.ValueString())
+		for scopesIndex := range r.OpenidConnect.Configs.OpenidConnect.Scopes {
+			scopes = append(scopes, r.OpenidConnect.Configs.OpenidConnect.Scopes[scopesIndex].ValueString())
 		}
 		authMethods := make([]string, 0, len(r.OpenidConnect.Configs.OpenidConnect.AuthMethods))
-		for _, authMethodsItem := range r.OpenidConnect.Configs.OpenidConnect.AuthMethods {
-			authMethods = append(authMethods, authMethodsItem.ValueString())
+		for authMethodsIndex := range r.OpenidConnect.Configs.OpenidConnect.AuthMethods {
+			authMethods = append(authMethods, r.OpenidConnect.Configs.OpenidConnect.AuthMethods[authMethodsIndex].ValueString())
 		}
 		var additionalProperties interface{}
 		if !r.OpenidConnect.Configs.OpenidConnect.AdditionalProperties.IsUnknown() && !r.OpenidConnect.Configs.OpenidConnect.AdditionalProperties.IsNull() {
@@ -247,10 +247,10 @@ func (r *ApplicationAuthStrategyResourceModel) ToSharedCreateAppAuthStrategyRequ
 			dcrProviderID = nil
 		}
 		labels1 := make(map[string]*string)
-		for labelsKey1, labelsValue1 := range r.OpenidConnect.Labels {
+		for labelsKey1 := range r.OpenidConnect.Labels {
 			labelsInst1 := new(string)
-			if !labelsValue1.IsUnknown() && !labelsValue1.IsNull() {
-				*labelsInst1 = labelsValue1.ValueString()
+			if !r.OpenidConnect.Labels[labelsKey1].IsUnknown() && !r.OpenidConnect.Labels[labelsKey1].IsNull() {
+				*labelsInst1 = r.OpenidConnect.Labels[labelsKey1].ValueString()
 			} else {
 				labelsInst1 = nil
 			}

--- a/internal/provider/auditlog_resource.go
+++ b/internal/provider/auditlog_resource.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect/v3/internal/planmodifiers/stringplanmodifier"
 	"github.com/kong/terraform-provider-konnect/v3/internal/sdk"
-	"github.com/kong/terraform-provider-konnect/v3/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -93,9 +92,6 @@ func (r *AuditLogResource) Schema(ctx context.Context, req resource.SchemaReques
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `Timestamp when this webhook was last updated. Initial value is 0001-01-01T00:00:0Z.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 		},
 	}
@@ -375,7 +371,10 @@ func (r *AuditLogResource) Delete(ctx context.Context, req resource.DeleteReques
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 200 {
+	switch res.StatusCode {
+	case 200, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/auditlogdestination_resource.go
+++ b/internal/provider/auditlogdestination_resource.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect/v3/internal/planmodifiers/stringplanmodifier"
 	"github.com/kong/terraform-provider-konnect/v3/internal/sdk"
-	"github.com/kong/terraform-provider-konnect/v3/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -64,9 +63,6 @@ func (r *AuditLogDestinationResource) Schema(ctx context.Context, req resource.S
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `Timestamp when this webhook was created.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"endpoint": schema.StringAttribute{
 				Required:    true,
@@ -108,9 +104,6 @@ func (r *AuditLogDestinationResource) Schema(ctx context.Context, req resource.S
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `Timestamp when this webhook was last updated. Initial value is 0001-01-01T00:00:0Z.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 		},
 	}
@@ -420,7 +413,10 @@ func (r *AuditLogDestinationResource) Delete(ctx context.Context, req resource.D
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/catalogservice_resource.go
+++ b/internal/provider/catalogservice_resource.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect/v3/internal/planmodifiers/stringplanmodifier"
 	"github.com/kong/terraform-provider-konnect/v3/internal/sdk"
-	"github.com/kong/terraform-provider-konnect/v3/internal/validators"
 	"regexp"
 )
 
@@ -60,9 +59,6 @@ func (r *CatalogServiceResource) Schema(ctx context.Context, req resource.Schema
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity creation date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"custom_fields": schema.StringAttribute{
 				CustomType:  jsontypes.NormalizedType{},
@@ -113,9 +109,6 @@ func (r *CatalogServiceResource) Schema(ctx context.Context, req resource.Schema
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity update date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 		},
 	}
@@ -351,7 +344,10 @@ func (r *CatalogServiceResource) Delete(ctx context.Context, req resource.Delete
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/catalogservice_resource_sdk.go
+++ b/internal/provider/catalogservice_resource_sdk.go
@@ -99,10 +99,10 @@ func (r *CatalogServiceResourceModel) ToSharedCreateCatalogService(ctx context.C
 		description = nil
 	}
 	labels := make(map[string]*string)
-	for labelsKey, labelsValue := range r.Labels {
+	for labelsKey := range r.Labels {
 		labelsInst := new(string)
-		if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-			*labelsInst = labelsValue.ValueString()
+		if !r.Labels[labelsKey].IsUnknown() && !r.Labels[labelsKey].IsNull() {
+			*labelsInst = r.Labels[labelsKey].ValueString()
 		} else {
 			labelsInst = nil
 		}
@@ -147,10 +147,10 @@ func (r *CatalogServiceResourceModel) ToSharedUpdateCatalogService(ctx context.C
 	var labels map[string]*string
 	if r.Labels != nil {
 		labels = make(map[string]*string)
-		for labelsKey, labelsValue := range r.Labels {
+		for labelsKey := range r.Labels {
 			labelsInst := new(string)
-			if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-				*labelsInst = labelsValue.ValueString()
+			if !r.Labels[labelsKey].IsUnknown() && !r.Labels[labelsKey].IsNull() {
+				*labelsInst = r.Labels[labelsKey].ValueString()
 			} else {
 				labelsInst = nil
 			}

--- a/internal/provider/centralizedconsumer_resource.go
+++ b/internal/provider/centralizedconsumer_resource.go
@@ -20,7 +20,6 @@ import (
 	speakeasy_listplanmodifier "github.com/kong/terraform-provider-konnect/v3/internal/planmodifiers/listplanmodifier"
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect/v3/internal/planmodifiers/stringplanmodifier"
 	"github.com/kong/terraform-provider-konnect/v3/internal/sdk"
-	"github.com/kong/terraform-provider-konnect/v3/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -74,9 +73,6 @@ func (r *CentralizedConsumerResource) Schema(ctx context.Context, req resource.S
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity creation date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"custom_id": schema.StringAttribute{
 				Optional:    true,
@@ -127,9 +123,6 @@ func (r *CentralizedConsumerResource) Schema(ctx context.Context, req resource.S
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity update date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"username": schema.StringAttribute{
 				Required:    true,
@@ -372,7 +365,10 @@ func (r *CentralizedConsumerResource) Delete(ctx context.Context, req resource.D
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/centralizedconsumer_resource_sdk.go
+++ b/internal/provider/centralizedconsumer_resource_sdk.go
@@ -131,8 +131,8 @@ func (r *CentralizedConsumerResourceModel) ToSharedConsumerCreateRequest(ctx con
 		customID = nil
 	}
 	consumerGroups := make([]string, 0, len(r.ConsumerGroups))
-	for _, consumerGroupsItem := range r.ConsumerGroups {
-		consumerGroups = append(consumerGroups, consumerGroupsItem.ValueString())
+	for consumerGroupsIndex := range r.ConsumerGroups {
+		consumerGroups = append(consumerGroups, r.ConsumerGroups[consumerGroupsIndex].ValueString())
 	}
 	typeVar := new(shared.ConsumerType)
 	if !r.Type.IsUnknown() && !r.Type.IsNull() {
@@ -141,8 +141,8 @@ func (r *CentralizedConsumerResourceModel) ToSharedConsumerCreateRequest(ctx con
 		typeVar = nil
 	}
 	tags := make([]string, 0, len(r.Tags))
-	for _, tagsItem := range r.Tags {
-		tags = append(tags, tagsItem.ValueString())
+	for tagsIndex := range r.Tags {
+		tags = append(tags, r.Tags[tagsIndex].ValueString())
 	}
 	out := shared.ConsumerCreateRequest{
 		Username:       username,
@@ -173,8 +173,8 @@ func (r *CentralizedConsumerResourceModel) ToSharedUpdateConsumerPayload(ctx con
 	var consumerGroups []string
 	if r.ConsumerGroups != nil {
 		consumerGroups = make([]string, 0, len(r.ConsumerGroups))
-		for _, consumerGroupsItem := range r.ConsumerGroups {
-			consumerGroups = append(consumerGroups, consumerGroupsItem.ValueString())
+		for consumerGroupsIndex := range r.ConsumerGroups {
+			consumerGroups = append(consumerGroups, r.ConsumerGroups[consumerGroupsIndex].ValueString())
 		}
 	}
 	typeVar := new(shared.ConsumerType)
@@ -184,8 +184,8 @@ func (r *CentralizedConsumerResourceModel) ToSharedUpdateConsumerPayload(ctx con
 		typeVar = nil
 	}
 	tags := make([]string, 0, len(r.Tags))
-	for _, tagsItem := range r.Tags {
-		tags = append(tags, tagsItem.ValueString())
+	for tagsIndex := range r.Tags {
+		tags = append(tags, r.Tags[tagsIndex].ValueString())
 	}
 	out := shared.UpdateConsumerPayload{
 		Username:       username,

--- a/internal/provider/centralizedconsumerkey_resource.go
+++ b/internal/provider/centralizedconsumerkey_resource.go
@@ -22,7 +22,6 @@ import (
 	speakeasy_listplanmodifier "github.com/kong/terraform-provider-konnect/v3/internal/planmodifiers/listplanmodifier"
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect/v3/internal/planmodifiers/stringplanmodifier"
 	"github.com/kong/terraform-provider-konnect/v3/internal/sdk"
-	"github.com/kong/terraform-provider-konnect/v3/internal/validators"
 	custom_stringvalidators "github.com/kong/terraform-provider-konnect/v3/internal/validators/stringvalidators"
 )
 
@@ -73,9 +72,6 @@ func (r *CentralizedConsumerKeyResource) Schema(ctx context.Context, req resourc
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity creation date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"id": schema.StringAttribute{
 				Computed: true,
@@ -135,9 +131,6 @@ func (r *CentralizedConsumerKeyResource) Schema(ctx context.Context, req resourc
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity update date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 		},
 	}
@@ -374,7 +367,10 @@ func (r *CentralizedConsumerKeyResource) Delete(ctx context.Context, req resourc
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/centralizedconsumerkey_resource_sdk.go
+++ b/internal/provider/centralizedconsumerkey_resource_sdk.go
@@ -128,8 +128,8 @@ func (r *CentralizedConsumerKeyResourceModel) ToSharedCreateAPIKeyPayload(ctx co
 		secret = nil
 	}
 	tags := make([]string, 0, len(r.Tags))
-	for _, tagsItem := range r.Tags {
-		tags = append(tags, tagsItem.ValueString())
+	for tagsIndex := range r.Tags {
+		tags = append(tags, r.Tags[tagsIndex].ValueString())
 	}
 	out := shared.CreateAPIKeyPayload{
 		Type:   typeVar,

--- a/internal/provider/cloudgatewayconfiguration_resource_sdk.go
+++ b/internal/provider/cloudgatewayconfiguration_resource_sdk.go
@@ -106,21 +106,21 @@ func (r *CloudGatewayConfigurationResourceModel) ToSharedCreateConfigurationRequ
 	version = r.Version.ValueString()
 
 	dataplaneGroups := make([]shared.CreateConfigurationDataPlaneGroup, 0, len(r.DataplaneGroups))
-	for _, dataplaneGroupsItem := range r.DataplaneGroups {
-		provider := shared.ProviderName(dataplaneGroupsItem.Provider.ValueString())
+	for dataplaneGroupsIndex := range r.DataplaneGroups {
+		provider := shared.ProviderName(r.DataplaneGroups[dataplaneGroupsIndex].Provider.ValueString())
 		var region string
-		region = dataplaneGroupsItem.Region.ValueString()
+		region = r.DataplaneGroups[dataplaneGroupsIndex].Region.ValueString()
 
 		var cloudGatewayNetworkID string
-		cloudGatewayNetworkID = dataplaneGroupsItem.CloudGatewayNetworkID.ValueString()
+		cloudGatewayNetworkID = r.DataplaneGroups[dataplaneGroupsIndex].CloudGatewayNetworkID.ValueString()
 
 		var autoscale shared.ConfigurationDataPlaneGroupAutoscale
 		var configurationDataPlaneGroupAutoscaleStatic *shared.ConfigurationDataPlaneGroupAutoscaleStatic
-		if dataplaneGroupsItem.Autoscale.ConfigurationDataPlaneGroupAutoscaleStatic != nil {
-			kind := shared.Kind(dataplaneGroupsItem.Autoscale.ConfigurationDataPlaneGroupAutoscaleStatic.Kind.ValueString())
-			instanceType := shared.InstanceTypeName(dataplaneGroupsItem.Autoscale.ConfigurationDataPlaneGroupAutoscaleStatic.InstanceType.ValueString())
+		if r.DataplaneGroups[dataplaneGroupsIndex].Autoscale.ConfigurationDataPlaneGroupAutoscaleStatic != nil {
+			kind := shared.Kind(r.DataplaneGroups[dataplaneGroupsIndex].Autoscale.ConfigurationDataPlaneGroupAutoscaleStatic.Kind.ValueString())
+			instanceType := shared.InstanceTypeName(r.DataplaneGroups[dataplaneGroupsIndex].Autoscale.ConfigurationDataPlaneGroupAutoscaleStatic.InstanceType.ValueString())
 			var requestedInstances int64
-			requestedInstances = dataplaneGroupsItem.Autoscale.ConfigurationDataPlaneGroupAutoscaleStatic.RequestedInstances.ValueInt64()
+			requestedInstances = r.DataplaneGroups[dataplaneGroupsIndex].Autoscale.ConfigurationDataPlaneGroupAutoscaleStatic.RequestedInstances.ValueInt64()
 
 			configurationDataPlaneGroupAutoscaleStatic = &shared.ConfigurationDataPlaneGroupAutoscaleStatic{
 				Kind:               kind,
@@ -134,14 +134,14 @@ func (r *CloudGatewayConfigurationResourceModel) ToSharedCreateConfigurationRequ
 			}
 		}
 		var configurationDataPlaneGroupAutoscaleAutopilot *shared.ConfigurationDataPlaneGroupAutoscaleAutopilot
-		if dataplaneGroupsItem.Autoscale.ConfigurationDataPlaneGroupAutoscaleAutopilot != nil {
-			kind1 := shared.ConfigurationDataPlaneGroupAutoscaleAutopilotKind(dataplaneGroupsItem.Autoscale.ConfigurationDataPlaneGroupAutoscaleAutopilot.Kind.ValueString())
+		if r.DataplaneGroups[dataplaneGroupsIndex].Autoscale.ConfigurationDataPlaneGroupAutoscaleAutopilot != nil {
+			kind1 := shared.ConfigurationDataPlaneGroupAutoscaleAutopilotKind(r.DataplaneGroups[dataplaneGroupsIndex].Autoscale.ConfigurationDataPlaneGroupAutoscaleAutopilot.Kind.ValueString())
 			var baseRps int64
-			baseRps = dataplaneGroupsItem.Autoscale.ConfigurationDataPlaneGroupAutoscaleAutopilot.BaseRps.ValueInt64()
+			baseRps = r.DataplaneGroups[dataplaneGroupsIndex].Autoscale.ConfigurationDataPlaneGroupAutoscaleAutopilot.BaseRps.ValueInt64()
 
 			maxRps := new(int64)
-			if !dataplaneGroupsItem.Autoscale.ConfigurationDataPlaneGroupAutoscaleAutopilot.MaxRps.IsUnknown() && !dataplaneGroupsItem.Autoscale.ConfigurationDataPlaneGroupAutoscaleAutopilot.MaxRps.IsNull() {
-				*maxRps = dataplaneGroupsItem.Autoscale.ConfigurationDataPlaneGroupAutoscaleAutopilot.MaxRps.ValueInt64()
+			if !r.DataplaneGroups[dataplaneGroupsIndex].Autoscale.ConfigurationDataPlaneGroupAutoscaleAutopilot.MaxRps.IsUnknown() && !r.DataplaneGroups[dataplaneGroupsIndex].Autoscale.ConfigurationDataPlaneGroupAutoscaleAutopilot.MaxRps.IsNull() {
+				*maxRps = r.DataplaneGroups[dataplaneGroupsIndex].Autoscale.ConfigurationDataPlaneGroupAutoscaleAutopilot.MaxRps.ValueInt64()
 			} else {
 				maxRps = nil
 			}
@@ -156,13 +156,13 @@ func (r *CloudGatewayConfigurationResourceModel) ToSharedCreateConfigurationRequ
 				ConfigurationDataPlaneGroupAutoscaleAutopilot: configurationDataPlaneGroupAutoscaleAutopilot,
 			}
 		}
-		environment := make([]shared.ConfigurationDataPlaneGroupEnvironmentField, 0, len(dataplaneGroupsItem.Environment))
-		for _, environmentItem := range dataplaneGroupsItem.Environment {
+		environment := make([]shared.ConfigurationDataPlaneGroupEnvironmentField, 0, len(r.DataplaneGroups[dataplaneGroupsIndex].Environment))
+		for environmentIndex := range r.DataplaneGroups[dataplaneGroupsIndex].Environment {
 			var name string
-			name = environmentItem.Name.ValueString()
+			name = r.DataplaneGroups[dataplaneGroupsIndex].Environment[environmentIndex].Name.ValueString()
 
 			var value string
-			value = environmentItem.Value.ValueString()
+			value = r.DataplaneGroups[dataplaneGroupsIndex].Environment[environmentIndex].Value.ValueString()
 
 			environment = append(environment, shared.ConfigurationDataPlaneGroupEnvironmentField{
 				Name:  name,

--- a/internal/provider/cloudgatewaynetwork_resource_sdk.go
+++ b/internal/provider/cloudgatewaynetwork_resource_sdk.go
@@ -102,8 +102,8 @@ func (r *CloudGatewayNetworkResourceModel) ToSharedCreateNetworkRequest(ctx cont
 	region = r.Region.ValueString()
 
 	availabilityZones := make([]string, 0, len(r.AvailabilityZones))
-	for _, availabilityZonesItem := range r.AvailabilityZones {
-		availabilityZones = append(availabilityZones, availabilityZonesItem.ValueString())
+	for availabilityZonesIndex := range r.AvailabilityZones {
+		availabilityZones = append(availabilityZones, r.AvailabilityZones[availabilityZonesIndex].ValueString())
 	}
 	var cidrBlock string
 	cidrBlock = r.CidrBlock.ValueString()

--- a/internal/provider/cloudgatewayprivatedns_resource.go
+++ b/internal/provider/cloudgatewayprivatedns_resource.go
@@ -24,7 +24,6 @@ import (
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect/v3/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect/v3/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect/v3/internal/sdk"
-	"github.com/kong/terraform-provider-konnect/v3/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -70,9 +69,6 @@ func (r *CloudGatewayPrivateDNSResource) Schema(ctx context.Context, req resourc
 							speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 						},
 						Description: `An RFC-3339 timestamp representation of Private DNS creation date.`,
-						Validators: []validator.String{
-							validators.IsRFC3339(),
-						},
 					},
 					"entity_version": schema.Int64Attribute{
 						Computed: true,
@@ -109,13 +105,7 @@ func (r *CloudGatewayPrivateDNSResource) Schema(ctx context.Context, req resourc
 								Description: `Object that contains mappings from proxied internal domains to remote DNS server IP address for a Private DNS Resolver.`,
 							},
 							"kind": schema.StringAttribute{
-								Computed:    true,
-								Description: `must be "aws-outbound-resolver"`,
-								Validators: []validator.String{
-									stringvalidator.OneOf(
-										"aws-outbound-resolver",
-									),
-								},
+								Computed: true,
 							},
 						},
 					},
@@ -128,19 +118,7 @@ func (r *CloudGatewayPrivateDNSResource) Schema(ctx context.Context, req resourc
 							`- ` + "`" + `ready` + "`" + ` - The attachment is fully operational and can route traffic as configured.` + "\n" +
 							`- ` + "`" + `error` + "`" + ` - The attachment is in an error state, and is not operational.` + "\n" +
 							`- ` + "`" + `terminating` + "`" + ` - The attachment is in the process of being deleted.` + "\n" +
-							`- ` + "`" + `terminated` + "`" + ` - The attachment has been fully deleted and is no longer available.` + "\n" +
-							`must be one of ["created", "initializing", "pending-association", "ready", "error", "terminating", "terminated"]`,
-						Validators: []validator.String{
-							stringvalidator.OneOf(
-								"created",
-								"initializing",
-								"pending-association",
-								"ready",
-								"error",
-								"terminating",
-								"terminated",
-							),
-						},
+							`- ` + "`" + `terminated` + "`" + ` - The attachment has been fully deleted and is no longer available.`,
 					},
 					"state_metadata": schema.SingleNestedAttribute{
 						Computed: true,
@@ -162,16 +140,7 @@ func (r *CloudGatewayPrivateDNSResource) Schema(ctx context.Context, req resourc
 							speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 						},
 						Description: `An RFC-3339 timestamp representation of Private DNS update date.`,
-						Validators: []validator.String{
-							validators.IsRFC3339(),
-						},
 					},
-				},
-				Validators: []validator.Object{
-					objectvalidator.ConflictsWith(path.Expressions{
-						path.MatchRelative().AtParent().AtName("aws_private_hosted_zone_response"),
-						path.MatchRelative().AtParent().AtName("gcp_private_hosted_zone_response"),
-					}...),
 				},
 			},
 			"aws_private_hosted_zone_response": schema.SingleNestedAttribute{
@@ -183,9 +152,6 @@ func (r *CloudGatewayPrivateDNSResource) Schema(ctx context.Context, req resourc
 							speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 						},
 						Description: `An RFC-3339 timestamp representation of Private DNS creation date.`,
-						Validators: []validator.String{
-							validators.IsRFC3339(),
-						},
 					},
 					"entity_version": schema.Int64Attribute{
 						Computed: true,
@@ -213,13 +179,7 @@ func (r *CloudGatewayPrivateDNSResource) Schema(ctx context.Context, req resourc
 								Description: `AWS Hosted Zone to create attachment to.`,
 							},
 							"kind": schema.StringAttribute{
-								Computed:    true,
-								Description: `must be "aws-private-hosted-zone-attachment"`,
-								Validators: []validator.String{
-									stringvalidator.OneOf(
-										"aws-private-hosted-zone-attachment",
-									),
-								},
+								Computed: true,
 							},
 						},
 					},
@@ -232,19 +192,7 @@ func (r *CloudGatewayPrivateDNSResource) Schema(ctx context.Context, req resourc
 							`- ` + "`" + `ready` + "`" + ` - The attachment is fully operational and can route traffic as configured.` + "\n" +
 							`- ` + "`" + `error` + "`" + ` - The attachment is in an error state, and is not operational.` + "\n" +
 							`- ` + "`" + `terminating` + "`" + ` - The attachment is in the process of being deleted.` + "\n" +
-							`- ` + "`" + `terminated` + "`" + ` - The attachment has been fully deleted and is no longer available.` + "\n" +
-							`must be one of ["created", "initializing", "pending-association", "ready", "error", "terminating", "terminated"]`,
-						Validators: []validator.String{
-							stringvalidator.OneOf(
-								"created",
-								"initializing",
-								"pending-association",
-								"ready",
-								"error",
-								"terminating",
-								"terminated",
-							),
-						},
+							`- ` + "`" + `terminated` + "`" + ` - The attachment has been fully deleted and is no longer available.`,
 					},
 					"state_metadata": schema.SingleNestedAttribute{
 						Computed: true,
@@ -266,16 +214,7 @@ func (r *CloudGatewayPrivateDNSResource) Schema(ctx context.Context, req resourc
 							speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 						},
 						Description: `An RFC-3339 timestamp representation of Private DNS update date.`,
-						Validators: []validator.String{
-							validators.IsRFC3339(),
-						},
 					},
-				},
-				Validators: []validator.Object{
-					objectvalidator.ConflictsWith(path.Expressions{
-						path.MatchRelative().AtParent().AtName("aws_private_dns_resolver_response"),
-						path.MatchRelative().AtParent().AtName("gcp_private_hosted_zone_response"),
-					}...),
 				},
 			},
 			"entity_version": schema.Int64Attribute{
@@ -295,9 +234,6 @@ func (r *CloudGatewayPrivateDNSResource) Schema(ctx context.Context, req resourc
 							speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 						},
 						Description: `An RFC-3339 timestamp representation of Private DNS creation date.`,
-						Validators: []validator.String{
-							validators.IsRFC3339(),
-						},
 					},
 					"entity_version": schema.Int64Attribute{
 						Computed: true,
@@ -325,13 +261,7 @@ func (r *CloudGatewayPrivateDNSResource) Schema(ctx context.Context, req resourc
 								Description: `Domain name to create attachment to.`,
 							},
 							"kind": schema.StringAttribute{
-								Computed:    true,
-								Description: `must be "gcp-private-hosted-zone-attachment"`,
-								Validators: []validator.String{
-									stringvalidator.OneOf(
-										"gcp-private-hosted-zone-attachment",
-									),
-								},
+								Computed: true,
 							},
 							"peer_project_id": schema.StringAttribute{
 								Computed:    true,
@@ -352,19 +282,7 @@ func (r *CloudGatewayPrivateDNSResource) Schema(ctx context.Context, req resourc
 							`- ` + "`" + `ready` + "`" + ` - The attachment is fully operational and can route traffic as configured.` + "\n" +
 							`- ` + "`" + `error` + "`" + ` - The attachment is in an error state, and is not operational.` + "\n" +
 							`- ` + "`" + `terminating` + "`" + ` - The attachment is in the process of being deleted.` + "\n" +
-							`- ` + "`" + `terminated` + "`" + ` - The attachment has been fully deleted and is no longer available.` + "\n" +
-							`must be one of ["created", "initializing", "pending-association", "ready", "error", "terminating", "terminated"]`,
-						Validators: []validator.String{
-							stringvalidator.OneOf(
-								"created",
-								"initializing",
-								"pending-association",
-								"ready",
-								"error",
-								"terminating",
-								"terminated",
-							),
-						},
+							`- ` + "`" + `terminated` + "`" + ` - The attachment has been fully deleted and is no longer available.`,
 					},
 					"state_metadata": schema.SingleNestedAttribute{
 						Computed: true,
@@ -386,16 +304,7 @@ func (r *CloudGatewayPrivateDNSResource) Schema(ctx context.Context, req resourc
 							speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 						},
 						Description: `An RFC-3339 timestamp representation of Private DNS update date.`,
-						Validators: []validator.String{
-							validators.IsRFC3339(),
-						},
 					},
-				},
-				Validators: []validator.Object{
-					objectvalidator.ConflictsWith(path.Expressions{
-						path.MatchRelative().AtParent().AtName("aws_private_dns_resolver_response"),
-						path.MatchRelative().AtParent().AtName("aws_private_hosted_zone_response"),
-					}...),
 				},
 			},
 			"id": schema.StringAttribute{
@@ -620,6 +529,13 @@ func (r *CloudGatewayPrivateDNSResource) Create(ctx context.Context, req resourc
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
+	if res.StatusCode == 409 {
+		resp.Diagnostics.AddError(
+			"Resource Already Exists",
+			"When creating this resource, the API indicated that this resource already exists. You can bring the existing resource under management using Terraform import functionality or retry with a unique configuration.",
+		)
+		return
+	}
 	if res.StatusCode != 201 {
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
@@ -795,7 +711,10 @@ func (r *CloudGatewayPrivateDNSResource) Delete(ctx context.Context, req resourc
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/cloudgatewayprivatedns_resource_sdk.go
+++ b/internal/provider/cloudgatewayprivatedns_resource_sdk.go
@@ -168,10 +168,10 @@ func (r *CloudGatewayPrivateDNSResourceModel) ToSharedCreatePrivateDNSRequest(ct
 		if r.PrivateDNSAttachmentConfig.AwsPrivateDNSResolverAttachmentConfig != nil {
 			kind1 := shared.AWSPrivateDNSResolverType(r.PrivateDNSAttachmentConfig.AwsPrivateDNSResolverAttachmentConfig.Kind.ValueString())
 			dnsConfig := make(map[string]shared.PrivateDNSResolverConfig)
-			for dnsConfigKey, dnsConfigValue := range r.PrivateDNSAttachmentConfig.AwsPrivateDNSResolverAttachmentConfig.DNSConfig {
-				remoteDNSServerIPAddresses := make([]string, 0, len(dnsConfigValue.RemoteDNSServerIPAddresses))
-				for _, remoteDNSServerIPAddressesItem := range dnsConfigValue.RemoteDNSServerIPAddresses {
-					remoteDNSServerIPAddresses = append(remoteDNSServerIPAddresses, remoteDNSServerIPAddressesItem.ValueString())
+			for dnsConfigKey := range r.PrivateDNSAttachmentConfig.AwsPrivateDNSResolverAttachmentConfig.DNSConfig {
+				remoteDNSServerIPAddresses := make([]string, 0, len(r.PrivateDNSAttachmentConfig.AwsPrivateDNSResolverAttachmentConfig.DNSConfig[dnsConfigKey].RemoteDNSServerIPAddresses))
+				for remoteDNSServerIPAddressesIndex := range r.PrivateDNSAttachmentConfig.AwsPrivateDNSResolverAttachmentConfig.DNSConfig[dnsConfigKey].RemoteDNSServerIPAddresses {
+					remoteDNSServerIPAddresses = append(remoteDNSServerIPAddresses, r.PrivateDNSAttachmentConfig.AwsPrivateDNSResolverAttachmentConfig.DNSConfig[dnsConfigKey].RemoteDNSServerIPAddresses[remoteDNSServerIPAddressesIndex].ValueString())
 				}
 				dnsConfigInst := shared.PrivateDNSResolverConfig{
 					RemoteDNSServerIPAddresses: remoteDNSServerIPAddresses,

--- a/internal/provider/cloudgatewaytransitgateway_resource.go
+++ b/internal/provider/cloudgatewaytransitgateway_resource.go
@@ -24,7 +24,6 @@ import (
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect/v3/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect/v3/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect/v3/internal/sdk"
-	"github.com/kong/terraform-provider-konnect/v3/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -195,9 +194,6 @@ func (r *CloudGatewayTransitGatewayResource) Schema(ctx context.Context, req res
 							speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 						},
 						Description: `An RFC-3339 timestamp representation of transit gateway creation date.`,
-						Validators: []validator.String{
-							validators.IsRFC3339(),
-						},
 					},
 					"dns_config": schema.ListNestedAttribute{
 						Computed: true,
@@ -249,19 +245,7 @@ func (r *CloudGatewayTransitGatewayResource) Schema(ctx context.Context, req res
 							`- ` + "`" + `pending-user-action` + "`" + ` The attachment request is awaiting user action in customer VPC.` + "\n" +
 							`- ` + "`" + `ready` + "`" + ` - The transit gateway attachment is fully operational and can route traffic as configured.` + "\n" +
 							`- ` + "`" + `terminating` + "`" + ` - The attachment is in the process of being deleted and is no longer accepting new traffic.` + "\n" +
-							`- ` + "`" + `terminated` + "`" + ` - The attachment has been fully deleted and is no longer available.` + "\n" +
-							`must be one of ["created", "initializing", "pending-acceptance", "pending-user-action", "ready", "terminating", "terminated"]`,
-						Validators: []validator.String{
-							stringvalidator.OneOf(
-								"created",
-								"initializing",
-								"pending-acceptance",
-								"pending-user-action",
-								"ready",
-								"terminating",
-								"terminated",
-							),
-						},
+							`- ` + "`" + `terminated` + "`" + ` - The attachment has been fully deleted and is no longer available.`,
 					},
 					"state_metadata": schema.SingleNestedAttribute{
 						Computed: true,
@@ -284,13 +268,7 @@ func (r *CloudGatewayTransitGatewayResource) Schema(ctx context.Context, req res
 						Computed: true,
 						Attributes: map[string]schema.Attribute{
 							"kind": schema.StringAttribute{
-								Computed:    true,
-								Description: `must be "aws-resource-endpoint-attachment"`,
-								Validators: []validator.String{
-									stringvalidator.OneOf(
-										"aws-resource-endpoint-attachment",
-									),
-								},
+								Computed: true,
 							},
 							"ram_share_arn": schema.StringAttribute{
 								Computed:    true,
@@ -318,17 +296,7 @@ func (r *CloudGatewayTransitGatewayResource) Schema(ctx context.Context, req res
 												`- ` + "`" + `missing` + "`" + ` - The config is missing and is no longer accepting new traffic.` + "\n" +
 												`- ` + "`" + `ready` + "`" + ` - The config is fully operational and can route traffic as configured.` + "\n" +
 												`- ` + "`" + `error` + "`" + ` - The config is in an error state, and is not operational.` + "\n" +
-												`- ` + "`" + `terminating` + "`" + ` - The config is in the process of being deleted and is no longer accepting new traffic.` + "\n" +
-												`must be one of ["initializing", "missing", "ready", "error", "terminating"]`,
-											Validators: []validator.String{
-												stringvalidator.OneOf(
-													"initializing",
-													"missing",
-													"ready",
-													"error",
-													"terminating",
-												),
-											},
+												`- ` + "`" + `terminating` + "`" + ` - The config is in the process of being deleted and is no longer accepting new traffic.`,
 										},
 									},
 								},
@@ -342,23 +310,7 @@ func (r *CloudGatewayTransitGatewayResource) Schema(ctx context.Context, req res
 							speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 						},
 						Description: `An RFC-3339 timestamp representation of transit gateway update date.`,
-						Validators: []validator.String{
-							validators.IsRFC3339(),
-						},
 					},
-				},
-				Validators: []validator.Object{
-					objectvalidator.ConflictsWith(path.Expressions{
-						path.MatchRelative().AtParent().AtName("aws_resource_endpoint_gateway"),
-						path.MatchRelative().AtParent().AtName("aws_transit_gateway"),
-						path.MatchRelative().AtParent().AtName("aws_transit_gateway_response"),
-						path.MatchRelative().AtParent().AtName("aws_vpc_peering_gateway"),
-						path.MatchRelative().AtParent().AtName("aws_vpc_peering_gateway_response"),
-						path.MatchRelative().AtParent().AtName("azure_transit_gateway"),
-						path.MatchRelative().AtParent().AtName("azure_transit_gateway_response"),
-						path.MatchRelative().AtParent().AtName("gcpvpc_peering_gateway_response"),
-						path.MatchRelative().AtParent().AtName("gcp_vpc_peering_transit_gateway"),
-					}...),
 				},
 			},
 			"aws_transit_gateway": schema.SingleNestedAttribute{
@@ -484,9 +436,6 @@ func (r *CloudGatewayTransitGatewayResource) Schema(ctx context.Context, req res
 							speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 						},
 						Description: `An RFC-3339 timestamp representation of transit gateway creation date.`,
-						Validators: []validator.String{
-							validators.IsRFC3339(),
-						},
 					},
 					"dns_config": schema.ListNestedAttribute{
 						Computed: true,
@@ -538,19 +487,7 @@ func (r *CloudGatewayTransitGatewayResource) Schema(ctx context.Context, req res
 							`- ` + "`" + `pending-user-action` + "`" + ` The attachment request is awaiting user action in customer VPC.` + "\n" +
 							`- ` + "`" + `ready` + "`" + ` - The transit gateway attachment is fully operational and can route traffic as configured.` + "\n" +
 							`- ` + "`" + `terminating` + "`" + ` - The attachment is in the process of being deleted and is no longer accepting new traffic.` + "\n" +
-							`- ` + "`" + `terminated` + "`" + ` - The attachment has been fully deleted and is no longer available.` + "\n" +
-							`must be one of ["created", "initializing", "pending-acceptance", "pending-user-action", "ready", "terminating", "terminated"]`,
-						Validators: []validator.String{
-							stringvalidator.OneOf(
-								"created",
-								"initializing",
-								"pending-acceptance",
-								"pending-user-action",
-								"ready",
-								"terminating",
-								"terminated",
-							),
-						},
+							`- ` + "`" + `terminated` + "`" + ` - The attachment has been fully deleted and is no longer available.`,
 					},
 					"state_metadata": schema.SingleNestedAttribute{
 						Computed: true,
@@ -573,13 +510,7 @@ func (r *CloudGatewayTransitGatewayResource) Schema(ctx context.Context, req res
 						Computed: true,
 						Attributes: map[string]schema.Attribute{
 							"kind": schema.StringAttribute{
-								Computed:    true,
-								Description: `must be "aws-transit-gateway-attachment"`,
-								Validators: []validator.String{
-									stringvalidator.OneOf(
-										"aws-transit-gateway-attachment",
-									),
-								},
+								Computed: true,
 							},
 							"ram_share_arn": schema.StringAttribute{
 								Computed:    true,
@@ -597,23 +528,7 @@ func (r *CloudGatewayTransitGatewayResource) Schema(ctx context.Context, req res
 							speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 						},
 						Description: `An RFC-3339 timestamp representation of transit gateway update date.`,
-						Validators: []validator.String{
-							validators.IsRFC3339(),
-						},
 					},
-				},
-				Validators: []validator.Object{
-					objectvalidator.ConflictsWith(path.Expressions{
-						path.MatchRelative().AtParent().AtName("aws_resource_endpoint_gateway"),
-						path.MatchRelative().AtParent().AtName("aws_resource_endpoint_gateway_response"),
-						path.MatchRelative().AtParent().AtName("aws_transit_gateway"),
-						path.MatchRelative().AtParent().AtName("aws_vpc_peering_gateway"),
-						path.MatchRelative().AtParent().AtName("aws_vpc_peering_gateway_response"),
-						path.MatchRelative().AtParent().AtName("azure_transit_gateway"),
-						path.MatchRelative().AtParent().AtName("azure_transit_gateway_response"),
-						path.MatchRelative().AtParent().AtName("gcpvpc_peering_gateway_response"),
-						path.MatchRelative().AtParent().AtName("gcp_vpc_peering_transit_gateway"),
-					}...),
 				},
 			},
 			"aws_vpc_peering_gateway": schema.SingleNestedAttribute{
@@ -746,9 +661,6 @@ func (r *CloudGatewayTransitGatewayResource) Schema(ctx context.Context, req res
 							speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 						},
 						Description: `An RFC-3339 timestamp representation of transit gateway creation date.`,
-						Validators: []validator.String{
-							validators.IsRFC3339(),
-						},
 					},
 					"dns_config": schema.ListNestedAttribute{
 						Computed: true,
@@ -800,19 +712,7 @@ func (r *CloudGatewayTransitGatewayResource) Schema(ctx context.Context, req res
 							`- ` + "`" + `pending-user-action` + "`" + ` The attachment request is awaiting user action in customer VPC.` + "\n" +
 							`- ` + "`" + `ready` + "`" + ` - The transit gateway attachment is fully operational and can route traffic as configured.` + "\n" +
 							`- ` + "`" + `terminating` + "`" + ` - The attachment is in the process of being deleted and is no longer accepting new traffic.` + "\n" +
-							`- ` + "`" + `terminated` + "`" + ` - The attachment has been fully deleted and is no longer available.` + "\n" +
-							`must be one of ["created", "initializing", "pending-acceptance", "pending-user-action", "ready", "terminating", "terminated"]`,
-						Validators: []validator.String{
-							stringvalidator.OneOf(
-								"created",
-								"initializing",
-								"pending-acceptance",
-								"pending-user-action",
-								"ready",
-								"terminating",
-								"terminated",
-							),
-						},
+							`- ` + "`" + `terminated` + "`" + ` - The attachment has been fully deleted and is no longer available.`,
 					},
 					"state_metadata": schema.SingleNestedAttribute{
 						Computed: true,
@@ -835,13 +735,7 @@ func (r *CloudGatewayTransitGatewayResource) Schema(ctx context.Context, req res
 						Computed: true,
 						Attributes: map[string]schema.Attribute{
 							"kind": schema.StringAttribute{
-								Computed:    true,
-								Description: `must be "aws-vpc-peering-attachment"`,
-								Validators: []validator.String{
-									stringvalidator.OneOf(
-										"aws-vpc-peering-attachment",
-									),
-								},
+								Computed: true,
 							},
 							"peer_account_id": schema.StringAttribute{
 								Computed: true,
@@ -860,23 +754,7 @@ func (r *CloudGatewayTransitGatewayResource) Schema(ctx context.Context, req res
 							speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 						},
 						Description: `An RFC-3339 timestamp representation of transit gateway update date.`,
-						Validators: []validator.String{
-							validators.IsRFC3339(),
-						},
 					},
-				},
-				Validators: []validator.Object{
-					objectvalidator.ConflictsWith(path.Expressions{
-						path.MatchRelative().AtParent().AtName("aws_resource_endpoint_gateway"),
-						path.MatchRelative().AtParent().AtName("aws_resource_endpoint_gateway_response"),
-						path.MatchRelative().AtParent().AtName("aws_transit_gateway"),
-						path.MatchRelative().AtParent().AtName("aws_transit_gateway_response"),
-						path.MatchRelative().AtParent().AtName("aws_vpc_peering_gateway"),
-						path.MatchRelative().AtParent().AtName("azure_transit_gateway"),
-						path.MatchRelative().AtParent().AtName("azure_transit_gateway_response"),
-						path.MatchRelative().AtParent().AtName("gcpvpc_peering_gateway_response"),
-						path.MatchRelative().AtParent().AtName("gcp_vpc_peering_transit_gateway"),
-					}...),
 				},
 			},
 			"azure_transit_gateway": schema.SingleNestedAttribute{
@@ -1000,9 +878,6 @@ func (r *CloudGatewayTransitGatewayResource) Schema(ctx context.Context, req res
 							speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 						},
 						Description: `An RFC-3339 timestamp representation of transit gateway creation date.`,
-						Validators: []validator.String{
-							validators.IsRFC3339(),
-						},
 					},
 					"dns_config": schema.ListNestedAttribute{
 						Computed: true,
@@ -1054,19 +929,7 @@ func (r *CloudGatewayTransitGatewayResource) Schema(ctx context.Context, req res
 							`- ` + "`" + `pending-user-action` + "`" + ` The attachment request is awaiting user action in customer VPC.` + "\n" +
 							`- ` + "`" + `ready` + "`" + ` - The transit gateway attachment is fully operational and can route traffic as configured.` + "\n" +
 							`- ` + "`" + `terminating` + "`" + ` - The attachment is in the process of being deleted and is no longer accepting new traffic.` + "\n" +
-							`- ` + "`" + `terminated` + "`" + ` - The attachment has been fully deleted and is no longer available.` + "\n" +
-							`must be one of ["created", "initializing", "pending-acceptance", "pending-user-action", "ready", "terminating", "terminated"]`,
-						Validators: []validator.String{
-							stringvalidator.OneOf(
-								"created",
-								"initializing",
-								"pending-acceptance",
-								"pending-user-action",
-								"ready",
-								"terminating",
-								"terminated",
-							),
-						},
+							`- ` + "`" + `terminated` + "`" + ` - The attachment has been fully deleted and is no longer available.`,
 					},
 					"state_metadata": schema.SingleNestedAttribute{
 						Computed: true,
@@ -1089,13 +952,7 @@ func (r *CloudGatewayTransitGatewayResource) Schema(ctx context.Context, req res
 						Computed: true,
 						Attributes: map[string]schema.Attribute{
 							"kind": schema.StringAttribute{
-								Computed:    true,
-								Description: `must be "azure-vnet-peering-attachment"`,
-								Validators: []validator.String{
-									stringvalidator.OneOf(
-										"azure-vnet-peering-attachment",
-									),
-								},
+								Computed: true,
 							},
 							"resource_group_name": schema.StringAttribute{
 								Computed:    true,
@@ -1121,23 +978,7 @@ func (r *CloudGatewayTransitGatewayResource) Schema(ctx context.Context, req res
 							speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 						},
 						Description: `An RFC-3339 timestamp representation of transit gateway update date.`,
-						Validators: []validator.String{
-							validators.IsRFC3339(),
-						},
 					},
-				},
-				Validators: []validator.Object{
-					objectvalidator.ConflictsWith(path.Expressions{
-						path.MatchRelative().AtParent().AtName("aws_resource_endpoint_gateway"),
-						path.MatchRelative().AtParent().AtName("aws_resource_endpoint_gateway_response"),
-						path.MatchRelative().AtParent().AtName("aws_transit_gateway"),
-						path.MatchRelative().AtParent().AtName("aws_transit_gateway_response"),
-						path.MatchRelative().AtParent().AtName("aws_vpc_peering_gateway"),
-						path.MatchRelative().AtParent().AtName("aws_vpc_peering_gateway_response"),
-						path.MatchRelative().AtParent().AtName("azure_transit_gateway"),
-						path.MatchRelative().AtParent().AtName("gcpvpc_peering_gateway_response"),
-						path.MatchRelative().AtParent().AtName("gcp_vpc_peering_transit_gateway"),
-					}...),
 				},
 			},
 			"entity_version": schema.Int64Attribute{
@@ -1255,9 +1096,6 @@ func (r *CloudGatewayTransitGatewayResource) Schema(ctx context.Context, req res
 							speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 						},
 						Description: `An RFC-3339 timestamp representation of transit gateway creation date.`,
-						Validators: []validator.String{
-							validators.IsRFC3339(),
-						},
 					},
 					"dns_config": schema.ListNestedAttribute{
 						Computed: true,
@@ -1309,19 +1147,7 @@ func (r *CloudGatewayTransitGatewayResource) Schema(ctx context.Context, req res
 							`- ` + "`" + `pending-user-action` + "`" + ` The attachment request is awaiting user action in customer VPC.` + "\n" +
 							`- ` + "`" + `ready` + "`" + ` - The transit gateway attachment is fully operational and can route traffic as configured.` + "\n" +
 							`- ` + "`" + `terminating` + "`" + ` - The attachment is in the process of being deleted and is no longer accepting new traffic.` + "\n" +
-							`- ` + "`" + `terminated` + "`" + ` - The attachment has been fully deleted and is no longer available.` + "\n" +
-							`must be one of ["created", "initializing", "pending-acceptance", "pending-user-action", "ready", "terminating", "terminated"]`,
-						Validators: []validator.String{
-							stringvalidator.OneOf(
-								"created",
-								"initializing",
-								"pending-acceptance",
-								"pending-user-action",
-								"ready",
-								"terminating",
-								"terminated",
-							),
-						},
+							`- ` + "`" + `terminated` + "`" + ` - The attachment has been fully deleted and is no longer available.`,
 					},
 					"state_metadata": schema.SingleNestedAttribute{
 						Computed: true,
@@ -1344,13 +1170,7 @@ func (r *CloudGatewayTransitGatewayResource) Schema(ctx context.Context, req res
 						Computed: true,
 						Attributes: map[string]schema.Attribute{
 							"kind": schema.StringAttribute{
-								Computed:    true,
-								Description: `must be "gcp-vpc-peering-attachment"`,
-								Validators: []validator.String{
-									stringvalidator.OneOf(
-										"gcp-vpc-peering-attachment",
-									),
-								},
+								Computed: true,
 							},
 							"peer_project_id": schema.StringAttribute{
 								Computed:    true,
@@ -1368,23 +1188,7 @@ func (r *CloudGatewayTransitGatewayResource) Schema(ctx context.Context, req res
 							speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 						},
 						Description: `An RFC-3339 timestamp representation of transit gateway update date.`,
-						Validators: []validator.String{
-							validators.IsRFC3339(),
-						},
 					},
-				},
-				Validators: []validator.Object{
-					objectvalidator.ConflictsWith(path.Expressions{
-						path.MatchRelative().AtParent().AtName("aws_resource_endpoint_gateway"),
-						path.MatchRelative().AtParent().AtName("aws_resource_endpoint_gateway_response"),
-						path.MatchRelative().AtParent().AtName("aws_transit_gateway"),
-						path.MatchRelative().AtParent().AtName("aws_transit_gateway_response"),
-						path.MatchRelative().AtParent().AtName("aws_vpc_peering_gateway"),
-						path.MatchRelative().AtParent().AtName("aws_vpc_peering_gateway_response"),
-						path.MatchRelative().AtParent().AtName("azure_transit_gateway"),
-						path.MatchRelative().AtParent().AtName("azure_transit_gateway_response"),
-						path.MatchRelative().AtParent().AtName("gcp_vpc_peering_transit_gateway"),
-					}...),
 				},
 			},
 			"id": schema.StringAttribute{
@@ -1462,6 +1266,13 @@ func (r *CloudGatewayTransitGatewayResource) Create(ctx context.Context, req res
 	}
 	if res == nil {
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
+		return
+	}
+	if res.StatusCode == 409 {
+		resp.Diagnostics.AddError(
+			"Resource Already Exists",
+			"When creating this resource, the API indicated that this resource already exists. You can bring the existing resource under management using Terraform import functionality or retry with a unique configuration.",
+		)
 		return
 	}
 	if res.StatusCode != 201 {
@@ -1602,7 +1413,10 @@ func (r *CloudGatewayTransitGatewayResource) Delete(ctx context.Context, req res
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/cloudgatewaytransitgateway_resource_sdk.go
+++ b/internal/provider/cloudgatewaytransitgateway_resource_sdk.go
@@ -297,14 +297,14 @@ func (r *CloudGatewayTransitGatewayResourceModel) ToSharedCreateTransitGatewayRe
 		name = r.AWSTransitGateway.Name.ValueString()
 
 		dnsConfig := make([]shared.TransitGatewayDNSConfig, 0, len(r.AWSTransitGateway.DNSConfig))
-		for _, dnsConfigItem := range r.AWSTransitGateway.DNSConfig {
-			remoteDNSServerIPAddresses := make([]string, 0, len(dnsConfigItem.RemoteDNSServerIPAddresses))
-			for _, remoteDNSServerIPAddressesItem := range dnsConfigItem.RemoteDNSServerIPAddresses {
-				remoteDNSServerIPAddresses = append(remoteDNSServerIPAddresses, remoteDNSServerIPAddressesItem.ValueString())
+		for dnsConfigIndex := range r.AWSTransitGateway.DNSConfig {
+			remoteDNSServerIPAddresses := make([]string, 0, len(r.AWSTransitGateway.DNSConfig[dnsConfigIndex].RemoteDNSServerIPAddresses))
+			for remoteDNSServerIPAddressesIndex := range r.AWSTransitGateway.DNSConfig[dnsConfigIndex].RemoteDNSServerIPAddresses {
+				remoteDNSServerIPAddresses = append(remoteDNSServerIPAddresses, r.AWSTransitGateway.DNSConfig[dnsConfigIndex].RemoteDNSServerIPAddresses[remoteDNSServerIPAddressesIndex].ValueString())
 			}
-			domainProxyList := make([]string, 0, len(dnsConfigItem.DomainProxyList))
-			for _, domainProxyListItem := range dnsConfigItem.DomainProxyList {
-				domainProxyList = append(domainProxyList, domainProxyListItem.ValueString())
+			domainProxyList := make([]string, 0, len(r.AWSTransitGateway.DNSConfig[dnsConfigIndex].DomainProxyList))
+			for domainProxyListIndex := range r.AWSTransitGateway.DNSConfig[dnsConfigIndex].DomainProxyList {
+				domainProxyList = append(domainProxyList, r.AWSTransitGateway.DNSConfig[dnsConfigIndex].DomainProxyList[domainProxyListIndex].ValueString())
 			}
 			dnsConfig = append(dnsConfig, shared.TransitGatewayDNSConfig{
 				RemoteDNSServerIPAddresses: remoteDNSServerIPAddresses,
@@ -312,8 +312,8 @@ func (r *CloudGatewayTransitGatewayResourceModel) ToSharedCreateTransitGatewayRe
 			})
 		}
 		cidrBlocks := make([]string, 0, len(r.AWSTransitGateway.CidrBlocks))
-		for _, cidrBlocksItem := range r.AWSTransitGateway.CidrBlocks {
-			cidrBlocks = append(cidrBlocks, cidrBlocksItem.ValueString())
+		for cidrBlocksIndex := range r.AWSTransitGateway.CidrBlocks {
+			cidrBlocks = append(cidrBlocks, r.AWSTransitGateway.CidrBlocks[cidrBlocksIndex].ValueString())
 		}
 		kind := shared.AWSTransitGatewayAttachmentType(r.AWSTransitGateway.TransitGatewayAttachmentConfig.Kind.ValueString())
 		var transitGatewayID string
@@ -345,14 +345,14 @@ func (r *CloudGatewayTransitGatewayResourceModel) ToSharedCreateTransitGatewayRe
 		name1 = r.AWSVpcPeeringGateway.Name.ValueString()
 
 		dnsConfig1 := make([]shared.TransitGatewayDNSConfig, 0, len(r.AWSVpcPeeringGateway.DNSConfig))
-		for _, dnsConfigItem1 := range r.AWSVpcPeeringGateway.DNSConfig {
-			remoteDNSServerIPAddresses1 := make([]string, 0, len(dnsConfigItem1.RemoteDNSServerIPAddresses))
-			for _, remoteDNSServerIPAddressesItem1 := range dnsConfigItem1.RemoteDNSServerIPAddresses {
-				remoteDNSServerIPAddresses1 = append(remoteDNSServerIPAddresses1, remoteDNSServerIPAddressesItem1.ValueString())
+		for dnsConfigIndex1 := range r.AWSVpcPeeringGateway.DNSConfig {
+			remoteDNSServerIPAddresses1 := make([]string, 0, len(r.AWSVpcPeeringGateway.DNSConfig[dnsConfigIndex1].RemoteDNSServerIPAddresses))
+			for remoteDNSServerIPAddressesIndex1 := range r.AWSVpcPeeringGateway.DNSConfig[dnsConfigIndex1].RemoteDNSServerIPAddresses {
+				remoteDNSServerIPAddresses1 = append(remoteDNSServerIPAddresses1, r.AWSVpcPeeringGateway.DNSConfig[dnsConfigIndex1].RemoteDNSServerIPAddresses[remoteDNSServerIPAddressesIndex1].ValueString())
 			}
-			domainProxyList1 := make([]string, 0, len(dnsConfigItem1.DomainProxyList))
-			for _, domainProxyListItem1 := range dnsConfigItem1.DomainProxyList {
-				domainProxyList1 = append(domainProxyList1, domainProxyListItem1.ValueString())
+			domainProxyList1 := make([]string, 0, len(r.AWSVpcPeeringGateway.DNSConfig[dnsConfigIndex1].DomainProxyList))
+			for domainProxyListIndex1 := range r.AWSVpcPeeringGateway.DNSConfig[dnsConfigIndex1].DomainProxyList {
+				domainProxyList1 = append(domainProxyList1, r.AWSVpcPeeringGateway.DNSConfig[dnsConfigIndex1].DomainProxyList[domainProxyListIndex1].ValueString())
 			}
 			dnsConfig1 = append(dnsConfig1, shared.TransitGatewayDNSConfig{
 				RemoteDNSServerIPAddresses: remoteDNSServerIPAddresses1,
@@ -360,8 +360,8 @@ func (r *CloudGatewayTransitGatewayResourceModel) ToSharedCreateTransitGatewayRe
 			})
 		}
 		cidrBlocks1 := make([]string, 0, len(r.AWSVpcPeeringGateway.CidrBlocks))
-		for _, cidrBlocksItem1 := range r.AWSVpcPeeringGateway.CidrBlocks {
-			cidrBlocks1 = append(cidrBlocks1, cidrBlocksItem1.ValueString())
+		for cidrBlocksIndex1 := range r.AWSVpcPeeringGateway.CidrBlocks {
+			cidrBlocks1 = append(cidrBlocks1, r.AWSVpcPeeringGateway.CidrBlocks[cidrBlocksIndex1].ValueString())
 		}
 		kind1 := shared.AWSVPCPeeringAttachmentConfig(r.AWSVpcPeeringGateway.TransitGatewayAttachmentConfig.Kind.ValueString())
 		var peerAccountID string
@@ -397,14 +397,14 @@ func (r *CloudGatewayTransitGatewayResourceModel) ToSharedCreateTransitGatewayRe
 		name2 = r.AWSResourceEndpointGateway.Name.ValueString()
 
 		dnsConfig2 := make([]shared.TransitGatewayDNSConfig, 0, len(r.AWSResourceEndpointGateway.DNSConfig))
-		for _, dnsConfigItem2 := range r.AWSResourceEndpointGateway.DNSConfig {
-			remoteDNSServerIPAddresses2 := make([]string, 0, len(dnsConfigItem2.RemoteDNSServerIPAddresses))
-			for _, remoteDNSServerIPAddressesItem2 := range dnsConfigItem2.RemoteDNSServerIPAddresses {
-				remoteDNSServerIPAddresses2 = append(remoteDNSServerIPAddresses2, remoteDNSServerIPAddressesItem2.ValueString())
+		for dnsConfigIndex2 := range r.AWSResourceEndpointGateway.DNSConfig {
+			remoteDNSServerIPAddresses2 := make([]string, 0, len(r.AWSResourceEndpointGateway.DNSConfig[dnsConfigIndex2].RemoteDNSServerIPAddresses))
+			for remoteDNSServerIPAddressesIndex2 := range r.AWSResourceEndpointGateway.DNSConfig[dnsConfigIndex2].RemoteDNSServerIPAddresses {
+				remoteDNSServerIPAddresses2 = append(remoteDNSServerIPAddresses2, r.AWSResourceEndpointGateway.DNSConfig[dnsConfigIndex2].RemoteDNSServerIPAddresses[remoteDNSServerIPAddressesIndex2].ValueString())
 			}
-			domainProxyList2 := make([]string, 0, len(dnsConfigItem2.DomainProxyList))
-			for _, domainProxyListItem2 := range dnsConfigItem2.DomainProxyList {
-				domainProxyList2 = append(domainProxyList2, domainProxyListItem2.ValueString())
+			domainProxyList2 := make([]string, 0, len(r.AWSResourceEndpointGateway.DNSConfig[dnsConfigIndex2].DomainProxyList))
+			for domainProxyListIndex2 := range r.AWSResourceEndpointGateway.DNSConfig[dnsConfigIndex2].DomainProxyList {
+				domainProxyList2 = append(domainProxyList2, r.AWSResourceEndpointGateway.DNSConfig[dnsConfigIndex2].DomainProxyList[domainProxyListIndex2].ValueString())
 			}
 			dnsConfig2 = append(dnsConfig2, shared.TransitGatewayDNSConfig{
 				RemoteDNSServerIPAddresses: remoteDNSServerIPAddresses2,
@@ -416,12 +416,12 @@ func (r *CloudGatewayTransitGatewayResourceModel) ToSharedCreateTransitGatewayRe
 		ramShareArn1 = r.AWSResourceEndpointGateway.TransitGatewayAttachmentConfig.RAMShareArn.ValueString()
 
 		resourceConfig := make([]shared.AwsResourceEndpointConfig, 0, len(r.AWSResourceEndpointGateway.TransitGatewayAttachmentConfig.ResourceConfig))
-		for _, resourceConfigItem := range r.AWSResourceEndpointGateway.TransitGatewayAttachmentConfig.ResourceConfig {
+		for resourceConfigIndex := range r.AWSResourceEndpointGateway.TransitGatewayAttachmentConfig.ResourceConfig {
 			var resourceConfigID string
-			resourceConfigID = resourceConfigItem.ResourceConfigID.ValueString()
+			resourceConfigID = r.AWSResourceEndpointGateway.TransitGatewayAttachmentConfig.ResourceConfig[resourceConfigIndex].ResourceConfigID.ValueString()
 
 			var domainName string
-			domainName = resourceConfigItem.DomainName.ValueString()
+			domainName = r.AWSResourceEndpointGateway.TransitGatewayAttachmentConfig.ResourceConfig[resourceConfigIndex].DomainName.ValueString()
 
 			resourceConfig = append(resourceConfig, shared.AwsResourceEndpointConfig{
 				ResourceConfigID: resourceConfigID,
@@ -450,14 +450,14 @@ func (r *CloudGatewayTransitGatewayResourceModel) ToSharedCreateTransitGatewayRe
 		name3 = r.AzureTransitGateway.Name.ValueString()
 
 		dnsConfig3 := make([]shared.TransitGatewayDNSConfig, 0, len(r.AzureTransitGateway.DNSConfig))
-		for _, dnsConfigItem3 := range r.AzureTransitGateway.DNSConfig {
-			remoteDNSServerIPAddresses3 := make([]string, 0, len(dnsConfigItem3.RemoteDNSServerIPAddresses))
-			for _, remoteDNSServerIPAddressesItem3 := range dnsConfigItem3.RemoteDNSServerIPAddresses {
-				remoteDNSServerIPAddresses3 = append(remoteDNSServerIPAddresses3, remoteDNSServerIPAddressesItem3.ValueString())
+		for dnsConfigIndex3 := range r.AzureTransitGateway.DNSConfig {
+			remoteDNSServerIPAddresses3 := make([]string, 0, len(r.AzureTransitGateway.DNSConfig[dnsConfigIndex3].RemoteDNSServerIPAddresses))
+			for remoteDNSServerIPAddressesIndex3 := range r.AzureTransitGateway.DNSConfig[dnsConfigIndex3].RemoteDNSServerIPAddresses {
+				remoteDNSServerIPAddresses3 = append(remoteDNSServerIPAddresses3, r.AzureTransitGateway.DNSConfig[dnsConfigIndex3].RemoteDNSServerIPAddresses[remoteDNSServerIPAddressesIndex3].ValueString())
 			}
-			domainProxyList3 := make([]string, 0, len(dnsConfigItem3.DomainProxyList))
-			for _, domainProxyListItem3 := range dnsConfigItem3.DomainProxyList {
-				domainProxyList3 = append(domainProxyList3, domainProxyListItem3.ValueString())
+			domainProxyList3 := make([]string, 0, len(r.AzureTransitGateway.DNSConfig[dnsConfigIndex3].DomainProxyList))
+			for domainProxyListIndex3 := range r.AzureTransitGateway.DNSConfig[dnsConfigIndex3].DomainProxyList {
+				domainProxyList3 = append(domainProxyList3, r.AzureTransitGateway.DNSConfig[dnsConfigIndex3].DomainProxyList[domainProxyListIndex3].ValueString())
 			}
 			dnsConfig3 = append(dnsConfig3, shared.TransitGatewayDNSConfig{
 				RemoteDNSServerIPAddresses: remoteDNSServerIPAddresses3,
@@ -501,14 +501,14 @@ func (r *CloudGatewayTransitGatewayResourceModel) ToSharedCreateTransitGatewayRe
 		name4 = r.GcpVpcPeeringTransitGateway.Name.ValueString()
 
 		dnsConfig4 := make([]shared.TransitGatewayDNSConfig, 0, len(r.GcpVpcPeeringTransitGateway.DNSConfig))
-		for _, dnsConfigItem4 := range r.GcpVpcPeeringTransitGateway.DNSConfig {
-			remoteDNSServerIPAddresses4 := make([]string, 0, len(dnsConfigItem4.RemoteDNSServerIPAddresses))
-			for _, remoteDNSServerIPAddressesItem4 := range dnsConfigItem4.RemoteDNSServerIPAddresses {
-				remoteDNSServerIPAddresses4 = append(remoteDNSServerIPAddresses4, remoteDNSServerIPAddressesItem4.ValueString())
+		for dnsConfigIndex4 := range r.GcpVpcPeeringTransitGateway.DNSConfig {
+			remoteDNSServerIPAddresses4 := make([]string, 0, len(r.GcpVpcPeeringTransitGateway.DNSConfig[dnsConfigIndex4].RemoteDNSServerIPAddresses))
+			for remoteDNSServerIPAddressesIndex4 := range r.GcpVpcPeeringTransitGateway.DNSConfig[dnsConfigIndex4].RemoteDNSServerIPAddresses {
+				remoteDNSServerIPAddresses4 = append(remoteDNSServerIPAddresses4, r.GcpVpcPeeringTransitGateway.DNSConfig[dnsConfigIndex4].RemoteDNSServerIPAddresses[remoteDNSServerIPAddressesIndex4].ValueString())
 			}
-			domainProxyList4 := make([]string, 0, len(dnsConfigItem4.DomainProxyList))
-			for _, domainProxyListItem4 := range dnsConfigItem4.DomainProxyList {
-				domainProxyList4 = append(domainProxyList4, domainProxyListItem4.ValueString())
+			domainProxyList4 := make([]string, 0, len(r.GcpVpcPeeringTransitGateway.DNSConfig[dnsConfigIndex4].DomainProxyList))
+			for domainProxyListIndex4 := range r.GcpVpcPeeringTransitGateway.DNSConfig[dnsConfigIndex4].DomainProxyList {
+				domainProxyList4 = append(domainProxyList4, r.GcpVpcPeeringTransitGateway.DNSConfig[dnsConfigIndex4].DomainProxyList[domainProxyListIndex4].ValueString())
 			}
 			dnsConfig4 = append(dnsConfig4, shared.TransitGatewayDNSConfig{
 				RemoteDNSServerIPAddresses: remoteDNSServerIPAddresses4,

--- a/internal/provider/cmek_resource.go
+++ b/internal/provider/cmek_resource.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect/v3/internal/planmodifiers/stringplanmodifier"
 	"github.com/kong/terraform-provider-konnect/v3/internal/sdk"
-	"github.com/kong/terraform-provider-konnect/v3/internal/validators"
 	"slices"
 )
 
@@ -58,9 +57,6 @@ func (r *CmekResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity creation date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"description": schema.StringAttribute{
 				Computed:    true,
@@ -93,9 +89,6 @@ func (r *CmekResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity update date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 		},
 	}
@@ -331,7 +324,10 @@ func (r *CmekResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewayacl_resource.go
+++ b/internal/provider/gatewayacl_resource.go
@@ -299,7 +299,10 @@ func (r *GatewayACLResource) Delete(ctx context.Context, req resource.DeleteRequ
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewayacl_resource_sdk.go
+++ b/internal/provider/gatewayacl_resource_sdk.go
@@ -116,8 +116,8 @@ func (r *GatewayACLResourceModel) ToSharedACLWithoutParents(ctx context.Context)
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	out := shared.ACLWithoutParents{

--- a/internal/provider/gatewaybasicauth_resource.go
+++ b/internal/provider/gatewaybasicauth_resource.go
@@ -345,7 +345,10 @@ func (r *GatewayBasicAuthResource) Delete(ctx context.Context, req resource.Dele
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaybasicauth_resource_sdk.go
+++ b/internal/provider/gatewaybasicauth_resource_sdk.go
@@ -116,8 +116,8 @@ func (r *GatewayBasicAuthResourceModel) ToSharedBasicAuthWithoutParents(ctx cont
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	var username string

--- a/internal/provider/gatewaycacertificate_resource.go
+++ b/internal/provider/gatewaycacertificate_resource.go
@@ -319,7 +319,10 @@ func (r *GatewayCACertificateResource) Delete(ctx context.Context, req resource.
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaycacertificate_resource_sdk.go
+++ b/internal/provider/gatewaycacertificate_resource_sdk.go
@@ -131,8 +131,8 @@ func (r *GatewayCACertificateResourceModel) ToSharedCACertificateInput(ctx conte
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)

--- a/internal/provider/gatewaycertificate_resource.go
+++ b/internal/provider/gatewaycertificate_resource.go
@@ -334,7 +334,10 @@ func (r *GatewayCertificateResource) Delete(ctx context.Context, req resource.De
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaycertificate_resource_sdk.go
+++ b/internal/provider/gatewaycertificate_resource_sdk.go
@@ -154,8 +154,8 @@ func (r *GatewayCertificateResourceModel) ToSharedCertificateInput(ctx context.C
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)

--- a/internal/provider/gatewayconfigstore_resource.go
+++ b/internal/provider/gatewayconfigstore_resource.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect/v3/internal/planmodifiers/stringplanmodifier"
 	"github.com/kong/terraform-provider-konnect/v3/internal/sdk"
-	"github.com/kong/terraform-provider-konnect/v3/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -65,9 +64,6 @@ func (r *GatewayConfigStoreResource) Schema(ctx context.Context, req resource.Sc
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity creation date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"id": schema.StringAttribute{
 				Computed: true,
@@ -88,9 +84,6 @@ func (r *GatewayConfigStoreResource) Schema(ctx context.Context, req resource.Sc
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity update date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 		},
 	}
@@ -326,7 +319,10 @@ func (r *GatewayConfigStoreResource) Delete(ctx context.Context, req resource.De
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewayconfigstoresecret_resource.go
+++ b/internal/provider/gatewayconfigstoresecret_resource.go
@@ -18,7 +18,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect/v3/internal/planmodifiers/stringplanmodifier"
 	"github.com/kong/terraform-provider-konnect/v3/internal/sdk"
-	"github.com/kong/terraform-provider-konnect/v3/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -70,9 +69,6 @@ func (r *GatewayConfigStoreSecretResource) Schema(ctx context.Context, req resou
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity creation date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"key": schema.StringAttribute{
 				Required: true,
@@ -90,9 +86,6 @@ func (r *GatewayConfigStoreSecretResource) Schema(ctx context.Context, req resou
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity update date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"value": schema.StringAttribute{
 				Required:  true,
@@ -412,7 +405,10 @@ func (r *GatewayConfigStoreSecretResource) Delete(ctx context.Context, req resou
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewayconsumer_resource.go
+++ b/internal/provider/gatewayconsumer_resource.go
@@ -319,7 +319,10 @@ func (r *GatewayConsumerResource) Delete(ctx context.Context, req resource.Delet
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewayconsumer_resource_sdk.go
+++ b/internal/provider/gatewayconsumer_resource_sdk.go
@@ -134,8 +134,8 @@ func (r *GatewayConsumerResourceModel) ToSharedConsumer(ctx context.Context) (*s
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)

--- a/internal/provider/gatewayconsumergroup_resource.go
+++ b/internal/provider/gatewayconsumergroup_resource.go
@@ -314,7 +314,10 @@ func (r *GatewayConsumerGroupResource) Delete(ctx context.Context, req resource.
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewayconsumergroup_resource_sdk.go
+++ b/internal/provider/gatewayconsumergroup_resource_sdk.go
@@ -145,8 +145,8 @@ func (r *GatewayConsumerGroupResourceModel) ToSharedConsumerGroup(ctx context.Co
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)

--- a/internal/provider/gatewayconsumergroupmember_resource.go
+++ b/internal/provider/gatewayconsumergroupmember_resource.go
@@ -219,7 +219,10 @@ func (r *GatewayConsumerGroupMemberResource) Delete(ctx context.Context, req res
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaycontrolplane_resource_sdk.go
+++ b/internal/provider/gatewaycontrolplane_resource_sdk.go
@@ -123,15 +123,15 @@ func (r *GatewayControlPlaneResourceModel) ToSharedCreateControlPlaneRequest(ctx
 		cloudGateway = nil
 	}
 	proxyUrls := make([]shared.ProxyURL, 0, len(r.ProxyUrls))
-	for _, proxyUrlsItem := range r.ProxyUrls {
+	for proxyUrlsIndex := range r.ProxyUrls {
 		var host string
-		host = proxyUrlsItem.Host.ValueString()
+		host = r.ProxyUrls[proxyUrlsIndex].Host.ValueString()
 
 		var port int64
-		port = proxyUrlsItem.Port.ValueInt64()
+		port = r.ProxyUrls[proxyUrlsIndex].Port.ValueInt64()
 
 		var protocol string
-		protocol = proxyUrlsItem.Protocol.ValueString()
+		protocol = r.ProxyUrls[proxyUrlsIndex].Protocol.ValueString()
 
 		proxyUrls = append(proxyUrls, shared.ProxyURL{
 			Host:     host,
@@ -140,10 +140,10 @@ func (r *GatewayControlPlaneResourceModel) ToSharedCreateControlPlaneRequest(ctx
 		})
 	}
 	labels := make(map[string]*string)
-	for labelsKey, labelsValue := range r.Labels {
+	for labelsKey := range r.Labels {
 		labelsInst := new(string)
-		if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-			*labelsInst = labelsValue.ValueString()
+		if !r.Labels[labelsKey].IsUnknown() && !r.Labels[labelsKey].IsNull() {
+			*labelsInst = r.Labels[labelsKey].ValueString()
 		} else {
 			labelsInst = nil
 		}
@@ -184,15 +184,15 @@ func (r *GatewayControlPlaneResourceModel) ToSharedUpdateControlPlaneRequest(ctx
 		authType = nil
 	}
 	proxyUrls := make([]shared.ProxyURL, 0, len(r.ProxyUrls))
-	for _, proxyUrlsItem := range r.ProxyUrls {
+	for proxyUrlsIndex := range r.ProxyUrls {
 		var host string
-		host = proxyUrlsItem.Host.ValueString()
+		host = r.ProxyUrls[proxyUrlsIndex].Host.ValueString()
 
 		var port int64
-		port = proxyUrlsItem.Port.ValueInt64()
+		port = r.ProxyUrls[proxyUrlsIndex].Port.ValueInt64()
 
 		var protocol string
-		protocol = proxyUrlsItem.Protocol.ValueString()
+		protocol = r.ProxyUrls[proxyUrlsIndex].Protocol.ValueString()
 
 		proxyUrls = append(proxyUrls, shared.ProxyURL{
 			Host:     host,
@@ -201,10 +201,10 @@ func (r *GatewayControlPlaneResourceModel) ToSharedUpdateControlPlaneRequest(ctx
 		})
 	}
 	labels := make(map[string]*string)
-	for labelsKey, labelsValue := range r.Labels {
+	for labelsKey := range r.Labels {
 		labelsInst := new(string)
-		if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-			*labelsInst = labelsValue.ValueString()
+		if !r.Labels[labelsKey].IsUnknown() && !r.Labels[labelsKey].IsNull() {
+			*labelsInst = r.Labels[labelsKey].ValueString()
 		} else {
 			labelsInst = nil
 		}

--- a/internal/provider/gatewaycontrolplanemembership_resource.go
+++ b/internal/provider/gatewaycontrolplanemembership_resource.go
@@ -228,7 +228,10 @@ func (r *GatewayControlPlaneMembershipResource) Delete(ctx context.Context, req 
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaycontrolplanemembership_resource_sdk.go
+++ b/internal/provider/gatewaycontrolplanemembership_resource_sdk.go
@@ -55,9 +55,9 @@ func (r *GatewayControlPlaneMembershipResourceModel) ToSharedGroupMembership(ctx
 	var diags diag.Diagnostics
 
 	members := make([]shared.Members, 0, len(r.Members))
-	for _, membersItem := range r.Members {
+	for membersIndex := range r.Members {
 		var id string
-		id = membersItem.ID.ValueString()
+		id = r.Members[membersIndex].ID.ValueString()
 
 		members = append(members, shared.Members{
 			ID: id,

--- a/internal/provider/gatewaycustompluginschema_resource.go
+++ b/internal/provider/gatewaycustompluginschema_resource.go
@@ -131,6 +131,13 @@ func (r *GatewayCustomPluginSchemaResource) Create(ctx context.Context, req reso
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
+	if res.StatusCode == 409 {
+		resp.Diagnostics.AddError(
+			"Resource Already Exists",
+			"When creating this resource, the API indicated that this resource already exists. You can bring the existing resource under management using Terraform import functionality or retry with a unique configuration.",
+		)
+		return
+	}
 	if res.StatusCode != 201 {
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
@@ -305,7 +312,10 @@ func (r *GatewayCustomPluginSchemaResource) Delete(ctx context.Context, req reso
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaycustompluginstreaming_resource.go
+++ b/internal/provider/gatewaycustompluginstreaming_resource.go
@@ -324,7 +324,10 @@ func (r *GatewayCustomPluginStreamingResource) Delete(ctx context.Context, req r
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaycustompluginstreaming_resource_sdk.go
+++ b/internal/provider/gatewaycustompluginstreaming_resource_sdk.go
@@ -138,8 +138,8 @@ func (r *GatewayCustomPluginStreamingResourceModel) ToSharedCustomPlugin(ctx con
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)

--- a/internal/provider/gatewaydataplaneclientcertificate_resource.go
+++ b/internal/provider/gatewaydataplaneclientcertificate_resource.go
@@ -272,7 +272,10 @@ func (r *GatewayDataPlaneClientCertificateResource) Delete(ctx context.Context, 
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewayhmacauth_resource.go
+++ b/internal/provider/gatewayhmacauth_resource.go
@@ -309,7 +309,10 @@ func (r *GatewayHMACAuthResource) Delete(ctx context.Context, req resource.Delet
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewayhmacauth_resource_sdk.go
+++ b/internal/provider/gatewayhmacauth_resource_sdk.go
@@ -120,8 +120,8 @@ func (r *GatewayHMACAuthResourceModel) ToSharedHMACAuthWithoutParents(ctx contex
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	var username string

--- a/internal/provider/gatewayjwt_resource.go
+++ b/internal/provider/gatewayjwt_resource.go
@@ -359,7 +359,10 @@ func (r *GatewayJWTResource) Delete(ctx context.Context, req resource.DeleteRequ
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewayjwt_resource_sdk.go
+++ b/internal/provider/gatewayjwt_resource_sdk.go
@@ -144,8 +144,8 @@ func (r *GatewayJWTResourceModel) ToSharedJWTWithoutParents(ctx context.Context)
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	out := shared.JWTWithoutParents{

--- a/internal/provider/gatewaykey_resource.go
+++ b/internal/provider/gatewaykey_resource.go
@@ -365,7 +365,10 @@ func (r *GatewayKeyResource) Delete(ctx context.Context, req resource.DeleteRequ
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaykey_resource_sdk.go
+++ b/internal/provider/gatewaykey_resource_sdk.go
@@ -190,8 +190,8 @@ func (r *GatewayKeyResourceModel) ToSharedKey(ctx context.Context) (*shared.Key,
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)

--- a/internal/provider/gatewaykeyauth_resource.go
+++ b/internal/provider/gatewaykeyauth_resource.go
@@ -310,7 +310,10 @@ func (r *GatewayKeyAuthResource) Delete(ctx context.Context, req resource.Delete
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaykeyauth_resource_sdk.go
+++ b/internal/provider/gatewaykeyauth_resource_sdk.go
@@ -120,8 +120,8 @@ func (r *GatewayKeyAuthResourceModel) ToSharedKeyAuthWithoutParents(ctx context.
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	ttl := new(int64)

--- a/internal/provider/gatewaykeyset_resource.go
+++ b/internal/provider/gatewaykeyset_resource.go
@@ -314,7 +314,10 @@ func (r *GatewayKeySetResource) Delete(ctx context.Context, req resource.DeleteR
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaykeyset_resource_sdk.go
+++ b/internal/provider/gatewaykeyset_resource_sdk.go
@@ -133,8 +133,8 @@ func (r *GatewayKeySetResourceModel) ToSharedKeySet(ctx context.Context) (*share
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)

--- a/internal/provider/gatewaymtlsauth_resource.go
+++ b/internal/provider/gatewaymtlsauth_resource.go
@@ -323,7 +323,10 @@ func (r *GatewayMTLSAuthResource) Delete(ctx context.Context, req resource.Delet
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaymtlsauth_resource_sdk.go
+++ b/internal/provider/gatewaymtlsauth_resource_sdk.go
@@ -135,8 +135,8 @@ func (r *GatewayMTLSAuthResourceModel) ToSharedMTLSAuthWithoutParents(ctx contex
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	out := shared.MTLSAuthWithoutParents{

--- a/internal/provider/gatewaypartial_resource.go
+++ b/internal/provider/gatewaypartial_resource.go
@@ -79,7 +79,6 @@ func (r *GatewayPartialResource) Schema(ctx context.Context, req resource.Schema
 				Description: `A unique string representing a UTF-8 encoded name.`,
 			},
 			"redis_ce": schema.SingleNestedAttribute{
-				Computed: true,
 				Optional: true,
 				Attributes: map[string]schema.Attribute{
 					"config": schema.SingleNestedAttribute{
@@ -179,7 +178,6 @@ func (r *GatewayPartialResource) Schema(ctx context.Context, req resource.Schema
 				},
 			},
 			"redis_ee": schema.SingleNestedAttribute{
-				Computed: true,
 				Optional: true,
 				Attributes: map[string]schema.Attribute{
 					"config": schema.SingleNestedAttribute{
@@ -643,7 +641,10 @@ func (r *GatewayPartialResource) Delete(ctx context.Context, req resource.Delete
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypartial_resource_sdk.go
+++ b/internal/provider/gatewaypartial_resource_sdk.go
@@ -282,8 +282,8 @@ func (r *GatewayPartialResourceModel) ToSharedPartial(ctx context.Context) (*sha
 		var tags []string
 		if r.RedisCe.Tags != nil {
 			tags = make([]string, 0, len(r.RedisCe.Tags))
-			for _, tagsItem := range r.RedisCe.Tags {
-				tags = append(tags, tagsItem.ValueString())
+			for tagsIndex := range r.RedisCe.Tags {
+				tags = append(tags, r.RedisCe.Tags[tagsIndex].ValueString())
 			}
 		}
 		updatedAt := new(int64)
@@ -317,16 +317,16 @@ func (r *GatewayPartialResourceModel) ToSharedPartial(ctx context.Context) (*sha
 		var clusterNodes []shared.PartialRedisEeClusterNodes
 		if r.RedisEe.Config.ClusterNodes != nil {
 			clusterNodes = make([]shared.PartialRedisEeClusterNodes, 0, len(r.RedisEe.Config.ClusterNodes))
-			for _, clusterNodesItem := range r.RedisEe.Config.ClusterNodes {
+			for clusterNodesIndex := range r.RedisEe.Config.ClusterNodes {
 				ip := new(string)
-				if !clusterNodesItem.IP.IsUnknown() && !clusterNodesItem.IP.IsNull() {
-					*ip = clusterNodesItem.IP.ValueString()
+				if !r.RedisEe.Config.ClusterNodes[clusterNodesIndex].IP.IsUnknown() && !r.RedisEe.Config.ClusterNodes[clusterNodesIndex].IP.IsNull() {
+					*ip = r.RedisEe.Config.ClusterNodes[clusterNodesIndex].IP.ValueString()
 				} else {
 					ip = nil
 				}
 				port1 := new(int64)
-				if !clusterNodesItem.Port.IsUnknown() && !clusterNodesItem.Port.IsNull() {
-					*port1 = clusterNodesItem.Port.ValueInt64()
+				if !r.RedisEe.Config.ClusterNodes[clusterNodesIndex].Port.IsUnknown() && !r.RedisEe.Config.ClusterNodes[clusterNodesIndex].Port.IsNull() {
+					*port1 = r.RedisEe.Config.ClusterNodes[clusterNodesIndex].Port.ValueInt64()
 				} else {
 					port1 = nil
 				}
@@ -405,16 +405,16 @@ func (r *GatewayPartialResourceModel) ToSharedPartial(ctx context.Context) (*sha
 		var sentinelNodes []shared.PartialRedisEeSentinelNodes
 		if r.RedisEe.Config.SentinelNodes != nil {
 			sentinelNodes = make([]shared.PartialRedisEeSentinelNodes, 0, len(r.RedisEe.Config.SentinelNodes))
-			for _, sentinelNodesItem := range r.RedisEe.Config.SentinelNodes {
+			for sentinelNodesIndex := range r.RedisEe.Config.SentinelNodes {
 				host2 := new(string)
-				if !sentinelNodesItem.Host.IsUnknown() && !sentinelNodesItem.Host.IsNull() {
-					*host2 = sentinelNodesItem.Host.ValueString()
+				if !r.RedisEe.Config.SentinelNodes[sentinelNodesIndex].Host.IsUnknown() && !r.RedisEe.Config.SentinelNodes[sentinelNodesIndex].Host.IsNull() {
+					*host2 = r.RedisEe.Config.SentinelNodes[sentinelNodesIndex].Host.ValueString()
 				} else {
 					host2 = nil
 				}
 				port3 := new(int64)
-				if !sentinelNodesItem.Port.IsUnknown() && !sentinelNodesItem.Port.IsNull() {
-					*port3 = sentinelNodesItem.Port.ValueInt64()
+				if !r.RedisEe.Config.SentinelNodes[sentinelNodesIndex].Port.IsUnknown() && !r.RedisEe.Config.SentinelNodes[sentinelNodesIndex].Port.IsNull() {
+					*port3 = r.RedisEe.Config.SentinelNodes[sentinelNodesIndex].Port.ValueInt64()
 				} else {
 					port3 = nil
 				}
@@ -510,8 +510,8 @@ func (r *GatewayPartialResourceModel) ToSharedPartial(ctx context.Context) (*sha
 		var tags1 []string
 		if r.RedisEe.Tags != nil {
 			tags1 = make([]string, 0, len(r.RedisEe.Tags))
-			for _, tagsItem1 := range r.RedisEe.Tags {
-				tags1 = append(tags1, tagsItem1.ValueString())
+			for tagsIndex1 := range r.RedisEe.Tags {
+				tags1 = append(tags1, r.RedisEe.Tags[tagsIndex1].ValueString())
 			}
 		}
 		updatedAt1 := new(int64)

--- a/internal/provider/gatewaypluginace_resource.go
+++ b/internal/provider/gatewaypluginace_resource.go
@@ -796,7 +796,10 @@ func (r *GatewayPluginAceResource) Delete(ctx context.Context, req resource.Dele
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginace_resource_sdk.go
+++ b/internal/provider/gatewaypluginace_resource_sdk.go
@@ -264,8 +264,8 @@ func (r *GatewayPluginAceResourceModel) ToSharedAcePlugin(ctx context.Context) (
 		var after *shared.AcePluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.AcePluginAfter{
 				Access: access,
@@ -274,8 +274,8 @@ func (r *GatewayPluginAceResourceModel) ToSharedAcePlugin(ctx context.Context) (
 		var before *shared.AcePluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.AcePluginBefore{
 				Access: access1,
@@ -289,22 +289,22 @@ func (r *GatewayPluginAceResourceModel) ToSharedAcePlugin(ctx context.Context) (
 	var partials []shared.Partials
 	if r.Partials != nil {
 		partials = make([]shared.Partials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -318,8 +318,8 @@ func (r *GatewayPluginAceResourceModel) ToSharedAcePlugin(ctx context.Context) (
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -355,16 +355,16 @@ func (r *GatewayPluginAceResourceModel) ToSharedAcePlugin(ctx context.Context) (
 				var clusterNodes []shared.AcePluginClusterNodes
 				if r.Config.RateLimiting.Redis.ClusterNodes != nil {
 					clusterNodes = make([]shared.AcePluginClusterNodes, 0, len(r.Config.RateLimiting.Redis.ClusterNodes))
-					for _, clusterNodesItem := range r.Config.RateLimiting.Redis.ClusterNodes {
+					for clusterNodesIndex := range r.Config.RateLimiting.Redis.ClusterNodes {
 						ip := new(string)
-						if !clusterNodesItem.IP.IsUnknown() && !clusterNodesItem.IP.IsNull() {
-							*ip = clusterNodesItem.IP.ValueString()
+						if !r.Config.RateLimiting.Redis.ClusterNodes[clusterNodesIndex].IP.IsUnknown() && !r.Config.RateLimiting.Redis.ClusterNodes[clusterNodesIndex].IP.IsNull() {
+							*ip = r.Config.RateLimiting.Redis.ClusterNodes[clusterNodesIndex].IP.ValueString()
 						} else {
 							ip = nil
 						}
 						port := new(int64)
-						if !clusterNodesItem.Port.IsUnknown() && !clusterNodesItem.Port.IsNull() {
-							*port = clusterNodesItem.Port.ValueInt64()
+						if !r.Config.RateLimiting.Redis.ClusterNodes[clusterNodesIndex].Port.IsUnknown() && !r.Config.RateLimiting.Redis.ClusterNodes[clusterNodesIndex].Port.IsNull() {
+							*port = r.Config.RateLimiting.Redis.ClusterNodes[clusterNodesIndex].Port.ValueInt64()
 						} else {
 							port = nil
 						}
@@ -443,16 +443,16 @@ func (r *GatewayPluginAceResourceModel) ToSharedAcePlugin(ctx context.Context) (
 				var sentinelNodes []shared.AcePluginSentinelNodes
 				if r.Config.RateLimiting.Redis.SentinelNodes != nil {
 					sentinelNodes = make([]shared.AcePluginSentinelNodes, 0, len(r.Config.RateLimiting.Redis.SentinelNodes))
-					for _, sentinelNodesItem := range r.Config.RateLimiting.Redis.SentinelNodes {
+					for sentinelNodesIndex := range r.Config.RateLimiting.Redis.SentinelNodes {
 						host1 := new(string)
-						if !sentinelNodesItem.Host.IsUnknown() && !sentinelNodesItem.Host.IsNull() {
-							*host1 = sentinelNodesItem.Host.ValueString()
+						if !r.Config.RateLimiting.Redis.SentinelNodes[sentinelNodesIndex].Host.IsUnknown() && !r.Config.RateLimiting.Redis.SentinelNodes[sentinelNodesIndex].Host.IsNull() {
+							*host1 = r.Config.RateLimiting.Redis.SentinelNodes[sentinelNodesIndex].Host.ValueString()
 						} else {
 							host1 = nil
 						}
 						port2 := new(int64)
-						if !sentinelNodesItem.Port.IsUnknown() && !sentinelNodesItem.Port.IsNull() {
-							*port2 = sentinelNodesItem.Port.ValueInt64()
+						if !r.Config.RateLimiting.Redis.SentinelNodes[sentinelNodesIndex].Port.IsUnknown() && !r.Config.RateLimiting.Redis.SentinelNodes[sentinelNodesIndex].Port.IsNull() {
+							*port2 = r.Config.RateLimiting.Redis.SentinelNodes[sentinelNodesIndex].Port.ValueInt64()
 						} else {
 							port2 = nil
 						}

--- a/internal/provider/gatewaypluginacl_resource.go
+++ b/internal/provider/gatewaypluginacl_resource.go
@@ -495,7 +495,10 @@ func (r *GatewayPluginACLResource) Delete(ctx context.Context, req resource.Dele
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginacl_resource_sdk.go
+++ b/internal/provider/gatewaypluginacl_resource_sdk.go
@@ -215,8 +215,8 @@ func (r *GatewayPluginACLResourceModel) ToSharedACLPlugin(ctx context.Context) (
 		var after *shared.ACLPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.ACLPluginAfter{
 				Access: access,
@@ -225,8 +225,8 @@ func (r *GatewayPluginACLResourceModel) ToSharedACLPlugin(ctx context.Context) (
 		var before *shared.ACLPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.ACLPluginBefore{
 				Access: access1,
@@ -240,22 +240,22 @@ func (r *GatewayPluginACLResourceModel) ToSharedACLPlugin(ctx context.Context) (
 	var partials []shared.ACLPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.ACLPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -269,8 +269,8 @@ func (r *GatewayPluginACLResourceModel) ToSharedACLPlugin(ctx context.Context) (
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -284,8 +284,8 @@ func (r *GatewayPluginACLResourceModel) ToSharedACLPlugin(ctx context.Context) (
 		var allow []string
 		if r.Config.Allow != nil {
 			allow = make([]string, 0, len(r.Config.Allow))
-			for _, allowItem := range r.Config.Allow {
-				allow = append(allow, allowItem.ValueString())
+			for allowIndex := range r.Config.Allow {
+				allow = append(allow, r.Config.Allow[allowIndex].ValueString())
 			}
 		}
 		alwaysUseAuthenticatedGroups := new(bool)
@@ -297,8 +297,8 @@ func (r *GatewayPluginACLResourceModel) ToSharedACLPlugin(ctx context.Context) (
 		var deny []string
 		if r.Config.Deny != nil {
 			deny = make([]string, 0, len(r.Config.Deny))
-			for _, denyItem := range r.Config.Deny {
-				deny = append(deny, denyItem.ValueString())
+			for denyIndex := range r.Config.Deny {
+				deny = append(deny, r.Config.Deny[denyIndex].ValueString())
 			}
 		}
 		hideGroupsHeader := new(bool)

--- a/internal/provider/gatewaypluginacme_resource.go
+++ b/internal/provider/gatewaypluginacme_resource.go
@@ -857,7 +857,10 @@ func (r *GatewayPluginAcmeResource) Delete(ctx context.Context, req resource.Del
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginacme_resource_sdk.go
+++ b/internal/provider/gatewaypluginacme_resource_sdk.go
@@ -294,8 +294,8 @@ func (r *GatewayPluginAcmeResourceModel) ToSharedAcmePlugin(ctx context.Context)
 		var after *shared.AcmePluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.AcmePluginAfter{
 				Access: access,
@@ -304,8 +304,8 @@ func (r *GatewayPluginAcmeResourceModel) ToSharedAcmePlugin(ctx context.Context)
 		var before *shared.AcmePluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.AcmePluginBefore{
 				Access: access1,
@@ -319,22 +319,22 @@ func (r *GatewayPluginAcmeResourceModel) ToSharedAcmePlugin(ctx context.Context)
 	var partials []shared.AcmePluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.AcmePluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -348,8 +348,8 @@ func (r *GatewayPluginAcmeResourceModel) ToSharedAcmePlugin(ctx context.Context)
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -398,8 +398,8 @@ func (r *GatewayPluginAcmeResourceModel) ToSharedAcmePlugin(ctx context.Context)
 	var domains []string
 	if r.Config.Domains != nil {
 		domains = make([]string, 0, len(r.Config.Domains))
-		for _, domainsItem := range r.Config.Domains {
-			domains = append(domains, domainsItem.ValueString())
+		for domainsIndex := range r.Config.Domains {
+			domains = append(domains, r.Config.Domains[domainsIndex].ValueString())
 		}
 	}
 	eabHmacKey := new(string)
@@ -502,9 +502,9 @@ func (r *GatewayPluginAcmeResourceModel) ToSharedAcmePlugin(ctx context.Context)
 		var kong map[string]interface{}
 		if r.Config.StorageConfig.Kong != nil {
 			kong = make(map[string]interface{})
-			for kongKey, kongValue := range r.Config.StorageConfig.Kong {
+			for kongKey := range r.Config.StorageConfig.Kong {
 				var kongInst interface{}
-				_ = json.Unmarshal([]byte(kongValue.ValueString()), &kongInst)
+				_ = json.Unmarshal([]byte(r.Config.StorageConfig.Kong[kongKey].ValueString()), &kongInst)
 				kong[kongKey] = kongInst
 			}
 		}

--- a/internal/provider/gatewaypluginaiawsguardrails_resource.go
+++ b/internal/provider/gatewaypluginaiawsguardrails_resource.go
@@ -562,7 +562,10 @@ func (r *GatewayPluginAiAwsGuardrailsResource) Delete(ctx context.Context, req r
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginaiawsguardrails_resource_sdk.go
+++ b/internal/provider/gatewaypluginaiawsguardrails_resource_sdk.go
@@ -228,8 +228,8 @@ func (r *GatewayPluginAiAwsGuardrailsResourceModel) ToSharedAiAwsGuardrailsPlugi
 		var after *shared.AiAwsGuardrailsPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.AiAwsGuardrailsPluginAfter{
 				Access: access,
@@ -238,8 +238,8 @@ func (r *GatewayPluginAiAwsGuardrailsResourceModel) ToSharedAiAwsGuardrailsPlugi
 		var before *shared.AiAwsGuardrailsPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.AiAwsGuardrailsPluginBefore{
 				Access: access1,
@@ -253,22 +253,22 @@ func (r *GatewayPluginAiAwsGuardrailsResourceModel) ToSharedAiAwsGuardrailsPlugi
 	var partials []shared.AiAwsGuardrailsPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.AiAwsGuardrailsPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -282,8 +282,8 @@ func (r *GatewayPluginAiAwsGuardrailsResourceModel) ToSharedAiAwsGuardrailsPlugi
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)

--- a/internal/provider/gatewaypluginaiazurecontentsafety_resource.go
+++ b/internal/provider/gatewaypluginaiazurecontentsafety_resource.go
@@ -587,7 +587,10 @@ func (r *GatewayPluginAiAzureContentSafetyResource) Delete(ctx context.Context, 
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginaiazurecontentsafety_resource_sdk.go
+++ b/internal/provider/gatewaypluginaiazurecontentsafety_resource_sdk.go
@@ -239,8 +239,8 @@ func (r *GatewayPluginAiAzureContentSafetyResourceModel) ToSharedAiAzureContentS
 		var after *shared.AiAzureContentSafetyPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.AiAzureContentSafetyPluginAfter{
 				Access: access,
@@ -249,8 +249,8 @@ func (r *GatewayPluginAiAzureContentSafetyResourceModel) ToSharedAiAzureContentS
 		var before *shared.AiAzureContentSafetyPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.AiAzureContentSafetyPluginBefore{
 				Access: access1,
@@ -264,22 +264,22 @@ func (r *GatewayPluginAiAzureContentSafetyResourceModel) ToSharedAiAzureContentS
 	var partials []shared.AiAzureContentSafetyPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.AiAzureContentSafetyPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -293,8 +293,8 @@ func (r *GatewayPluginAiAzureContentSafetyResourceModel) ToSharedAiAzureContentS
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -336,19 +336,19 @@ func (r *GatewayPluginAiAzureContentSafetyResourceModel) ToSharedAiAzureContentS
 	var blocklistNames []string
 	if r.Config.BlocklistNames != nil {
 		blocklistNames = make([]string, 0, len(r.Config.BlocklistNames))
-		for _, blocklistNamesItem := range r.Config.BlocklistNames {
-			blocklistNames = append(blocklistNames, blocklistNamesItem.ValueString())
+		for blocklistNamesIndex := range r.Config.BlocklistNames {
+			blocklistNames = append(blocklistNames, r.Config.BlocklistNames[blocklistNamesIndex].ValueString())
 		}
 	}
 	var categories []shared.Categories
 	if r.Config.Categories != nil {
 		categories = make([]shared.Categories, 0, len(r.Config.Categories))
-		for _, categoriesItem := range r.Config.Categories {
+		for categoriesIndex := range r.Config.Categories {
 			var name1 string
-			name1 = categoriesItem.Name.ValueString()
+			name1 = r.Config.Categories[categoriesIndex].Name.ValueString()
 
 			var rejectionLevel int64
-			rejectionLevel = categoriesItem.RejectionLevel.ValueInt64()
+			rejectionLevel = r.Config.Categories[categoriesIndex].RejectionLevel.ValueInt64()
 
 			categories = append(categories, shared.Categories{
 				Name:           name1,

--- a/internal/provider/gatewaypluginaigcpmodelarmor_resource.go
+++ b/internal/provider/gatewaypluginaigcpmodelarmor_resource.go
@@ -581,7 +581,10 @@ func (r *GatewayPluginAiGcpModelArmorResource) Delete(ctx context.Context, req r
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginaigcpmodelarmor_resource_sdk.go
+++ b/internal/provider/gatewaypluginaigcpmodelarmor_resource_sdk.go
@@ -230,8 +230,8 @@ func (r *GatewayPluginAiGcpModelArmorResourceModel) ToSharedAiGcpModelArmorPlugi
 		var after *shared.AiGcpModelArmorPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.AiGcpModelArmorPluginAfter{
 				Access: access,
@@ -240,8 +240,8 @@ func (r *GatewayPluginAiGcpModelArmorResourceModel) ToSharedAiGcpModelArmorPlugi
 		var before *shared.AiGcpModelArmorPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.AiGcpModelArmorPluginBefore{
 				Access: access1,
@@ -255,22 +255,22 @@ func (r *GatewayPluginAiGcpModelArmorResourceModel) ToSharedAiGcpModelArmorPlugi
 	var partials []shared.AiGcpModelArmorPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.AiGcpModelArmorPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -284,8 +284,8 @@ func (r *GatewayPluginAiGcpModelArmorResourceModel) ToSharedAiGcpModelArmorPlugi
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)

--- a/internal/provider/gatewaypluginaillmasjudge_resource.go
+++ b/internal/provider/gatewaypluginaillmasjudge_resource.go
@@ -987,7 +987,10 @@ func (r *GatewayPluginAiLlmAsJudgeResource) Delete(ctx context.Context, req reso
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginaillmasjudge_resource_sdk.go
+++ b/internal/provider/gatewaypluginaillmasjudge_resource_sdk.go
@@ -318,8 +318,8 @@ func (r *GatewayPluginAiLlmAsJudgeResourceModel) ToSharedAiLlmAsJudgePlugin(ctx 
 		var after *shared.AiLlmAsJudgePluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.AiLlmAsJudgePluginAfter{
 				Access: access,
@@ -328,8 +328,8 @@ func (r *GatewayPluginAiLlmAsJudgeResourceModel) ToSharedAiLlmAsJudgePlugin(ctx 
 		var before *shared.AiLlmAsJudgePluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.AiLlmAsJudgePluginBefore{
 				Access: access1,
@@ -343,22 +343,22 @@ func (r *GatewayPluginAiLlmAsJudgeResourceModel) ToSharedAiLlmAsJudgePlugin(ctx 
 	var partials []shared.AiLlmAsJudgePluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.AiLlmAsJudgePluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -372,8 +372,8 @@ func (r *GatewayPluginAiLlmAsJudgeResourceModel) ToSharedAiLlmAsJudgePlugin(ctx 
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)

--- a/internal/provider/gatewaypluginaimcpoauth2_resource.go
+++ b/internal/provider/gatewaypluginaimcpoauth2_resource.go
@@ -704,7 +704,10 @@ func (r *GatewayPluginAiMcpOauth2Resource) Delete(ctx context.Context, req resou
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginaimcpoauth2_resource_sdk.go
+++ b/internal/provider/gatewaypluginaimcpoauth2_resource_sdk.go
@@ -271,8 +271,8 @@ func (r *GatewayPluginAiMcpOauth2ResourceModel) ToSharedAiMcpOauth2Plugin(ctx co
 		var after *shared.AiMcpOauth2PluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.AiMcpOauth2PluginAfter{
 				Access: access,
@@ -281,8 +281,8 @@ func (r *GatewayPluginAiMcpOauth2ResourceModel) ToSharedAiMcpOauth2Plugin(ctx co
 		var before *shared.AiMcpOauth2PluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.AiMcpOauth2PluginBefore{
 				Access: access1,
@@ -296,22 +296,22 @@ func (r *GatewayPluginAiMcpOauth2ResourceModel) ToSharedAiMcpOauth2Plugin(ctx co
 	var partials []shared.AiMcpOauth2PluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.AiMcpOauth2PluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -325,8 +325,8 @@ func (r *GatewayPluginAiMcpOauth2ResourceModel) ToSharedAiMcpOauth2Plugin(ctx co
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -340,16 +340,16 @@ func (r *GatewayPluginAiMcpOauth2ResourceModel) ToSharedAiMcpOauth2Plugin(ctx co
 		var args map[string]string
 		if r.Config.Args != nil {
 			args = make(map[string]string)
-			for argsKey, argsValue := range r.Config.Args {
+			for argsKey := range r.Config.Args {
 				var argsInst string
-				argsInst = argsValue.ValueString()
+				argsInst = r.Config.Args[argsKey].ValueString()
 
 				args[argsKey] = argsInst
 			}
 		}
 		authorizationServers := make([]string, 0, len(r.Config.AuthorizationServers))
-		for _, authorizationServersItem := range r.Config.AuthorizationServers {
-			authorizationServers = append(authorizationServers, authorizationServersItem.ValueString())
+		for authorizationServersIndex := range r.Config.AuthorizationServers {
+			authorizationServers = append(authorizationServers, r.Config.AuthorizationServers[authorizationServersIndex].ValueString())
 		}
 		cacheIntrospection := new(bool)
 		if !r.Config.CacheIntrospection.IsUnknown() && !r.Config.CacheIntrospection.IsNull() {
@@ -360,12 +360,12 @@ func (r *GatewayPluginAiMcpOauth2ResourceModel) ToSharedAiMcpOauth2Plugin(ctx co
 		var claimToHeader []shared.ClaimToHeader
 		if r.Config.ClaimToHeader != nil {
 			claimToHeader = make([]shared.ClaimToHeader, 0, len(r.Config.ClaimToHeader))
-			for _, claimToHeaderItem := range r.Config.ClaimToHeader {
+			for claimToHeaderIndex := range r.Config.ClaimToHeader {
 				var claim string
-				claim = claimToHeaderItem.Claim.ValueString()
+				claim = r.Config.ClaimToHeader[claimToHeaderIndex].Claim.ValueString()
 
 				var header string
-				header = claimToHeaderItem.Header.ValueString()
+				header = r.Config.ClaimToHeader[claimToHeaderIndex].Header.ValueString()
 
 				claimToHeader = append(claimToHeader, shared.ClaimToHeader{
 					Claim:  claim,
@@ -403,9 +403,9 @@ func (r *GatewayPluginAiMcpOauth2ResourceModel) ToSharedAiMcpOauth2Plugin(ctx co
 		var headers map[string]string
 		if r.Config.Headers != nil {
 			headers = make(map[string]string)
-			for headersKey, headersValue := range r.Config.Headers {
+			for headersKey := range r.Config.Headers {
 				var headersInst string
-				headersInst = headersValue.ValueString()
+				headersInst = r.Config.Headers[headersKey].ValueString()
 
 				headers[headersKey] = headersInst
 			}
@@ -491,8 +491,8 @@ func (r *GatewayPluginAiMcpOauth2ResourceModel) ToSharedAiMcpOauth2Plugin(ctx co
 		var scopesSupported []string
 		if r.Config.ScopesSupported != nil {
 			scopesSupported = make([]string, 0, len(r.Config.ScopesSupported))
-			for _, scopesSupportedItem := range r.Config.ScopesSupported {
-				scopesSupported = append(scopesSupported, scopesSupportedItem.ValueString())
+			for scopesSupportedIndex := range r.Config.ScopesSupported {
+				scopesSupported = append(scopesSupported, r.Config.ScopesSupported[scopesSupportedIndex].ValueString())
 			}
 		}
 		sslVerify := new(bool)

--- a/internal/provider/gatewaypluginaimcpproxy_resource.go
+++ b/internal/provider/gatewaypluginaimcpproxy_resource.go
@@ -661,7 +661,10 @@ func (r *GatewayPluginAiMcpProxyResource) Delete(ctx context.Context, req resour
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginaimcpproxy_resource_sdk.go
+++ b/internal/provider/gatewaypluginaimcpproxy_resource_sdk.go
@@ -288,8 +288,8 @@ func (r *GatewayPluginAiMcpProxyResourceModel) ToSharedAiMcpProxyPlugin(ctx cont
 		var after *shared.AiMcpProxyPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.AiMcpProxyPluginAfter{
 				Access: access,
@@ -298,8 +298,8 @@ func (r *GatewayPluginAiMcpProxyResourceModel) ToSharedAiMcpProxyPlugin(ctx cont
 		var before *shared.AiMcpProxyPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.AiMcpProxyPluginBefore{
 				Access: access1,
@@ -313,22 +313,22 @@ func (r *GatewayPluginAiMcpProxyResourceModel) ToSharedAiMcpProxyPlugin(ctx cont
 	var partials []shared.AiMcpProxyPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.AiMcpProxyPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -342,8 +342,8 @@ func (r *GatewayPluginAiMcpProxyResourceModel) ToSharedAiMcpProxyPlugin(ctx cont
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -407,36 +407,36 @@ func (r *GatewayPluginAiMcpProxyResourceModel) ToSharedAiMcpProxyPlugin(ctx cont
 	var tools []shared.Tools
 	if r.Config.Tools != nil {
 		tools = make([]shared.Tools, 0, len(r.Config.Tools))
-		for _, toolsItem := range r.Config.Tools {
+		for toolsIndex := range r.Config.Tools {
 			var annotations *shared.Annotations
-			if toolsItem.Annotations != nil {
+			if r.Config.Tools[toolsIndex].Annotations != nil {
 				destructiveHint := new(bool)
-				if !toolsItem.Annotations.DestructiveHint.IsUnknown() && !toolsItem.Annotations.DestructiveHint.IsNull() {
-					*destructiveHint = toolsItem.Annotations.DestructiveHint.ValueBool()
+				if !r.Config.Tools[toolsIndex].Annotations.DestructiveHint.IsUnknown() && !r.Config.Tools[toolsIndex].Annotations.DestructiveHint.IsNull() {
+					*destructiveHint = r.Config.Tools[toolsIndex].Annotations.DestructiveHint.ValueBool()
 				} else {
 					destructiveHint = nil
 				}
 				idempotentHint := new(bool)
-				if !toolsItem.Annotations.IdempotentHint.IsUnknown() && !toolsItem.Annotations.IdempotentHint.IsNull() {
-					*idempotentHint = toolsItem.Annotations.IdempotentHint.ValueBool()
+				if !r.Config.Tools[toolsIndex].Annotations.IdempotentHint.IsUnknown() && !r.Config.Tools[toolsIndex].Annotations.IdempotentHint.IsNull() {
+					*idempotentHint = r.Config.Tools[toolsIndex].Annotations.IdempotentHint.ValueBool()
 				} else {
 					idempotentHint = nil
 				}
 				openWorldHint := new(bool)
-				if !toolsItem.Annotations.OpenWorldHint.IsUnknown() && !toolsItem.Annotations.OpenWorldHint.IsNull() {
-					*openWorldHint = toolsItem.Annotations.OpenWorldHint.ValueBool()
+				if !r.Config.Tools[toolsIndex].Annotations.OpenWorldHint.IsUnknown() && !r.Config.Tools[toolsIndex].Annotations.OpenWorldHint.IsNull() {
+					*openWorldHint = r.Config.Tools[toolsIndex].Annotations.OpenWorldHint.ValueBool()
 				} else {
 					openWorldHint = nil
 				}
 				readOnlyHint := new(bool)
-				if !toolsItem.Annotations.ReadOnlyHint.IsUnknown() && !toolsItem.Annotations.ReadOnlyHint.IsNull() {
-					*readOnlyHint = toolsItem.Annotations.ReadOnlyHint.ValueBool()
+				if !r.Config.Tools[toolsIndex].Annotations.ReadOnlyHint.IsUnknown() && !r.Config.Tools[toolsIndex].Annotations.ReadOnlyHint.IsNull() {
+					*readOnlyHint = r.Config.Tools[toolsIndex].Annotations.ReadOnlyHint.ValueBool()
 				} else {
 					readOnlyHint = nil
 				}
 				title := new(string)
-				if !toolsItem.Annotations.Title.IsUnknown() && !toolsItem.Annotations.Title.IsNull() {
-					*title = toolsItem.Annotations.Title.ValueString()
+				if !r.Config.Tools[toolsIndex].Annotations.Title.IsUnknown() && !r.Config.Tools[toolsIndex].Annotations.Title.IsNull() {
+					*title = r.Config.Tools[toolsIndex].Annotations.Title.ValueString()
 				} else {
 					title = nil
 				}
@@ -449,56 +449,56 @@ func (r *GatewayPluginAiMcpProxyResourceModel) ToSharedAiMcpProxyPlugin(ctx cont
 				}
 			}
 			var description string
-			description = toolsItem.Description.ValueString()
+			description = r.Config.Tools[toolsIndex].Description.ValueString()
 
 			var headers map[string][]string
-			if toolsItem.Headers != nil {
+			if r.Config.Tools[toolsIndex].Headers != nil {
 				headers = make(map[string][]string)
-				for headersKey, headersValue := range toolsItem.Headers {
-					headersInst := make([]string, 0, len(headersValue))
-					for _, item := range headersValue {
-						headersInst = append(headersInst, item.ValueString())
+				for headersKey := range r.Config.Tools[toolsIndex].Headers {
+					headersInst := make([]string, 0, len(r.Config.Tools[toolsIndex].Headers[headersKey]))
+					for index := range r.Config.Tools[toolsIndex].Headers[headersKey] {
+						headersInst = append(headersInst, r.Config.Tools[toolsIndex].Headers[headersKey][index].ValueString())
 					}
 					headers[headersKey] = headersInst
 				}
 			}
 			host := new(string)
-			if !toolsItem.Host.IsUnknown() && !toolsItem.Host.IsNull() {
-				*host = toolsItem.Host.ValueString()
+			if !r.Config.Tools[toolsIndex].Host.IsUnknown() && !r.Config.Tools[toolsIndex].Host.IsNull() {
+				*host = r.Config.Tools[toolsIndex].Host.ValueString()
 			} else {
 				host = nil
 			}
 			method := new(shared.AiMcpProxyPluginMethod)
-			if !toolsItem.Method.IsUnknown() && !toolsItem.Method.IsNull() {
-				*method = shared.AiMcpProxyPluginMethod(toolsItem.Method.ValueString())
+			if !r.Config.Tools[toolsIndex].Method.IsUnknown() && !r.Config.Tools[toolsIndex].Method.IsNull() {
+				*method = shared.AiMcpProxyPluginMethod(r.Config.Tools[toolsIndex].Method.ValueString())
 			} else {
 				method = nil
 			}
-			parameters := make([]shared.Parameters, 0, len(toolsItem.Parameters))
-			for _, parametersItem := range toolsItem.Parameters {
+			parameters := make([]shared.Parameters, 0, len(r.Config.Tools[toolsIndex].Parameters))
+			for parametersIndex := range r.Config.Tools[toolsIndex].Parameters {
 				name1 := new(string)
-				if !parametersItem.Name.IsUnknown() && !parametersItem.Name.IsNull() {
-					*name1 = parametersItem.Name.ValueString()
+				if !r.Config.Tools[toolsIndex].Parameters[parametersIndex].Name.IsUnknown() && !r.Config.Tools[toolsIndex].Parameters[parametersIndex].Name.IsNull() {
+					*name1 = r.Config.Tools[toolsIndex].Parameters[parametersIndex].Name.ValueString()
 				} else {
 					name1 = nil
 				}
 				in := new(string)
-				if !parametersItem.In.IsUnknown() && !parametersItem.In.IsNull() {
-					*in = parametersItem.In.ValueString()
+				if !r.Config.Tools[toolsIndex].Parameters[parametersIndex].In.IsUnknown() && !r.Config.Tools[toolsIndex].Parameters[parametersIndex].In.IsNull() {
+					*in = r.Config.Tools[toolsIndex].Parameters[parametersIndex].In.ValueString()
 				} else {
 					in = nil
 				}
 				required := new(bool)
-				if !parametersItem.Required.IsUnknown() && !parametersItem.Required.IsNull() {
-					*required = parametersItem.Required.ValueBool()
+				if !r.Config.Tools[toolsIndex].Parameters[parametersIndex].Required.IsUnknown() && !r.Config.Tools[toolsIndex].Parameters[parametersIndex].Required.IsNull() {
+					*required = r.Config.Tools[toolsIndex].Parameters[parametersIndex].Required.ValueBool()
 				} else {
 					required = nil
 				}
 				var schema *shared.Schema
-				if parametersItem.Schema != nil {
+				if r.Config.Tools[toolsIndex].Parameters[parametersIndex].Schema != nil {
 					typeVar := new(string)
-					if !parametersItem.Schema.Type.IsUnknown() && !parametersItem.Schema.Type.IsNull() {
-						*typeVar = parametersItem.Schema.Type.ValueString()
+					if !r.Config.Tools[toolsIndex].Parameters[parametersIndex].Schema.Type.IsUnknown() && !r.Config.Tools[toolsIndex].Parameters[parametersIndex].Schema.Type.IsNull() {
+						*typeVar = r.Config.Tools[toolsIndex].Parameters[parametersIndex].Schema.Type.ValueString()
 					} else {
 						typeVar = nil
 					}
@@ -507,8 +507,8 @@ func (r *GatewayPluginAiMcpProxyResourceModel) ToSharedAiMcpProxyPlugin(ctx cont
 					}
 				}
 				description1 := new(string)
-				if !parametersItem.Description.IsUnknown() && !parametersItem.Description.IsNull() {
-					*description1 = parametersItem.Description.ValueString()
+				if !r.Config.Tools[toolsIndex].Parameters[parametersIndex].Description.IsUnknown() && !r.Config.Tools[toolsIndex].Parameters[parametersIndex].Description.IsNull() {
+					*description1 = r.Config.Tools[toolsIndex].Parameters[parametersIndex].Description.ValueString()
 				} else {
 					description1 = nil
 				}
@@ -521,31 +521,31 @@ func (r *GatewayPluginAiMcpProxyResourceModel) ToSharedAiMcpProxyPlugin(ctx cont
 				})
 			}
 			path1 := new(string)
-			if !toolsItem.Path.IsUnknown() && !toolsItem.Path.IsNull() {
-				*path1 = toolsItem.Path.ValueString()
+			if !r.Config.Tools[toolsIndex].Path.IsUnknown() && !r.Config.Tools[toolsIndex].Path.IsNull() {
+				*path1 = r.Config.Tools[toolsIndex].Path.ValueString()
 			} else {
 				path1 = nil
 			}
 			var query map[string][]string
-			if toolsItem.Query != nil {
+			if r.Config.Tools[toolsIndex].Query != nil {
 				query = make(map[string][]string)
-				for queryKey, queryValue := range toolsItem.Query {
-					queryInst := make([]string, 0, len(queryValue))
-					for _, item1 := range queryValue {
-						queryInst = append(queryInst, item1.ValueString())
+				for queryKey := range r.Config.Tools[toolsIndex].Query {
+					queryInst := make([]string, 0, len(r.Config.Tools[toolsIndex].Query[queryKey]))
+					for index1 := range r.Config.Tools[toolsIndex].Query[queryKey] {
+						queryInst = append(queryInst, r.Config.Tools[toolsIndex].Query[queryKey][index1].ValueString())
 					}
 					query[queryKey] = queryInst
 				}
 			}
 			requestBody := new(string)
-			if !toolsItem.RequestBody.IsUnknown() && !toolsItem.RequestBody.IsNull() {
-				*requestBody = toolsItem.RequestBody.ValueString()
+			if !r.Config.Tools[toolsIndex].RequestBody.IsUnknown() && !r.Config.Tools[toolsIndex].RequestBody.IsNull() {
+				*requestBody = r.Config.Tools[toolsIndex].RequestBody.ValueString()
 			} else {
 				requestBody = nil
 			}
 			scheme := new(shared.Scheme)
-			if !toolsItem.Scheme.IsUnknown() && !toolsItem.Scheme.IsNull() {
-				*scheme = shared.Scheme(toolsItem.Scheme.ValueString())
+			if !r.Config.Tools[toolsIndex].Scheme.IsUnknown() && !r.Config.Tools[toolsIndex].Scheme.IsNull() {
+				*scheme = shared.Scheme(r.Config.Tools[toolsIndex].Scheme.ValueString())
 			} else {
 				scheme = nil
 			}

--- a/internal/provider/gatewaypluginaipromptcompressor_resource.go
+++ b/internal/provider/gatewaypluginaipromptcompressor_resource.go
@@ -574,7 +574,10 @@ func (r *GatewayPluginAiPromptCompressorResource) Delete(ctx context.Context, re
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginaipromptcompressor_resource_sdk.go
+++ b/internal/provider/gatewaypluginaipromptcompressor_resource_sdk.go
@@ -232,8 +232,8 @@ func (r *GatewayPluginAiPromptCompressorResourceModel) ToSharedAiPromptCompresso
 		var after *shared.AiPromptCompressorPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.AiPromptCompressorPluginAfter{
 				Access: access,
@@ -242,8 +242,8 @@ func (r *GatewayPluginAiPromptCompressorResourceModel) ToSharedAiPromptCompresso
 		var before *shared.AiPromptCompressorPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.AiPromptCompressorPluginBefore{
 				Access: access1,
@@ -257,22 +257,22 @@ func (r *GatewayPluginAiPromptCompressorResourceModel) ToSharedAiPromptCompresso
 	var partials []shared.AiPromptCompressorPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.AiPromptCompressorPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -286,8 +286,8 @@ func (r *GatewayPluginAiPromptCompressorResourceModel) ToSharedAiPromptCompresso
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -297,15 +297,15 @@ func (r *GatewayPluginAiPromptCompressorResourceModel) ToSharedAiPromptCompresso
 		updatedAt = nil
 	}
 	compressionRanges := make([]shared.CompressionRanges, 0, len(r.Config.CompressionRanges))
-	for _, compressionRangesItem := range r.Config.CompressionRanges {
+	for compressionRangesIndex := range r.Config.CompressionRanges {
 		var maxTokens int64
-		maxTokens = compressionRangesItem.MaxTokens.ValueInt64()
+		maxTokens = r.Config.CompressionRanges[compressionRangesIndex].MaxTokens.ValueInt64()
 
 		var minTokens int64
-		minTokens = compressionRangesItem.MinTokens.ValueInt64()
+		minTokens = r.Config.CompressionRanges[compressionRangesIndex].MinTokens.ValueInt64()
 
 		var value float64
-		value = compressionRangesItem.Value.ValueFloat64()
+		value = r.Config.CompressionRanges[compressionRangesIndex].Value.ValueFloat64()
 
 		compressionRanges = append(compressionRanges, shared.CompressionRanges{
 			MaxTokens: maxTokens,

--- a/internal/provider/gatewaypluginaipromptdecorator_resource.go
+++ b/internal/provider/gatewaypluginaipromptdecorator_resource.go
@@ -624,7 +624,10 @@ func (r *GatewayPluginAiPromptDecoratorResource) Delete(ctx context.Context, req
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginaipromptdecorator_resource_sdk.go
+++ b/internal/provider/gatewaypluginaipromptdecorator_resource_sdk.go
@@ -255,8 +255,8 @@ func (r *GatewayPluginAiPromptDecoratorResourceModel) ToSharedAiPromptDecoratorP
 		var after *shared.AiPromptDecoratorPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.AiPromptDecoratorPluginAfter{
 				Access: access,
@@ -265,8 +265,8 @@ func (r *GatewayPluginAiPromptDecoratorResourceModel) ToSharedAiPromptDecoratorP
 		var before *shared.AiPromptDecoratorPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.AiPromptDecoratorPluginBefore{
 				Access: access1,
@@ -280,22 +280,22 @@ func (r *GatewayPluginAiPromptDecoratorResourceModel) ToSharedAiPromptDecoratorP
 	var partials []shared.AiPromptDecoratorPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.AiPromptDecoratorPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -309,8 +309,8 @@ func (r *GatewayPluginAiPromptDecoratorResourceModel) ToSharedAiPromptDecoratorP
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -338,13 +338,13 @@ func (r *GatewayPluginAiPromptDecoratorResourceModel) ToSharedAiPromptDecoratorP
 			var append1 []shared.AiPromptDecoratorPluginAppend
 			if r.Config.Prompts.Append != nil {
 				append1 = make([]shared.AiPromptDecoratorPluginAppend, 0, len(r.Config.Prompts.Append))
-				for _, appendItem := range r.Config.Prompts.Append {
+				for appendIndex := range r.Config.Prompts.Append {
 					var content string
-					content = appendItem.Content.ValueString()
+					content = r.Config.Prompts.Append[appendIndex].Content.ValueString()
 
 					role := new(shared.Role)
-					if !appendItem.Role.IsUnknown() && !appendItem.Role.IsNull() {
-						*role = shared.Role(appendItem.Role.ValueString())
+					if !r.Config.Prompts.Append[appendIndex].Role.IsUnknown() && !r.Config.Prompts.Append[appendIndex].Role.IsNull() {
+						*role = shared.Role(r.Config.Prompts.Append[appendIndex].Role.ValueString())
 					} else {
 						role = nil
 					}
@@ -357,13 +357,13 @@ func (r *GatewayPluginAiPromptDecoratorResourceModel) ToSharedAiPromptDecoratorP
 			var prepend []shared.Prepend
 			if r.Config.Prompts.Prepend != nil {
 				prepend = make([]shared.Prepend, 0, len(r.Config.Prompts.Prepend))
-				for _, prependItem := range r.Config.Prompts.Prepend {
+				for prependIndex := range r.Config.Prompts.Prepend {
 					var content1 string
-					content1 = prependItem.Content.ValueString()
+					content1 = r.Config.Prompts.Prepend[prependIndex].Content.ValueString()
 
 					role1 := new(shared.AiPromptDecoratorPluginRole)
-					if !prependItem.Role.IsUnknown() && !prependItem.Role.IsNull() {
-						*role1 = shared.AiPromptDecoratorPluginRole(prependItem.Role.ValueString())
+					if !r.Config.Prompts.Prepend[prependIndex].Role.IsUnknown() && !r.Config.Prompts.Prepend[prependIndex].Role.IsNull() {
+						*role1 = shared.AiPromptDecoratorPluginRole(r.Config.Prompts.Prepend[prependIndex].Role.ValueString())
 					} else {
 						role1 = nil
 					}

--- a/internal/provider/gatewaypluginaipromptguard_resource.go
+++ b/internal/provider/gatewaypluginaipromptguard_resource.go
@@ -560,7 +560,10 @@ func (r *GatewayPluginAiPromptGuardResource) Delete(ctx context.Context, req res
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginaipromptguard_resource_sdk.go
+++ b/internal/provider/gatewaypluginaipromptguard_resource_sdk.go
@@ -237,8 +237,8 @@ func (r *GatewayPluginAiPromptGuardResourceModel) ToSharedAiPromptGuardPlugin(ct
 		var after *shared.AiPromptGuardPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.AiPromptGuardPluginAfter{
 				Access: access,
@@ -247,8 +247,8 @@ func (r *GatewayPluginAiPromptGuardResourceModel) ToSharedAiPromptGuardPlugin(ct
 		var before *shared.AiPromptGuardPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.AiPromptGuardPluginBefore{
 				Access: access1,
@@ -262,22 +262,22 @@ func (r *GatewayPluginAiPromptGuardResourceModel) ToSharedAiPromptGuardPlugin(ct
 	var partials []shared.AiPromptGuardPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.AiPromptGuardPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -291,8 +291,8 @@ func (r *GatewayPluginAiPromptGuardResourceModel) ToSharedAiPromptGuardPlugin(ct
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -312,15 +312,15 @@ func (r *GatewayPluginAiPromptGuardResourceModel) ToSharedAiPromptGuardPlugin(ct
 		var allowPatterns []string
 		if r.Config.AllowPatterns != nil {
 			allowPatterns = make([]string, 0, len(r.Config.AllowPatterns))
-			for _, allowPatternsItem := range r.Config.AllowPatterns {
-				allowPatterns = append(allowPatterns, allowPatternsItem.ValueString())
+			for allowPatternsIndex := range r.Config.AllowPatterns {
+				allowPatterns = append(allowPatterns, r.Config.AllowPatterns[allowPatternsIndex].ValueString())
 			}
 		}
 		var denyPatterns []string
 		if r.Config.DenyPatterns != nil {
 			denyPatterns = make([]string, 0, len(r.Config.DenyPatterns))
-			for _, denyPatternsItem := range r.Config.DenyPatterns {
-				denyPatterns = append(denyPatterns, denyPatternsItem.ValueString())
+			for denyPatternsIndex := range r.Config.DenyPatterns {
+				denyPatterns = append(denyPatterns, r.Config.DenyPatterns[denyPatternsIndex].ValueString())
 			}
 		}
 		genaiCategory := new(shared.GenaiCategory)

--- a/internal/provider/gatewaypluginaiprompttemplate_resource.go
+++ b/internal/provider/gatewaypluginaiprompttemplate_resource.go
@@ -532,7 +532,10 @@ func (r *GatewayPluginAiPromptTemplateResource) Delete(ctx context.Context, req 
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginaiprompttemplate_resource_sdk.go
+++ b/internal/provider/gatewaypluginaiprompttemplate_resource_sdk.go
@@ -220,8 +220,8 @@ func (r *GatewayPluginAiPromptTemplateResourceModel) ToSharedAiPromptTemplatePlu
 		var after *shared.AiPromptTemplatePluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.AiPromptTemplatePluginAfter{
 				Access: access,
@@ -230,8 +230,8 @@ func (r *GatewayPluginAiPromptTemplateResourceModel) ToSharedAiPromptTemplatePlu
 		var before *shared.AiPromptTemplatePluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.AiPromptTemplatePluginBefore{
 				Access: access1,
@@ -245,22 +245,22 @@ func (r *GatewayPluginAiPromptTemplateResourceModel) ToSharedAiPromptTemplatePlu
 	var partials []shared.AiPromptTemplatePluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.AiPromptTemplatePluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -274,8 +274,8 @@ func (r *GatewayPluginAiPromptTemplateResourceModel) ToSharedAiPromptTemplatePlu
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -303,12 +303,12 @@ func (r *GatewayPluginAiPromptTemplateResourceModel) ToSharedAiPromptTemplatePlu
 		maxRequestBodySize = nil
 	}
 	templates := make([]shared.Templates, 0, len(r.Config.Templates))
-	for _, templatesItem := range r.Config.Templates {
+	for templatesIndex := range r.Config.Templates {
 		var name1 string
-		name1 = templatesItem.Name.ValueString()
+		name1 = r.Config.Templates[templatesIndex].Name.ValueString()
 
 		var template string
-		template = templatesItem.Template.ValueString()
+		template = r.Config.Templates[templatesIndex].Template.ValueString()
 
 		templates = append(templates, shared.Templates{
 			Name:     name1,

--- a/internal/provider/gatewaypluginaiproxy_resource.go
+++ b/internal/provider/gatewaypluginaiproxy_resource.go
@@ -962,7 +962,10 @@ func (r *GatewayPluginAiProxyResource) Delete(ctx context.Context, req resource.
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginaiproxy_resource_sdk.go
+++ b/internal/provider/gatewaypluginaiproxy_resource_sdk.go
@@ -323,8 +323,8 @@ func (r *GatewayPluginAiProxyResourceModel) ToSharedAiProxyPlugin(ctx context.Co
 		var after *shared.AiProxyPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.AiProxyPluginAfter{
 				Access: access,
@@ -333,8 +333,8 @@ func (r *GatewayPluginAiProxyResourceModel) ToSharedAiProxyPlugin(ctx context.Co
 		var before *shared.AiProxyPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.AiProxyPluginBefore{
 				Access: access1,
@@ -348,22 +348,22 @@ func (r *GatewayPluginAiProxyResourceModel) ToSharedAiProxyPlugin(ctx context.Co
 	var partials []shared.AiProxyPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.AiProxyPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -377,8 +377,8 @@ func (r *GatewayPluginAiProxyResourceModel) ToSharedAiProxyPlugin(ctx context.Co
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)

--- a/internal/provider/gatewaypluginaiproxyadvanced_resource.go
+++ b/internal/provider/gatewaypluginaiproxyadvanced_resource.go
@@ -1860,7 +1860,10 @@ func (r *GatewayPluginAiProxyAdvancedResource) Delete(ctx context.Context, req r
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginaiproxyadvanced_resource_sdk.go
+++ b/internal/provider/gatewaypluginaiproxyadvanced_resource_sdk.go
@@ -515,8 +515,8 @@ func (r *GatewayPluginAiProxyAdvancedResourceModel) ToSharedAiProxyAdvancedPlugi
 		var after *shared.AiProxyAdvancedPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.AiProxyAdvancedPluginAfter{
 				Access: access,
@@ -525,8 +525,8 @@ func (r *GatewayPluginAiProxyAdvancedResourceModel) ToSharedAiProxyAdvancedPlugi
 		var before *shared.AiProxyAdvancedPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.AiProxyAdvancedPluginBefore{
 				Access: access1,
@@ -540,22 +540,22 @@ func (r *GatewayPluginAiProxyAdvancedResourceModel) ToSharedAiProxyAdvancedPlugi
 	var partials []shared.AiProxyAdvancedPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.AiProxyAdvancedPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -569,8 +569,8 @@ func (r *GatewayPluginAiProxyAdvancedResourceModel) ToSharedAiProxyAdvancedPlugi
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -936,90 +936,90 @@ func (r *GatewayPluginAiProxyAdvancedResourceModel) ToSharedAiProxyAdvancedPlugi
 		responseStreaming = nil
 	}
 	targets := make([]shared.Targets, 0, len(r.Config.Targets))
-	for _, targetsItem := range r.Config.Targets {
+	for targetsIndex := range r.Config.Targets {
 		var auth1 *shared.AiProxyAdvancedPluginConfigAuth
-		if targetsItem.Auth != nil {
+		if r.Config.Targets[targetsIndex].Auth != nil {
 			allowOverride1 := new(bool)
-			if !targetsItem.Auth.AllowOverride.IsUnknown() && !targetsItem.Auth.AllowOverride.IsNull() {
-				*allowOverride1 = targetsItem.Auth.AllowOverride.ValueBool()
+			if !r.Config.Targets[targetsIndex].Auth.AllowOverride.IsUnknown() && !r.Config.Targets[targetsIndex].Auth.AllowOverride.IsNull() {
+				*allowOverride1 = r.Config.Targets[targetsIndex].Auth.AllowOverride.ValueBool()
 			} else {
 				allowOverride1 = nil
 			}
 			awsAccessKeyId1 := new(string)
-			if !targetsItem.Auth.AwsAccessKeyID.IsUnknown() && !targetsItem.Auth.AwsAccessKeyID.IsNull() {
-				*awsAccessKeyId1 = targetsItem.Auth.AwsAccessKeyID.ValueString()
+			if !r.Config.Targets[targetsIndex].Auth.AwsAccessKeyID.IsUnknown() && !r.Config.Targets[targetsIndex].Auth.AwsAccessKeyID.IsNull() {
+				*awsAccessKeyId1 = r.Config.Targets[targetsIndex].Auth.AwsAccessKeyID.ValueString()
 			} else {
 				awsAccessKeyId1 = nil
 			}
 			awsSecretAccessKey1 := new(string)
-			if !targetsItem.Auth.AwsSecretAccessKey.IsUnknown() && !targetsItem.Auth.AwsSecretAccessKey.IsNull() {
-				*awsSecretAccessKey1 = targetsItem.Auth.AwsSecretAccessKey.ValueString()
+			if !r.Config.Targets[targetsIndex].Auth.AwsSecretAccessKey.IsUnknown() && !r.Config.Targets[targetsIndex].Auth.AwsSecretAccessKey.IsNull() {
+				*awsSecretAccessKey1 = r.Config.Targets[targetsIndex].Auth.AwsSecretAccessKey.ValueString()
 			} else {
 				awsSecretAccessKey1 = nil
 			}
 			azureClientId1 := new(string)
-			if !targetsItem.Auth.AzureClientID.IsUnknown() && !targetsItem.Auth.AzureClientID.IsNull() {
-				*azureClientId1 = targetsItem.Auth.AzureClientID.ValueString()
+			if !r.Config.Targets[targetsIndex].Auth.AzureClientID.IsUnknown() && !r.Config.Targets[targetsIndex].Auth.AzureClientID.IsNull() {
+				*azureClientId1 = r.Config.Targets[targetsIndex].Auth.AzureClientID.ValueString()
 			} else {
 				azureClientId1 = nil
 			}
 			azureClientSecret1 := new(string)
-			if !targetsItem.Auth.AzureClientSecret.IsUnknown() && !targetsItem.Auth.AzureClientSecret.IsNull() {
-				*azureClientSecret1 = targetsItem.Auth.AzureClientSecret.ValueString()
+			if !r.Config.Targets[targetsIndex].Auth.AzureClientSecret.IsUnknown() && !r.Config.Targets[targetsIndex].Auth.AzureClientSecret.IsNull() {
+				*azureClientSecret1 = r.Config.Targets[targetsIndex].Auth.AzureClientSecret.ValueString()
 			} else {
 				azureClientSecret1 = nil
 			}
 			azureTenantId1 := new(string)
-			if !targetsItem.Auth.AzureTenantID.IsUnknown() && !targetsItem.Auth.AzureTenantID.IsNull() {
-				*azureTenantId1 = targetsItem.Auth.AzureTenantID.ValueString()
+			if !r.Config.Targets[targetsIndex].Auth.AzureTenantID.IsUnknown() && !r.Config.Targets[targetsIndex].Auth.AzureTenantID.IsNull() {
+				*azureTenantId1 = r.Config.Targets[targetsIndex].Auth.AzureTenantID.ValueString()
 			} else {
 				azureTenantId1 = nil
 			}
 			azureUseManagedIdentity1 := new(bool)
-			if !targetsItem.Auth.AzureUseManagedIdentity.IsUnknown() && !targetsItem.Auth.AzureUseManagedIdentity.IsNull() {
-				*azureUseManagedIdentity1 = targetsItem.Auth.AzureUseManagedIdentity.ValueBool()
+			if !r.Config.Targets[targetsIndex].Auth.AzureUseManagedIdentity.IsUnknown() && !r.Config.Targets[targetsIndex].Auth.AzureUseManagedIdentity.IsNull() {
+				*azureUseManagedIdentity1 = r.Config.Targets[targetsIndex].Auth.AzureUseManagedIdentity.ValueBool()
 			} else {
 				azureUseManagedIdentity1 = nil
 			}
 			gcpServiceAccountJson1 := new(string)
-			if !targetsItem.Auth.GcpServiceAccountJSON.IsUnknown() && !targetsItem.Auth.GcpServiceAccountJSON.IsNull() {
-				*gcpServiceAccountJson1 = targetsItem.Auth.GcpServiceAccountJSON.ValueString()
+			if !r.Config.Targets[targetsIndex].Auth.GcpServiceAccountJSON.IsUnknown() && !r.Config.Targets[targetsIndex].Auth.GcpServiceAccountJSON.IsNull() {
+				*gcpServiceAccountJson1 = r.Config.Targets[targetsIndex].Auth.GcpServiceAccountJSON.ValueString()
 			} else {
 				gcpServiceAccountJson1 = nil
 			}
 			gcpUseServiceAccount1 := new(bool)
-			if !targetsItem.Auth.GcpUseServiceAccount.IsUnknown() && !targetsItem.Auth.GcpUseServiceAccount.IsNull() {
-				*gcpUseServiceAccount1 = targetsItem.Auth.GcpUseServiceAccount.ValueBool()
+			if !r.Config.Targets[targetsIndex].Auth.GcpUseServiceAccount.IsUnknown() && !r.Config.Targets[targetsIndex].Auth.GcpUseServiceAccount.IsNull() {
+				*gcpUseServiceAccount1 = r.Config.Targets[targetsIndex].Auth.GcpUseServiceAccount.ValueBool()
 			} else {
 				gcpUseServiceAccount1 = nil
 			}
 			headerName1 := new(string)
-			if !targetsItem.Auth.HeaderName.IsUnknown() && !targetsItem.Auth.HeaderName.IsNull() {
-				*headerName1 = targetsItem.Auth.HeaderName.ValueString()
+			if !r.Config.Targets[targetsIndex].Auth.HeaderName.IsUnknown() && !r.Config.Targets[targetsIndex].Auth.HeaderName.IsNull() {
+				*headerName1 = r.Config.Targets[targetsIndex].Auth.HeaderName.ValueString()
 			} else {
 				headerName1 = nil
 			}
 			headerValue1 := new(string)
-			if !targetsItem.Auth.HeaderValue.IsUnknown() && !targetsItem.Auth.HeaderValue.IsNull() {
-				*headerValue1 = targetsItem.Auth.HeaderValue.ValueString()
+			if !r.Config.Targets[targetsIndex].Auth.HeaderValue.IsUnknown() && !r.Config.Targets[targetsIndex].Auth.HeaderValue.IsNull() {
+				*headerValue1 = r.Config.Targets[targetsIndex].Auth.HeaderValue.ValueString()
 			} else {
 				headerValue1 = nil
 			}
 			paramLocation1 := new(shared.AiProxyAdvancedPluginConfigParamLocation)
-			if !targetsItem.Auth.ParamLocation.IsUnknown() && !targetsItem.Auth.ParamLocation.IsNull() {
-				*paramLocation1 = shared.AiProxyAdvancedPluginConfigParamLocation(targetsItem.Auth.ParamLocation.ValueString())
+			if !r.Config.Targets[targetsIndex].Auth.ParamLocation.IsUnknown() && !r.Config.Targets[targetsIndex].Auth.ParamLocation.IsNull() {
+				*paramLocation1 = shared.AiProxyAdvancedPluginConfigParamLocation(r.Config.Targets[targetsIndex].Auth.ParamLocation.ValueString())
 			} else {
 				paramLocation1 = nil
 			}
 			paramName1 := new(string)
-			if !targetsItem.Auth.ParamName.IsUnknown() && !targetsItem.Auth.ParamName.IsNull() {
-				*paramName1 = targetsItem.Auth.ParamName.ValueString()
+			if !r.Config.Targets[targetsIndex].Auth.ParamName.IsUnknown() && !r.Config.Targets[targetsIndex].Auth.ParamName.IsNull() {
+				*paramName1 = r.Config.Targets[targetsIndex].Auth.ParamName.ValueString()
 			} else {
 				paramName1 = nil
 			}
 			paramValue1 := new(string)
-			if !targetsItem.Auth.ParamValue.IsUnknown() && !targetsItem.Auth.ParamValue.IsNull() {
-				*paramValue1 = targetsItem.Auth.ParamValue.ValueString()
+			if !r.Config.Targets[targetsIndex].Auth.ParamValue.IsUnknown() && !r.Config.Targets[targetsIndex].Auth.ParamValue.IsNull() {
+				*paramValue1 = r.Config.Targets[targetsIndex].Auth.ParamValue.ValueString()
 			} else {
 				paramValue1 = nil
 			}
@@ -1041,22 +1041,22 @@ func (r *GatewayPluginAiProxyAdvancedResourceModel) ToSharedAiProxyAdvancedPlugi
 			}
 		}
 		description := new(string)
-		if !targetsItem.Description.IsUnknown() && !targetsItem.Description.IsNull() {
-			*description = targetsItem.Description.ValueString()
+		if !r.Config.Targets[targetsIndex].Description.IsUnknown() && !r.Config.Targets[targetsIndex].Description.IsNull() {
+			*description = r.Config.Targets[targetsIndex].Description.ValueString()
 		} else {
 			description = nil
 		}
 		var logging *shared.AiProxyAdvancedPluginLogging
-		if targetsItem.Logging != nil {
+		if r.Config.Targets[targetsIndex].Logging != nil {
 			logPayloads := new(bool)
-			if !targetsItem.Logging.LogPayloads.IsUnknown() && !targetsItem.Logging.LogPayloads.IsNull() {
-				*logPayloads = targetsItem.Logging.LogPayloads.ValueBool()
+			if !r.Config.Targets[targetsIndex].Logging.LogPayloads.IsUnknown() && !r.Config.Targets[targetsIndex].Logging.LogPayloads.IsNull() {
+				*logPayloads = r.Config.Targets[targetsIndex].Logging.LogPayloads.ValueBool()
 			} else {
 				logPayloads = nil
 			}
 			logStatistics := new(bool)
-			if !targetsItem.Logging.LogStatistics.IsUnknown() && !targetsItem.Logging.LogStatistics.IsNull() {
-				*logStatistics = targetsItem.Logging.LogStatistics.ValueBool()
+			if !r.Config.Targets[targetsIndex].Logging.LogStatistics.IsUnknown() && !r.Config.Targets[targetsIndex].Logging.LogStatistics.IsNull() {
+				*logStatistics = r.Config.Targets[targetsIndex].Logging.LogStatistics.ValueBool()
 			} else {
 				logStatistics = nil
 			}
@@ -1066,72 +1066,72 @@ func (r *GatewayPluginAiProxyAdvancedResourceModel) ToSharedAiProxyAdvancedPlugi
 			}
 		}
 		name2 := new(string)
-		if !targetsItem.Model.Name.IsUnknown() && !targetsItem.Model.Name.IsNull() {
-			*name2 = targetsItem.Model.Name.ValueString()
+		if !r.Config.Targets[targetsIndex].Model.Name.IsUnknown() && !r.Config.Targets[targetsIndex].Model.Name.IsNull() {
+			*name2 = r.Config.Targets[targetsIndex].Model.Name.ValueString()
 		} else {
 			name2 = nil
 		}
 		var optionsVar1 *shared.AiProxyAdvancedPluginConfigOptions
-		if targetsItem.Model.Options != nil {
+		if r.Config.Targets[targetsIndex].Model.Options != nil {
 			anthropicVersion := new(string)
-			if !targetsItem.Model.Options.AnthropicVersion.IsUnknown() && !targetsItem.Model.Options.AnthropicVersion.IsNull() {
-				*anthropicVersion = targetsItem.Model.Options.AnthropicVersion.ValueString()
+			if !r.Config.Targets[targetsIndex].Model.Options.AnthropicVersion.IsUnknown() && !r.Config.Targets[targetsIndex].Model.Options.AnthropicVersion.IsNull() {
+				*anthropicVersion = r.Config.Targets[targetsIndex].Model.Options.AnthropicVersion.ValueString()
 			} else {
 				anthropicVersion = nil
 			}
 			azureAPIVersion := new(string)
-			if !targetsItem.Model.Options.AzureAPIVersion.IsUnknown() && !targetsItem.Model.Options.AzureAPIVersion.IsNull() {
-				*azureAPIVersion = targetsItem.Model.Options.AzureAPIVersion.ValueString()
+			if !r.Config.Targets[targetsIndex].Model.Options.AzureAPIVersion.IsUnknown() && !r.Config.Targets[targetsIndex].Model.Options.AzureAPIVersion.IsNull() {
+				*azureAPIVersion = r.Config.Targets[targetsIndex].Model.Options.AzureAPIVersion.ValueString()
 			} else {
 				azureAPIVersion = nil
 			}
 			azureDeploymentID := new(string)
-			if !targetsItem.Model.Options.AzureDeploymentID.IsUnknown() && !targetsItem.Model.Options.AzureDeploymentID.IsNull() {
-				*azureDeploymentID = targetsItem.Model.Options.AzureDeploymentID.ValueString()
+			if !r.Config.Targets[targetsIndex].Model.Options.AzureDeploymentID.IsUnknown() && !r.Config.Targets[targetsIndex].Model.Options.AzureDeploymentID.IsNull() {
+				*azureDeploymentID = r.Config.Targets[targetsIndex].Model.Options.AzureDeploymentID.ValueString()
 			} else {
 				azureDeploymentID = nil
 			}
 			azureInstance := new(string)
-			if !targetsItem.Model.Options.AzureInstance.IsUnknown() && !targetsItem.Model.Options.AzureInstance.IsNull() {
-				*azureInstance = targetsItem.Model.Options.AzureInstance.ValueString()
+			if !r.Config.Targets[targetsIndex].Model.Options.AzureInstance.IsUnknown() && !r.Config.Targets[targetsIndex].Model.Options.AzureInstance.IsNull() {
+				*azureInstance = r.Config.Targets[targetsIndex].Model.Options.AzureInstance.ValueString()
 			} else {
 				azureInstance = nil
 			}
 			var bedrock1 *shared.AiProxyAdvancedPluginConfigBedrock
-			if targetsItem.Model.Options.Bedrock != nil {
+			if r.Config.Targets[targetsIndex].Model.Options.Bedrock != nil {
 				awsAssumeRoleArn1 := new(string)
-				if !targetsItem.Model.Options.Bedrock.AwsAssumeRoleArn.IsUnknown() && !targetsItem.Model.Options.Bedrock.AwsAssumeRoleArn.IsNull() {
-					*awsAssumeRoleArn1 = targetsItem.Model.Options.Bedrock.AwsAssumeRoleArn.ValueString()
+				if !r.Config.Targets[targetsIndex].Model.Options.Bedrock.AwsAssumeRoleArn.IsUnknown() && !r.Config.Targets[targetsIndex].Model.Options.Bedrock.AwsAssumeRoleArn.IsNull() {
+					*awsAssumeRoleArn1 = r.Config.Targets[targetsIndex].Model.Options.Bedrock.AwsAssumeRoleArn.ValueString()
 				} else {
 					awsAssumeRoleArn1 = nil
 				}
 				awsRegion1 := new(string)
-				if !targetsItem.Model.Options.Bedrock.AwsRegion.IsUnknown() && !targetsItem.Model.Options.Bedrock.AwsRegion.IsNull() {
-					*awsRegion1 = targetsItem.Model.Options.Bedrock.AwsRegion.ValueString()
+				if !r.Config.Targets[targetsIndex].Model.Options.Bedrock.AwsRegion.IsUnknown() && !r.Config.Targets[targetsIndex].Model.Options.Bedrock.AwsRegion.IsNull() {
+					*awsRegion1 = r.Config.Targets[targetsIndex].Model.Options.Bedrock.AwsRegion.ValueString()
 				} else {
 					awsRegion1 = nil
 				}
 				awsRoleSessionName1 := new(string)
-				if !targetsItem.Model.Options.Bedrock.AwsRoleSessionName.IsUnknown() && !targetsItem.Model.Options.Bedrock.AwsRoleSessionName.IsNull() {
-					*awsRoleSessionName1 = targetsItem.Model.Options.Bedrock.AwsRoleSessionName.ValueString()
+				if !r.Config.Targets[targetsIndex].Model.Options.Bedrock.AwsRoleSessionName.IsUnknown() && !r.Config.Targets[targetsIndex].Model.Options.Bedrock.AwsRoleSessionName.IsNull() {
+					*awsRoleSessionName1 = r.Config.Targets[targetsIndex].Model.Options.Bedrock.AwsRoleSessionName.ValueString()
 				} else {
 					awsRoleSessionName1 = nil
 				}
 				awsStsEndpointUrl1 := new(string)
-				if !targetsItem.Model.Options.Bedrock.AwsStsEndpointURL.IsUnknown() && !targetsItem.Model.Options.Bedrock.AwsStsEndpointURL.IsNull() {
-					*awsStsEndpointUrl1 = targetsItem.Model.Options.Bedrock.AwsStsEndpointURL.ValueString()
+				if !r.Config.Targets[targetsIndex].Model.Options.Bedrock.AwsStsEndpointURL.IsUnknown() && !r.Config.Targets[targetsIndex].Model.Options.Bedrock.AwsStsEndpointURL.IsNull() {
+					*awsStsEndpointUrl1 = r.Config.Targets[targetsIndex].Model.Options.Bedrock.AwsStsEndpointURL.ValueString()
 				} else {
 					awsStsEndpointUrl1 = nil
 				}
 				embeddingsNormalize1 := new(bool)
-				if !targetsItem.Model.Options.Bedrock.EmbeddingsNormalize.IsUnknown() && !targetsItem.Model.Options.Bedrock.EmbeddingsNormalize.IsNull() {
-					*embeddingsNormalize1 = targetsItem.Model.Options.Bedrock.EmbeddingsNormalize.ValueBool()
+				if !r.Config.Targets[targetsIndex].Model.Options.Bedrock.EmbeddingsNormalize.IsUnknown() && !r.Config.Targets[targetsIndex].Model.Options.Bedrock.EmbeddingsNormalize.IsNull() {
+					*embeddingsNormalize1 = r.Config.Targets[targetsIndex].Model.Options.Bedrock.EmbeddingsNormalize.ValueBool()
 				} else {
 					embeddingsNormalize1 = nil
 				}
 				performanceConfigLatency1 := new(string)
-				if !targetsItem.Model.Options.Bedrock.PerformanceConfigLatency.IsUnknown() && !targetsItem.Model.Options.Bedrock.PerformanceConfigLatency.IsNull() {
-					*performanceConfigLatency1 = targetsItem.Model.Options.Bedrock.PerformanceConfigLatency.ValueString()
+				if !r.Config.Targets[targetsIndex].Model.Options.Bedrock.PerformanceConfigLatency.IsUnknown() && !r.Config.Targets[targetsIndex].Model.Options.Bedrock.PerformanceConfigLatency.IsNull() {
+					*performanceConfigLatency1 = r.Config.Targets[targetsIndex].Model.Options.Bedrock.PerformanceConfigLatency.ValueString()
 				} else {
 					performanceConfigLatency1 = nil
 				}
@@ -1145,16 +1145,16 @@ func (r *GatewayPluginAiProxyAdvancedResourceModel) ToSharedAiProxyAdvancedPlugi
 				}
 			}
 			var cohere *shared.AiProxyAdvancedPluginCohere
-			if targetsItem.Model.Options.Cohere != nil {
+			if r.Config.Targets[targetsIndex].Model.Options.Cohere != nil {
 				embeddingInputType := new(shared.AiProxyAdvancedPluginEmbeddingInputType)
-				if !targetsItem.Model.Options.Cohere.EmbeddingInputType.IsUnknown() && !targetsItem.Model.Options.Cohere.EmbeddingInputType.IsNull() {
-					*embeddingInputType = shared.AiProxyAdvancedPluginEmbeddingInputType(targetsItem.Model.Options.Cohere.EmbeddingInputType.ValueString())
+				if !r.Config.Targets[targetsIndex].Model.Options.Cohere.EmbeddingInputType.IsUnknown() && !r.Config.Targets[targetsIndex].Model.Options.Cohere.EmbeddingInputType.IsNull() {
+					*embeddingInputType = shared.AiProxyAdvancedPluginEmbeddingInputType(r.Config.Targets[targetsIndex].Model.Options.Cohere.EmbeddingInputType.ValueString())
 				} else {
 					embeddingInputType = nil
 				}
 				waitForModel1 := new(bool)
-				if !targetsItem.Model.Options.Cohere.WaitForModel.IsUnknown() && !targetsItem.Model.Options.Cohere.WaitForModel.IsNull() {
-					*waitForModel1 = targetsItem.Model.Options.Cohere.WaitForModel.ValueBool()
+				if !r.Config.Targets[targetsIndex].Model.Options.Cohere.WaitForModel.IsUnknown() && !r.Config.Targets[targetsIndex].Model.Options.Cohere.WaitForModel.IsNull() {
+					*waitForModel1 = r.Config.Targets[targetsIndex].Model.Options.Cohere.WaitForModel.ValueBool()
 				} else {
 					waitForModel1 = nil
 				}
@@ -1164,34 +1164,34 @@ func (r *GatewayPluginAiProxyAdvancedResourceModel) ToSharedAiProxyAdvancedPlugi
 				}
 			}
 			embeddingsDimensions := new(int64)
-			if !targetsItem.Model.Options.EmbeddingsDimensions.IsUnknown() && !targetsItem.Model.Options.EmbeddingsDimensions.IsNull() {
-				*embeddingsDimensions = targetsItem.Model.Options.EmbeddingsDimensions.ValueInt64()
+			if !r.Config.Targets[targetsIndex].Model.Options.EmbeddingsDimensions.IsUnknown() && !r.Config.Targets[targetsIndex].Model.Options.EmbeddingsDimensions.IsNull() {
+				*embeddingsDimensions = r.Config.Targets[targetsIndex].Model.Options.EmbeddingsDimensions.ValueInt64()
 			} else {
 				embeddingsDimensions = nil
 			}
 			var gemini1 *shared.AiProxyAdvancedPluginConfigGemini
-			if targetsItem.Model.Options.Gemini != nil {
+			if r.Config.Targets[targetsIndex].Model.Options.Gemini != nil {
 				apiEndpoint1 := new(string)
-				if !targetsItem.Model.Options.Gemini.APIEndpoint.IsUnknown() && !targetsItem.Model.Options.Gemini.APIEndpoint.IsNull() {
-					*apiEndpoint1 = targetsItem.Model.Options.Gemini.APIEndpoint.ValueString()
+				if !r.Config.Targets[targetsIndex].Model.Options.Gemini.APIEndpoint.IsUnknown() && !r.Config.Targets[targetsIndex].Model.Options.Gemini.APIEndpoint.IsNull() {
+					*apiEndpoint1 = r.Config.Targets[targetsIndex].Model.Options.Gemini.APIEndpoint.ValueString()
 				} else {
 					apiEndpoint1 = nil
 				}
 				endpointID := new(string)
-				if !targetsItem.Model.Options.Gemini.EndpointID.IsUnknown() && !targetsItem.Model.Options.Gemini.EndpointID.IsNull() {
-					*endpointID = targetsItem.Model.Options.Gemini.EndpointID.ValueString()
+				if !r.Config.Targets[targetsIndex].Model.Options.Gemini.EndpointID.IsUnknown() && !r.Config.Targets[targetsIndex].Model.Options.Gemini.EndpointID.IsNull() {
+					*endpointID = r.Config.Targets[targetsIndex].Model.Options.Gemini.EndpointID.ValueString()
 				} else {
 					endpointID = nil
 				}
 				locationId1 := new(string)
-				if !targetsItem.Model.Options.Gemini.LocationID.IsUnknown() && !targetsItem.Model.Options.Gemini.LocationID.IsNull() {
-					*locationId1 = targetsItem.Model.Options.Gemini.LocationID.ValueString()
+				if !r.Config.Targets[targetsIndex].Model.Options.Gemini.LocationID.IsUnknown() && !r.Config.Targets[targetsIndex].Model.Options.Gemini.LocationID.IsNull() {
+					*locationId1 = r.Config.Targets[targetsIndex].Model.Options.Gemini.LocationID.ValueString()
 				} else {
 					locationId1 = nil
 				}
 				projectId1 := new(string)
-				if !targetsItem.Model.Options.Gemini.ProjectID.IsUnknown() && !targetsItem.Model.Options.Gemini.ProjectID.IsNull() {
-					*projectId1 = targetsItem.Model.Options.Gemini.ProjectID.ValueString()
+				if !r.Config.Targets[targetsIndex].Model.Options.Gemini.ProjectID.IsUnknown() && !r.Config.Targets[targetsIndex].Model.Options.Gemini.ProjectID.IsNull() {
+					*projectId1 = r.Config.Targets[targetsIndex].Model.Options.Gemini.ProjectID.ValueString()
 				} else {
 					projectId1 = nil
 				}
@@ -1203,16 +1203,16 @@ func (r *GatewayPluginAiProxyAdvancedResourceModel) ToSharedAiProxyAdvancedPlugi
 				}
 			}
 			var huggingface1 *shared.AiProxyAdvancedPluginConfigHuggingface
-			if targetsItem.Model.Options.Huggingface != nil {
+			if r.Config.Targets[targetsIndex].Model.Options.Huggingface != nil {
 				useCache1 := new(bool)
-				if !targetsItem.Model.Options.Huggingface.UseCache.IsUnknown() && !targetsItem.Model.Options.Huggingface.UseCache.IsNull() {
-					*useCache1 = targetsItem.Model.Options.Huggingface.UseCache.ValueBool()
+				if !r.Config.Targets[targetsIndex].Model.Options.Huggingface.UseCache.IsUnknown() && !r.Config.Targets[targetsIndex].Model.Options.Huggingface.UseCache.IsNull() {
+					*useCache1 = r.Config.Targets[targetsIndex].Model.Options.Huggingface.UseCache.ValueBool()
 				} else {
 					useCache1 = nil
 				}
 				waitForModel2 := new(bool)
-				if !targetsItem.Model.Options.Huggingface.WaitForModel.IsUnknown() && !targetsItem.Model.Options.Huggingface.WaitForModel.IsNull() {
-					*waitForModel2 = targetsItem.Model.Options.Huggingface.WaitForModel.ValueBool()
+				if !r.Config.Targets[targetsIndex].Model.Options.Huggingface.WaitForModel.IsUnknown() && !r.Config.Targets[targetsIndex].Model.Options.Huggingface.WaitForModel.IsNull() {
+					*waitForModel2 = r.Config.Targets[targetsIndex].Model.Options.Huggingface.WaitForModel.ValueBool()
 				} else {
 					waitForModel2 = nil
 				}
@@ -1222,62 +1222,62 @@ func (r *GatewayPluginAiProxyAdvancedResourceModel) ToSharedAiProxyAdvancedPlugi
 				}
 			}
 			inputCost := new(float64)
-			if !targetsItem.Model.Options.InputCost.IsUnknown() && !targetsItem.Model.Options.InputCost.IsNull() {
-				*inputCost = targetsItem.Model.Options.InputCost.ValueFloat64()
+			if !r.Config.Targets[targetsIndex].Model.Options.InputCost.IsUnknown() && !r.Config.Targets[targetsIndex].Model.Options.InputCost.IsNull() {
+				*inputCost = r.Config.Targets[targetsIndex].Model.Options.InputCost.ValueFloat64()
 			} else {
 				inputCost = nil
 			}
 			llama2Format := new(shared.AiProxyAdvancedPluginLlama2Format)
-			if !targetsItem.Model.Options.Llama2Format.IsUnknown() && !targetsItem.Model.Options.Llama2Format.IsNull() {
-				*llama2Format = shared.AiProxyAdvancedPluginLlama2Format(targetsItem.Model.Options.Llama2Format.ValueString())
+			if !r.Config.Targets[targetsIndex].Model.Options.Llama2Format.IsUnknown() && !r.Config.Targets[targetsIndex].Model.Options.Llama2Format.IsNull() {
+				*llama2Format = shared.AiProxyAdvancedPluginLlama2Format(r.Config.Targets[targetsIndex].Model.Options.Llama2Format.ValueString())
 			} else {
 				llama2Format = nil
 			}
 			maxTokens := new(int64)
-			if !targetsItem.Model.Options.MaxTokens.IsUnknown() && !targetsItem.Model.Options.MaxTokens.IsNull() {
-				*maxTokens = targetsItem.Model.Options.MaxTokens.ValueInt64()
+			if !r.Config.Targets[targetsIndex].Model.Options.MaxTokens.IsUnknown() && !r.Config.Targets[targetsIndex].Model.Options.MaxTokens.IsNull() {
+				*maxTokens = r.Config.Targets[targetsIndex].Model.Options.MaxTokens.ValueInt64()
 			} else {
 				maxTokens = nil
 			}
 			mistralFormat := new(shared.AiProxyAdvancedPluginMistralFormat)
-			if !targetsItem.Model.Options.MistralFormat.IsUnknown() && !targetsItem.Model.Options.MistralFormat.IsNull() {
-				*mistralFormat = shared.AiProxyAdvancedPluginMistralFormat(targetsItem.Model.Options.MistralFormat.ValueString())
+			if !r.Config.Targets[targetsIndex].Model.Options.MistralFormat.IsUnknown() && !r.Config.Targets[targetsIndex].Model.Options.MistralFormat.IsNull() {
+				*mistralFormat = shared.AiProxyAdvancedPluginMistralFormat(r.Config.Targets[targetsIndex].Model.Options.MistralFormat.ValueString())
 			} else {
 				mistralFormat = nil
 			}
 			outputCost := new(float64)
-			if !targetsItem.Model.Options.OutputCost.IsUnknown() && !targetsItem.Model.Options.OutputCost.IsNull() {
-				*outputCost = targetsItem.Model.Options.OutputCost.ValueFloat64()
+			if !r.Config.Targets[targetsIndex].Model.Options.OutputCost.IsUnknown() && !r.Config.Targets[targetsIndex].Model.Options.OutputCost.IsNull() {
+				*outputCost = r.Config.Targets[targetsIndex].Model.Options.OutputCost.ValueFloat64()
 			} else {
 				outputCost = nil
 			}
 			temperature := new(float64)
-			if !targetsItem.Model.Options.Temperature.IsUnknown() && !targetsItem.Model.Options.Temperature.IsNull() {
-				*temperature = targetsItem.Model.Options.Temperature.ValueFloat64()
+			if !r.Config.Targets[targetsIndex].Model.Options.Temperature.IsUnknown() && !r.Config.Targets[targetsIndex].Model.Options.Temperature.IsNull() {
+				*temperature = r.Config.Targets[targetsIndex].Model.Options.Temperature.ValueFloat64()
 			} else {
 				temperature = nil
 			}
 			topK := new(int64)
-			if !targetsItem.Model.Options.TopK.IsUnknown() && !targetsItem.Model.Options.TopK.IsNull() {
-				*topK = targetsItem.Model.Options.TopK.ValueInt64()
+			if !r.Config.Targets[targetsIndex].Model.Options.TopK.IsUnknown() && !r.Config.Targets[targetsIndex].Model.Options.TopK.IsNull() {
+				*topK = r.Config.Targets[targetsIndex].Model.Options.TopK.ValueInt64()
 			} else {
 				topK = nil
 			}
 			topP := new(float64)
-			if !targetsItem.Model.Options.TopP.IsUnknown() && !targetsItem.Model.Options.TopP.IsNull() {
-				*topP = targetsItem.Model.Options.TopP.ValueFloat64()
+			if !r.Config.Targets[targetsIndex].Model.Options.TopP.IsUnknown() && !r.Config.Targets[targetsIndex].Model.Options.TopP.IsNull() {
+				*topP = r.Config.Targets[targetsIndex].Model.Options.TopP.ValueFloat64()
 			} else {
 				topP = nil
 			}
 			upstreamPath := new(string)
-			if !targetsItem.Model.Options.UpstreamPath.IsUnknown() && !targetsItem.Model.Options.UpstreamPath.IsNull() {
-				*upstreamPath = targetsItem.Model.Options.UpstreamPath.ValueString()
+			if !r.Config.Targets[targetsIndex].Model.Options.UpstreamPath.IsUnknown() && !r.Config.Targets[targetsIndex].Model.Options.UpstreamPath.IsNull() {
+				*upstreamPath = r.Config.Targets[targetsIndex].Model.Options.UpstreamPath.ValueString()
 			} else {
 				upstreamPath = nil
 			}
 			upstreamUrl1 := new(string)
-			if !targetsItem.Model.Options.UpstreamURL.IsUnknown() && !targetsItem.Model.Options.UpstreamURL.IsNull() {
-				*upstreamUrl1 = targetsItem.Model.Options.UpstreamURL.ValueString()
+			if !r.Config.Targets[targetsIndex].Model.Options.UpstreamURL.IsUnknown() && !r.Config.Targets[targetsIndex].Model.Options.UpstreamURL.IsNull() {
+				*upstreamUrl1 = r.Config.Targets[targetsIndex].Model.Options.UpstreamURL.ValueString()
 			} else {
 				upstreamUrl1 = nil
 			}
@@ -1303,16 +1303,16 @@ func (r *GatewayPluginAiProxyAdvancedResourceModel) ToSharedAiProxyAdvancedPlugi
 				UpstreamURL:          upstreamUrl1,
 			}
 		}
-		provider1 := shared.AiProxyAdvancedPluginConfigProvider(targetsItem.Model.Provider.ValueString())
+		provider1 := shared.AiProxyAdvancedPluginConfigProvider(r.Config.Targets[targetsIndex].Model.Provider.ValueString())
 		model1 := shared.AiProxyAdvancedPluginConfigModel{
 			Name:     name2,
 			Options:  optionsVar1,
 			Provider: provider1,
 		}
-		routeType := shared.AiProxyAdvancedPluginRouteType(targetsItem.RouteType.ValueString())
+		routeType := shared.AiProxyAdvancedPluginRouteType(r.Config.Targets[targetsIndex].RouteType.ValueString())
 		weight := new(int64)
-		if !targetsItem.Weight.IsUnknown() && !targetsItem.Weight.IsNull() {
-			*weight = targetsItem.Weight.ValueInt64()
+		if !r.Config.Targets[targetsIndex].Weight.IsUnknown() && !r.Config.Targets[targetsIndex].Weight.IsNull() {
+			*weight = r.Config.Targets[targetsIndex].Weight.ValueInt64()
 		} else {
 			weight = nil
 		}
@@ -1431,16 +1431,16 @@ func (r *GatewayPluginAiProxyAdvancedResourceModel) ToSharedAiProxyAdvancedPlugi
 			var clusterNodes []shared.AiProxyAdvancedPluginClusterNodes
 			if r.Config.Vectordb.Redis.ClusterNodes != nil {
 				clusterNodes = make([]shared.AiProxyAdvancedPluginClusterNodes, 0, len(r.Config.Vectordb.Redis.ClusterNodes))
-				for _, clusterNodesItem := range r.Config.Vectordb.Redis.ClusterNodes {
+				for clusterNodesIndex := range r.Config.Vectordb.Redis.ClusterNodes {
 					ip := new(string)
-					if !clusterNodesItem.IP.IsUnknown() && !clusterNodesItem.IP.IsNull() {
-						*ip = clusterNodesItem.IP.ValueString()
+					if !r.Config.Vectordb.Redis.ClusterNodes[clusterNodesIndex].IP.IsUnknown() && !r.Config.Vectordb.Redis.ClusterNodes[clusterNodesIndex].IP.IsNull() {
+						*ip = r.Config.Vectordb.Redis.ClusterNodes[clusterNodesIndex].IP.ValueString()
 					} else {
 						ip = nil
 					}
 					port1 := new(int64)
-					if !clusterNodesItem.Port.IsUnknown() && !clusterNodesItem.Port.IsNull() {
-						*port1 = clusterNodesItem.Port.ValueInt64()
+					if !r.Config.Vectordb.Redis.ClusterNodes[clusterNodesIndex].Port.IsUnknown() && !r.Config.Vectordb.Redis.ClusterNodes[clusterNodesIndex].Port.IsNull() {
+						*port1 = r.Config.Vectordb.Redis.ClusterNodes[clusterNodesIndex].Port.ValueInt64()
 					} else {
 						port1 = nil
 					}
@@ -1519,16 +1519,16 @@ func (r *GatewayPluginAiProxyAdvancedResourceModel) ToSharedAiProxyAdvancedPlugi
 			var sentinelNodes []shared.AiProxyAdvancedPluginSentinelNodes
 			if r.Config.Vectordb.Redis.SentinelNodes != nil {
 				sentinelNodes = make([]shared.AiProxyAdvancedPluginSentinelNodes, 0, len(r.Config.Vectordb.Redis.SentinelNodes))
-				for _, sentinelNodesItem := range r.Config.Vectordb.Redis.SentinelNodes {
+				for sentinelNodesIndex := range r.Config.Vectordb.Redis.SentinelNodes {
 					host2 := new(string)
-					if !sentinelNodesItem.Host.IsUnknown() && !sentinelNodesItem.Host.IsNull() {
-						*host2 = sentinelNodesItem.Host.ValueString()
+					if !r.Config.Vectordb.Redis.SentinelNodes[sentinelNodesIndex].Host.IsUnknown() && !r.Config.Vectordb.Redis.SentinelNodes[sentinelNodesIndex].Host.IsNull() {
+						*host2 = r.Config.Vectordb.Redis.SentinelNodes[sentinelNodesIndex].Host.ValueString()
 					} else {
 						host2 = nil
 					}
 					port3 := new(int64)
-					if !sentinelNodesItem.Port.IsUnknown() && !sentinelNodesItem.Port.IsNull() {
-						*port3 = sentinelNodesItem.Port.ValueInt64()
+					if !r.Config.Vectordb.Redis.SentinelNodes[sentinelNodesIndex].Port.IsUnknown() && !r.Config.Vectordb.Redis.SentinelNodes[sentinelNodesIndex].Port.IsNull() {
+						*port3 = r.Config.Vectordb.Redis.SentinelNodes[sentinelNodesIndex].Port.ValueInt64()
 					} else {
 						port3 = nil
 					}

--- a/internal/provider/gatewaypluginairaginjector_resource.go
+++ b/internal/provider/gatewaypluginairaginjector_resource.go
@@ -1137,7 +1137,10 @@ func (r *GatewayPluginAiRagInjectorResource) Delete(ctx context.Context, req res
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginairaginjector_resource_sdk.go
+++ b/internal/provider/gatewaypluginairaginjector_resource_sdk.go
@@ -357,8 +357,8 @@ func (r *GatewayPluginAiRagInjectorResourceModel) ToSharedAiRagInjectorPlugin(ct
 		var after *shared.AiRagInjectorPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.AiRagInjectorPluginAfter{
 				Access: access,
@@ -367,8 +367,8 @@ func (r *GatewayPluginAiRagInjectorResourceModel) ToSharedAiRagInjectorPlugin(ct
 		var before *shared.AiRagInjectorPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.AiRagInjectorPluginBefore{
 				Access: access1,
@@ -382,22 +382,22 @@ func (r *GatewayPluginAiRagInjectorResourceModel) ToSharedAiRagInjectorPlugin(ct
 	var partials []shared.AiRagInjectorPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.AiRagInjectorPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -411,8 +411,8 @@ func (r *GatewayPluginAiRagInjectorResourceModel) ToSharedAiRagInjectorPlugin(ct
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -799,16 +799,16 @@ func (r *GatewayPluginAiRagInjectorResourceModel) ToSharedAiRagInjectorPlugin(ct
 		var clusterNodes []shared.AiRagInjectorPluginClusterNodes
 		if r.Config.Vectordb.Redis.ClusterNodes != nil {
 			clusterNodes = make([]shared.AiRagInjectorPluginClusterNodes, 0, len(r.Config.Vectordb.Redis.ClusterNodes))
-			for _, clusterNodesItem := range r.Config.Vectordb.Redis.ClusterNodes {
+			for clusterNodesIndex := range r.Config.Vectordb.Redis.ClusterNodes {
 				ip := new(string)
-				if !clusterNodesItem.IP.IsUnknown() && !clusterNodesItem.IP.IsNull() {
-					*ip = clusterNodesItem.IP.ValueString()
+				if !r.Config.Vectordb.Redis.ClusterNodes[clusterNodesIndex].IP.IsUnknown() && !r.Config.Vectordb.Redis.ClusterNodes[clusterNodesIndex].IP.IsNull() {
+					*ip = r.Config.Vectordb.Redis.ClusterNodes[clusterNodesIndex].IP.ValueString()
 				} else {
 					ip = nil
 				}
 				port1 := new(int64)
-				if !clusterNodesItem.Port.IsUnknown() && !clusterNodesItem.Port.IsNull() {
-					*port1 = clusterNodesItem.Port.ValueInt64()
+				if !r.Config.Vectordb.Redis.ClusterNodes[clusterNodesIndex].Port.IsUnknown() && !r.Config.Vectordb.Redis.ClusterNodes[clusterNodesIndex].Port.IsNull() {
+					*port1 = r.Config.Vectordb.Redis.ClusterNodes[clusterNodesIndex].Port.ValueInt64()
 				} else {
 					port1 = nil
 				}
@@ -887,16 +887,16 @@ func (r *GatewayPluginAiRagInjectorResourceModel) ToSharedAiRagInjectorPlugin(ct
 		var sentinelNodes []shared.AiRagInjectorPluginSentinelNodes
 		if r.Config.Vectordb.Redis.SentinelNodes != nil {
 			sentinelNodes = make([]shared.AiRagInjectorPluginSentinelNodes, 0, len(r.Config.Vectordb.Redis.SentinelNodes))
-			for _, sentinelNodesItem := range r.Config.Vectordb.Redis.SentinelNodes {
+			for sentinelNodesIndex := range r.Config.Vectordb.Redis.SentinelNodes {
 				host2 := new(string)
-				if !sentinelNodesItem.Host.IsUnknown() && !sentinelNodesItem.Host.IsNull() {
-					*host2 = sentinelNodesItem.Host.ValueString()
+				if !r.Config.Vectordb.Redis.SentinelNodes[sentinelNodesIndex].Host.IsUnknown() && !r.Config.Vectordb.Redis.SentinelNodes[sentinelNodesIndex].Host.IsNull() {
+					*host2 = r.Config.Vectordb.Redis.SentinelNodes[sentinelNodesIndex].Host.ValueString()
 				} else {
 					host2 = nil
 				}
 				port3 := new(int64)
-				if !sentinelNodesItem.Port.IsUnknown() && !sentinelNodesItem.Port.IsNull() {
-					*port3 = sentinelNodesItem.Port.ValueInt64()
+				if !r.Config.Vectordb.Redis.SentinelNodes[sentinelNodesIndex].Port.IsUnknown() && !r.Config.Vectordb.Redis.SentinelNodes[sentinelNodesIndex].Port.IsNull() {
+					*port3 = r.Config.Vectordb.Redis.SentinelNodes[sentinelNodesIndex].Port.ValueInt64()
 				} else {
 					port3 = nil
 				}

--- a/internal/provider/gatewaypluginairatelimitingadvanced_resource.go
+++ b/internal/provider/gatewaypluginairatelimitingadvanced_resource.go
@@ -892,7 +892,10 @@ func (r *GatewayPluginAiRateLimitingAdvancedResource) Delete(ctx context.Context
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginairatelimitingadvanced_resource_sdk.go
+++ b/internal/provider/gatewaypluginairatelimitingadvanced_resource_sdk.go
@@ -313,8 +313,8 @@ func (r *GatewayPluginAiRateLimitingAdvancedResourceModel) ToSharedAiRateLimitin
 		var after *shared.AiRateLimitingAdvancedPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.AiRateLimitingAdvancedPluginAfter{
 				Access: access,
@@ -323,8 +323,8 @@ func (r *GatewayPluginAiRateLimitingAdvancedResourceModel) ToSharedAiRateLimitin
 		var before *shared.AiRateLimitingAdvancedPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.AiRateLimitingAdvancedPluginBefore{
 				Access: access1,
@@ -338,22 +338,22 @@ func (r *GatewayPluginAiRateLimitingAdvancedResourceModel) ToSharedAiRateLimitin
 	var partials []shared.AiRateLimitingAdvancedPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.AiRateLimitingAdvancedPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -367,8 +367,8 @@ func (r *GatewayPluginAiRateLimitingAdvancedResourceModel) ToSharedAiRateLimitin
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -432,15 +432,15 @@ func (r *GatewayPluginAiRateLimitingAdvancedResourceModel) ToSharedAiRateLimitin
 		llmFormat = nil
 	}
 	llmProviders := make([]shared.LlmProviders, 0, len(r.Config.LlmProviders))
-	for _, llmProvidersItem := range r.Config.LlmProviders {
-		limit := make([]float64, 0, len(llmProvidersItem.Limit))
-		for _, limitItem := range llmProvidersItem.Limit {
-			limit = append(limit, limitItem.ValueFloat64())
+	for llmProvidersIndex := range r.Config.LlmProviders {
+		limit := make([]float64, 0, len(r.Config.LlmProviders[llmProvidersIndex].Limit))
+		for limitIndex := range r.Config.LlmProviders[llmProvidersIndex].Limit {
+			limit = append(limit, r.Config.LlmProviders[llmProvidersIndex].Limit[limitIndex].ValueFloat64())
 		}
-		name1 := shared.AiRateLimitingAdvancedPluginName(llmProvidersItem.Name.ValueString())
-		windowSize := make([]float64, 0, len(llmProvidersItem.WindowSize))
-		for _, windowSizeItem := range llmProvidersItem.WindowSize {
-			windowSize = append(windowSize, windowSizeItem.ValueFloat64())
+		name1 := shared.AiRateLimitingAdvancedPluginName(r.Config.LlmProviders[llmProvidersIndex].Name.ValueString())
+		windowSize := make([]float64, 0, len(r.Config.LlmProviders[llmProvidersIndex].WindowSize))
+		for windowSizeIndex := range r.Config.LlmProviders[llmProvidersIndex].WindowSize {
+			windowSize = append(windowSize, r.Config.LlmProviders[llmProvidersIndex].WindowSize[windowSizeIndex].ValueFloat64())
 		}
 		llmProviders = append(llmProviders, shared.LlmProviders{
 			Limit:      limit,
@@ -471,16 +471,16 @@ func (r *GatewayPluginAiRateLimitingAdvancedResourceModel) ToSharedAiRateLimitin
 		var clusterNodes []shared.ClusterNodes
 		if r.Config.Redis.ClusterNodes != nil {
 			clusterNodes = make([]shared.ClusterNodes, 0, len(r.Config.Redis.ClusterNodes))
-			for _, clusterNodesItem := range r.Config.Redis.ClusterNodes {
+			for clusterNodesIndex := range r.Config.Redis.ClusterNodes {
 				ip := new(string)
-				if !clusterNodesItem.IP.IsUnknown() && !clusterNodesItem.IP.IsNull() {
-					*ip = clusterNodesItem.IP.ValueString()
+				if !r.Config.Redis.ClusterNodes[clusterNodesIndex].IP.IsUnknown() && !r.Config.Redis.ClusterNodes[clusterNodesIndex].IP.IsNull() {
+					*ip = r.Config.Redis.ClusterNodes[clusterNodesIndex].IP.ValueString()
 				} else {
 					ip = nil
 				}
 				port := new(int64)
-				if !clusterNodesItem.Port.IsUnknown() && !clusterNodesItem.Port.IsNull() {
-					*port = clusterNodesItem.Port.ValueInt64()
+				if !r.Config.Redis.ClusterNodes[clusterNodesIndex].Port.IsUnknown() && !r.Config.Redis.ClusterNodes[clusterNodesIndex].Port.IsNull() {
+					*port = r.Config.Redis.ClusterNodes[clusterNodesIndex].Port.ValueInt64()
 				} else {
 					port = nil
 				}
@@ -559,16 +559,16 @@ func (r *GatewayPluginAiRateLimitingAdvancedResourceModel) ToSharedAiRateLimitin
 		var sentinelNodes []shared.SentinelNodes
 		if r.Config.Redis.SentinelNodes != nil {
 			sentinelNodes = make([]shared.SentinelNodes, 0, len(r.Config.Redis.SentinelNodes))
-			for _, sentinelNodesItem := range r.Config.Redis.SentinelNodes {
+			for sentinelNodesIndex := range r.Config.Redis.SentinelNodes {
 				host1 := new(string)
-				if !sentinelNodesItem.Host.IsUnknown() && !sentinelNodesItem.Host.IsNull() {
-					*host1 = sentinelNodesItem.Host.ValueString()
+				if !r.Config.Redis.SentinelNodes[sentinelNodesIndex].Host.IsUnknown() && !r.Config.Redis.SentinelNodes[sentinelNodesIndex].Host.IsNull() {
+					*host1 = r.Config.Redis.SentinelNodes[sentinelNodesIndex].Host.ValueString()
 				} else {
 					host1 = nil
 				}
 				port2 := new(int64)
-				if !sentinelNodesItem.Port.IsUnknown() && !sentinelNodesItem.Port.IsNull() {
-					*port2 = sentinelNodesItem.Port.ValueInt64()
+				if !r.Config.Redis.SentinelNodes[sentinelNodesIndex].Port.IsUnknown() && !r.Config.Redis.SentinelNodes[sentinelNodesIndex].Port.IsNull() {
+					*port2 = r.Config.Redis.SentinelNodes[sentinelNodesIndex].Port.ValueInt64()
 				} else {
 					port2 = nil
 				}

--- a/internal/provider/gatewaypluginairequesttransformer_resource.go
+++ b/internal/provider/gatewaypluginairequesttransformer_resource.go
@@ -943,7 +943,10 @@ func (r *GatewayPluginAiRequestTransformerResource) Delete(ctx context.Context, 
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginairequesttransformer_resource_sdk.go
+++ b/internal/provider/gatewaypluginairequesttransformer_resource_sdk.go
@@ -309,8 +309,8 @@ func (r *GatewayPluginAiRequestTransformerResourceModel) ToSharedAiRequestTransf
 		var after *shared.AiRequestTransformerPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.AiRequestTransformerPluginAfter{
 				Access: access,
@@ -319,8 +319,8 @@ func (r *GatewayPluginAiRequestTransformerResourceModel) ToSharedAiRequestTransf
 		var before *shared.AiRequestTransformerPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.AiRequestTransformerPluginBefore{
 				Access: access1,
@@ -334,22 +334,22 @@ func (r *GatewayPluginAiRequestTransformerResourceModel) ToSharedAiRequestTransf
 	var partials []shared.AiRequestTransformerPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.AiRequestTransformerPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -363,8 +363,8 @@ func (r *GatewayPluginAiRequestTransformerResourceModel) ToSharedAiRequestTransf
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)

--- a/internal/provider/gatewaypluginairesponsetransformer_resource.go
+++ b/internal/provider/gatewaypluginairesponsetransformer_resource.go
@@ -964,7 +964,10 @@ func (r *GatewayPluginAiResponseTransformerResource) Delete(ctx context.Context,
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginairesponsetransformer_resource_sdk.go
+++ b/internal/provider/gatewaypluginairesponsetransformer_resource_sdk.go
@@ -316,8 +316,8 @@ func (r *GatewayPluginAiResponseTransformerResourceModel) ToSharedAiResponseTran
 		var after *shared.AiResponseTransformerPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.AiResponseTransformerPluginAfter{
 				Access: access,
@@ -326,8 +326,8 @@ func (r *GatewayPluginAiResponseTransformerResourceModel) ToSharedAiResponseTran
 		var before *shared.AiResponseTransformerPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.AiResponseTransformerPluginBefore{
 				Access: access1,
@@ -341,22 +341,22 @@ func (r *GatewayPluginAiResponseTransformerResourceModel) ToSharedAiResponseTran
 	var partials []shared.AiResponseTransformerPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.AiResponseTransformerPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -370,8 +370,8 @@ func (r *GatewayPluginAiResponseTransformerResourceModel) ToSharedAiResponseTran
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)

--- a/internal/provider/gatewaypluginaisanitizer_resource.go
+++ b/internal/provider/gatewaypluginaisanitizer_resource.go
@@ -629,7 +629,10 @@ func (r *GatewayPluginAiSanitizerResource) Delete(ctx context.Context, req resou
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginaisanitizer_resource_sdk.go
+++ b/internal/provider/gatewaypluginaisanitizer_resource_sdk.go
@@ -247,8 +247,8 @@ func (r *GatewayPluginAiSanitizerResourceModel) ToSharedAiSanitizerPlugin(ctx co
 		var after *shared.AiSanitizerPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.AiSanitizerPluginAfter{
 				Access: access,
@@ -257,8 +257,8 @@ func (r *GatewayPluginAiSanitizerResourceModel) ToSharedAiSanitizerPlugin(ctx co
 		var before *shared.AiSanitizerPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.AiSanitizerPluginBefore{
 				Access: access1,
@@ -272,22 +272,22 @@ func (r *GatewayPluginAiSanitizerResourceModel) ToSharedAiSanitizerPlugin(ctx co
 	var partials []shared.AiSanitizerPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.AiSanitizerPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -301,8 +301,8 @@ func (r *GatewayPluginAiSanitizerResourceModel) ToSharedAiSanitizerPlugin(ctx co
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -326,16 +326,16 @@ func (r *GatewayPluginAiSanitizerResourceModel) ToSharedAiSanitizerPlugin(ctx co
 		var customPatterns []shared.CustomPatterns
 		if r.Config.CustomPatterns != nil {
 			customPatterns = make([]shared.CustomPatterns, 0, len(r.Config.CustomPatterns))
-			for _, customPatternsItem := range r.Config.CustomPatterns {
+			for customPatternsIndex := range r.Config.CustomPatterns {
 				var name1 string
-				name1 = customPatternsItem.Name.ValueString()
+				name1 = r.Config.CustomPatterns[customPatternsIndex].Name.ValueString()
 
 				var regex string
-				regex = customPatternsItem.Regex.ValueString()
+				regex = r.Config.CustomPatterns[customPatternsIndex].Regex.ValueString()
 
 				score := new(float64)
-				if !customPatternsItem.Score.IsUnknown() && !customPatternsItem.Score.IsNull() {
-					*score = customPatternsItem.Score.ValueFloat64()
+				if !r.Config.CustomPatterns[customPatternsIndex].Score.IsUnknown() && !r.Config.CustomPatterns[customPatternsIndex].Score.IsNull() {
+					*score = r.Config.CustomPatterns[customPatternsIndex].Score.ValueFloat64()
 				} else {
 					score = nil
 				}

--- a/internal/provider/gatewaypluginaisemanticcache_resource.go
+++ b/internal/provider/gatewaypluginaisemanticcache_resource.go
@@ -1170,7 +1170,10 @@ func (r *GatewayPluginAiSemanticCacheResource) Delete(ctx context.Context, req r
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginaisemanticcache_resource_sdk.go
+++ b/internal/provider/gatewaypluginaisemanticcache_resource_sdk.go
@@ -362,8 +362,8 @@ func (r *GatewayPluginAiSemanticCacheResourceModel) ToSharedAiSemanticCachePlugi
 		var after *shared.AiSemanticCachePluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.AiSemanticCachePluginAfter{
 				Access: access,
@@ -372,8 +372,8 @@ func (r *GatewayPluginAiSemanticCacheResourceModel) ToSharedAiSemanticCachePlugi
 		var before *shared.AiSemanticCachePluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.AiSemanticCachePluginBefore{
 				Access: access1,
@@ -387,22 +387,22 @@ func (r *GatewayPluginAiSemanticCacheResourceModel) ToSharedAiSemanticCachePlugi
 	var partials []shared.AiSemanticCachePluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.AiSemanticCachePluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -416,8 +416,8 @@ func (r *GatewayPluginAiSemanticCacheResourceModel) ToSharedAiSemanticCachePlugi
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -834,16 +834,16 @@ func (r *GatewayPluginAiSemanticCacheResourceModel) ToSharedAiSemanticCachePlugi
 		var clusterNodes []shared.AiSemanticCachePluginClusterNodes
 		if r.Config.Vectordb.Redis.ClusterNodes != nil {
 			clusterNodes = make([]shared.AiSemanticCachePluginClusterNodes, 0, len(r.Config.Vectordb.Redis.ClusterNodes))
-			for _, clusterNodesItem := range r.Config.Vectordb.Redis.ClusterNodes {
+			for clusterNodesIndex := range r.Config.Vectordb.Redis.ClusterNodes {
 				ip := new(string)
-				if !clusterNodesItem.IP.IsUnknown() && !clusterNodesItem.IP.IsNull() {
-					*ip = clusterNodesItem.IP.ValueString()
+				if !r.Config.Vectordb.Redis.ClusterNodes[clusterNodesIndex].IP.IsUnknown() && !r.Config.Vectordb.Redis.ClusterNodes[clusterNodesIndex].IP.IsNull() {
+					*ip = r.Config.Vectordb.Redis.ClusterNodes[clusterNodesIndex].IP.ValueString()
 				} else {
 					ip = nil
 				}
 				port1 := new(int64)
-				if !clusterNodesItem.Port.IsUnknown() && !clusterNodesItem.Port.IsNull() {
-					*port1 = clusterNodesItem.Port.ValueInt64()
+				if !r.Config.Vectordb.Redis.ClusterNodes[clusterNodesIndex].Port.IsUnknown() && !r.Config.Vectordb.Redis.ClusterNodes[clusterNodesIndex].Port.IsNull() {
+					*port1 = r.Config.Vectordb.Redis.ClusterNodes[clusterNodesIndex].Port.ValueInt64()
 				} else {
 					port1 = nil
 				}
@@ -922,16 +922,16 @@ func (r *GatewayPluginAiSemanticCacheResourceModel) ToSharedAiSemanticCachePlugi
 		var sentinelNodes []shared.AiSemanticCachePluginSentinelNodes
 		if r.Config.Vectordb.Redis.SentinelNodes != nil {
 			sentinelNodes = make([]shared.AiSemanticCachePluginSentinelNodes, 0, len(r.Config.Vectordb.Redis.SentinelNodes))
-			for _, sentinelNodesItem := range r.Config.Vectordb.Redis.SentinelNodes {
+			for sentinelNodesIndex := range r.Config.Vectordb.Redis.SentinelNodes {
 				host2 := new(string)
-				if !sentinelNodesItem.Host.IsUnknown() && !sentinelNodesItem.Host.IsNull() {
-					*host2 = sentinelNodesItem.Host.ValueString()
+				if !r.Config.Vectordb.Redis.SentinelNodes[sentinelNodesIndex].Host.IsUnknown() && !r.Config.Vectordb.Redis.SentinelNodes[sentinelNodesIndex].Host.IsNull() {
+					*host2 = r.Config.Vectordb.Redis.SentinelNodes[sentinelNodesIndex].Host.ValueString()
 				} else {
 					host2 = nil
 				}
 				port3 := new(int64)
-				if !sentinelNodesItem.Port.IsUnknown() && !sentinelNodesItem.Port.IsNull() {
-					*port3 = sentinelNodesItem.Port.ValueInt64()
+				if !r.Config.Vectordb.Redis.SentinelNodes[sentinelNodesIndex].Port.IsUnknown() && !r.Config.Vectordb.Redis.SentinelNodes[sentinelNodesIndex].Port.IsNull() {
+					*port3 = r.Config.Vectordb.Redis.SentinelNodes[sentinelNodesIndex].Port.ValueInt64()
 				} else {
 					port3 = nil
 				}

--- a/internal/provider/gatewaypluginaisemanticpromptguard_resource.go
+++ b/internal/provider/gatewaypluginaisemanticpromptguard_resource.go
@@ -1193,7 +1193,10 @@ func (r *GatewayPluginAiSemanticPromptGuardResource) Delete(ctx context.Context,
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginaisemanticpromptguard_resource_sdk.go
+++ b/internal/provider/gatewaypluginaisemanticpromptguard_resource_sdk.go
@@ -385,8 +385,8 @@ func (r *GatewayPluginAiSemanticPromptGuardResourceModel) ToSharedAiSemanticProm
 		var after *shared.AiSemanticPromptGuardPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.AiSemanticPromptGuardPluginAfter{
 				Access: access,
@@ -395,8 +395,8 @@ func (r *GatewayPluginAiSemanticPromptGuardResourceModel) ToSharedAiSemanticProm
 		var before *shared.AiSemanticPromptGuardPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.AiSemanticPromptGuardPluginBefore{
 				Access: access1,
@@ -410,22 +410,22 @@ func (r *GatewayPluginAiSemanticPromptGuardResourceModel) ToSharedAiSemanticProm
 	var partials []shared.AiSemanticPromptGuardPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.AiSemanticPromptGuardPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -439,8 +439,8 @@ func (r *GatewayPluginAiSemanticPromptGuardResourceModel) ToSharedAiSemanticProm
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -716,15 +716,15 @@ func (r *GatewayPluginAiSemanticPromptGuardResourceModel) ToSharedAiSemanticProm
 		var allowPrompts []string
 		if r.Config.Rules.AllowPrompts != nil {
 			allowPrompts = make([]string, 0, len(r.Config.Rules.AllowPrompts))
-			for _, allowPromptsItem := range r.Config.Rules.AllowPrompts {
-				allowPrompts = append(allowPrompts, allowPromptsItem.ValueString())
+			for allowPromptsIndex := range r.Config.Rules.AllowPrompts {
+				allowPrompts = append(allowPrompts, r.Config.Rules.AllowPrompts[allowPromptsIndex].ValueString())
 			}
 		}
 		var denyPrompts []string
 		if r.Config.Rules.DenyPrompts != nil {
 			denyPrompts = make([]string, 0, len(r.Config.Rules.DenyPrompts))
-			for _, denyPromptsItem := range r.Config.Rules.DenyPrompts {
-				denyPrompts = append(denyPrompts, denyPromptsItem.ValueString())
+			for denyPromptsIndex := range r.Config.Rules.DenyPrompts {
+				denyPrompts = append(denyPrompts, r.Config.Rules.DenyPrompts[denyPromptsIndex].ValueString())
 			}
 		}
 		matchAllConversationHistory := new(bool)
@@ -869,16 +869,16 @@ func (r *GatewayPluginAiSemanticPromptGuardResourceModel) ToSharedAiSemanticProm
 		var clusterNodes []shared.AiSemanticPromptGuardPluginClusterNodes
 		if r.Config.Vectordb.Redis.ClusterNodes != nil {
 			clusterNodes = make([]shared.AiSemanticPromptGuardPluginClusterNodes, 0, len(r.Config.Vectordb.Redis.ClusterNodes))
-			for _, clusterNodesItem := range r.Config.Vectordb.Redis.ClusterNodes {
+			for clusterNodesIndex := range r.Config.Vectordb.Redis.ClusterNodes {
 				ip := new(string)
-				if !clusterNodesItem.IP.IsUnknown() && !clusterNodesItem.IP.IsNull() {
-					*ip = clusterNodesItem.IP.ValueString()
+				if !r.Config.Vectordb.Redis.ClusterNodes[clusterNodesIndex].IP.IsUnknown() && !r.Config.Vectordb.Redis.ClusterNodes[clusterNodesIndex].IP.IsNull() {
+					*ip = r.Config.Vectordb.Redis.ClusterNodes[clusterNodesIndex].IP.ValueString()
 				} else {
 					ip = nil
 				}
 				port1 := new(int64)
-				if !clusterNodesItem.Port.IsUnknown() && !clusterNodesItem.Port.IsNull() {
-					*port1 = clusterNodesItem.Port.ValueInt64()
+				if !r.Config.Vectordb.Redis.ClusterNodes[clusterNodesIndex].Port.IsUnknown() && !r.Config.Vectordb.Redis.ClusterNodes[clusterNodesIndex].Port.IsNull() {
+					*port1 = r.Config.Vectordb.Redis.ClusterNodes[clusterNodesIndex].Port.ValueInt64()
 				} else {
 					port1 = nil
 				}
@@ -957,16 +957,16 @@ func (r *GatewayPluginAiSemanticPromptGuardResourceModel) ToSharedAiSemanticProm
 		var sentinelNodes []shared.AiSemanticPromptGuardPluginSentinelNodes
 		if r.Config.Vectordb.Redis.SentinelNodes != nil {
 			sentinelNodes = make([]shared.AiSemanticPromptGuardPluginSentinelNodes, 0, len(r.Config.Vectordb.Redis.SentinelNodes))
-			for _, sentinelNodesItem := range r.Config.Vectordb.Redis.SentinelNodes {
+			for sentinelNodesIndex := range r.Config.Vectordb.Redis.SentinelNodes {
 				host2 := new(string)
-				if !sentinelNodesItem.Host.IsUnknown() && !sentinelNodesItem.Host.IsNull() {
-					*host2 = sentinelNodesItem.Host.ValueString()
+				if !r.Config.Vectordb.Redis.SentinelNodes[sentinelNodesIndex].Host.IsUnknown() && !r.Config.Vectordb.Redis.SentinelNodes[sentinelNodesIndex].Host.IsNull() {
+					*host2 = r.Config.Vectordb.Redis.SentinelNodes[sentinelNodesIndex].Host.ValueString()
 				} else {
 					host2 = nil
 				}
 				port3 := new(int64)
-				if !sentinelNodesItem.Port.IsUnknown() && !sentinelNodesItem.Port.IsNull() {
-					*port3 = sentinelNodesItem.Port.ValueInt64()
+				if !r.Config.Vectordb.Redis.SentinelNodes[sentinelNodesIndex].Port.IsUnknown() && !r.Config.Vectordb.Redis.SentinelNodes[sentinelNodesIndex].Port.IsNull() {
+					*port3 = r.Config.Vectordb.Redis.SentinelNodes[sentinelNodesIndex].Port.ValueInt64()
 				} else {
 					port3 = nil
 				}

--- a/internal/provider/gatewaypluginaisemanticresponseguard_resource.go
+++ b/internal/provider/gatewaypluginaisemanticresponseguard_resource.go
@@ -1142,7 +1142,10 @@ func (r *GatewayPluginAiSemanticResponseGuardResource) Delete(ctx context.Contex
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginaisemanticresponseguard_resource_sdk.go
+++ b/internal/provider/gatewaypluginaisemanticresponseguard_resource_sdk.go
@@ -383,8 +383,8 @@ func (r *GatewayPluginAiSemanticResponseGuardResourceModel) ToSharedAiSemanticRe
 		var after *shared.AiSemanticResponseGuardPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.AiSemanticResponseGuardPluginAfter{
 				Access: access,
@@ -393,8 +393,8 @@ func (r *GatewayPluginAiSemanticResponseGuardResourceModel) ToSharedAiSemanticRe
 		var before *shared.AiSemanticResponseGuardPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.AiSemanticResponseGuardPluginBefore{
 				Access: access1,
@@ -408,22 +408,22 @@ func (r *GatewayPluginAiSemanticResponseGuardResourceModel) ToSharedAiSemanticRe
 	var partials []shared.AiSemanticResponseGuardPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.AiSemanticResponseGuardPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -437,8 +437,8 @@ func (r *GatewayPluginAiSemanticResponseGuardResourceModel) ToSharedAiSemanticRe
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -714,15 +714,15 @@ func (r *GatewayPluginAiSemanticResponseGuardResourceModel) ToSharedAiSemanticRe
 		var allowResponses []string
 		if r.Config.Rules.AllowResponses != nil {
 			allowResponses = make([]string, 0, len(r.Config.Rules.AllowResponses))
-			for _, allowResponsesItem := range r.Config.Rules.AllowResponses {
-				allowResponses = append(allowResponses, allowResponsesItem.ValueString())
+			for allowResponsesIndex := range r.Config.Rules.AllowResponses {
+				allowResponses = append(allowResponses, r.Config.Rules.AllowResponses[allowResponsesIndex].ValueString())
 			}
 		}
 		var denyResponses []string
 		if r.Config.Rules.DenyResponses != nil {
 			denyResponses = make([]string, 0, len(r.Config.Rules.DenyResponses))
-			for _, denyResponsesItem := range r.Config.Rules.DenyResponses {
-				denyResponses = append(denyResponses, denyResponsesItem.ValueString())
+			for denyResponsesIndex := range r.Config.Rules.DenyResponses {
+				denyResponses = append(denyResponses, r.Config.Rules.DenyResponses[denyResponsesIndex].ValueString())
 			}
 		}
 		maxResponseBodySize := new(int64)
@@ -853,16 +853,16 @@ func (r *GatewayPluginAiSemanticResponseGuardResourceModel) ToSharedAiSemanticRe
 		var clusterNodes []shared.AiSemanticResponseGuardPluginClusterNodes
 		if r.Config.Vectordb.Redis.ClusterNodes != nil {
 			clusterNodes = make([]shared.AiSemanticResponseGuardPluginClusterNodes, 0, len(r.Config.Vectordb.Redis.ClusterNodes))
-			for _, clusterNodesItem := range r.Config.Vectordb.Redis.ClusterNodes {
+			for clusterNodesIndex := range r.Config.Vectordb.Redis.ClusterNodes {
 				ip := new(string)
-				if !clusterNodesItem.IP.IsUnknown() && !clusterNodesItem.IP.IsNull() {
-					*ip = clusterNodesItem.IP.ValueString()
+				if !r.Config.Vectordb.Redis.ClusterNodes[clusterNodesIndex].IP.IsUnknown() && !r.Config.Vectordb.Redis.ClusterNodes[clusterNodesIndex].IP.IsNull() {
+					*ip = r.Config.Vectordb.Redis.ClusterNodes[clusterNodesIndex].IP.ValueString()
 				} else {
 					ip = nil
 				}
 				port1 := new(int64)
-				if !clusterNodesItem.Port.IsUnknown() && !clusterNodesItem.Port.IsNull() {
-					*port1 = clusterNodesItem.Port.ValueInt64()
+				if !r.Config.Vectordb.Redis.ClusterNodes[clusterNodesIndex].Port.IsUnknown() && !r.Config.Vectordb.Redis.ClusterNodes[clusterNodesIndex].Port.IsNull() {
+					*port1 = r.Config.Vectordb.Redis.ClusterNodes[clusterNodesIndex].Port.ValueInt64()
 				} else {
 					port1 = nil
 				}
@@ -941,16 +941,16 @@ func (r *GatewayPluginAiSemanticResponseGuardResourceModel) ToSharedAiSemanticRe
 		var sentinelNodes []shared.AiSemanticResponseGuardPluginSentinelNodes
 		if r.Config.Vectordb.Redis.SentinelNodes != nil {
 			sentinelNodes = make([]shared.AiSemanticResponseGuardPluginSentinelNodes, 0, len(r.Config.Vectordb.Redis.SentinelNodes))
-			for _, sentinelNodesItem := range r.Config.Vectordb.Redis.SentinelNodes {
+			for sentinelNodesIndex := range r.Config.Vectordb.Redis.SentinelNodes {
 				host2 := new(string)
-				if !sentinelNodesItem.Host.IsUnknown() && !sentinelNodesItem.Host.IsNull() {
-					*host2 = sentinelNodesItem.Host.ValueString()
+				if !r.Config.Vectordb.Redis.SentinelNodes[sentinelNodesIndex].Host.IsUnknown() && !r.Config.Vectordb.Redis.SentinelNodes[sentinelNodesIndex].Host.IsNull() {
+					*host2 = r.Config.Vectordb.Redis.SentinelNodes[sentinelNodesIndex].Host.ValueString()
 				} else {
 					host2 = nil
 				}
 				port3 := new(int64)
-				if !sentinelNodesItem.Port.IsUnknown() && !sentinelNodesItem.Port.IsNull() {
-					*port3 = sentinelNodesItem.Port.ValueInt64()
+				if !r.Config.Vectordb.Redis.SentinelNodes[sentinelNodesIndex].Port.IsUnknown() && !r.Config.Vectordb.Redis.SentinelNodes[sentinelNodesIndex].Port.IsNull() {
+					*port3 = r.Config.Vectordb.Redis.SentinelNodes[sentinelNodesIndex].Port.ValueInt64()
 				} else {
 					port3 = nil
 				}

--- a/internal/provider/gatewaypluginappdynamics_resource.go
+++ b/internal/provider/gatewaypluginappdynamics_resource.go
@@ -475,7 +475,10 @@ func (r *GatewayPluginAppDynamicsResource) Delete(ctx context.Context, req resou
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginappdynamics_resource_sdk.go
+++ b/internal/provider/gatewaypluginappdynamics_resource_sdk.go
@@ -210,8 +210,8 @@ func (r *GatewayPluginAppDynamicsResourceModel) ToSharedAppDynamicsPlugin(ctx co
 		var after *shared.AppDynamicsPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.AppDynamicsPluginAfter{
 				Access: access,
@@ -220,8 +220,8 @@ func (r *GatewayPluginAppDynamicsResourceModel) ToSharedAppDynamicsPlugin(ctx co
 		var before *shared.AppDynamicsPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.AppDynamicsPluginBefore{
 				Access: access1,
@@ -235,22 +235,22 @@ func (r *GatewayPluginAppDynamicsResourceModel) ToSharedAppDynamicsPlugin(ctx co
 	var partials []shared.AppDynamicsPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.AppDynamicsPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -264,8 +264,8 @@ func (r *GatewayPluginAppDynamicsResourceModel) ToSharedAppDynamicsPlugin(ctx co
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -277,9 +277,9 @@ func (r *GatewayPluginAppDynamicsResourceModel) ToSharedAppDynamicsPlugin(ctx co
 	var config map[string]interface{}
 	if r.Config != nil {
 		config = make(map[string]interface{})
-		for configKey, configValue := range r.Config {
+		for configKey := range r.Config {
 			var configInst interface{}
-			_ = json.Unmarshal([]byte(configValue.ValueString()), &configInst)
+			_ = json.Unmarshal([]byte(r.Config[configKey].ValueString()), &configInst)
 			config[configKey] = configInst
 		}
 	}

--- a/internal/provider/gatewaypluginawslambda_resource.go
+++ b/internal/provider/gatewaypluginawslambda_resource.go
@@ -687,7 +687,10 @@ func (r *GatewayPluginAwsLambdaResource) Delete(ctx context.Context, req resourc
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginawslambda_resource_sdk.go
+++ b/internal/provider/gatewaypluginawslambda_resource_sdk.go
@@ -254,8 +254,8 @@ func (r *GatewayPluginAwsLambdaResourceModel) ToSharedAwsLambdaPlugin(ctx contex
 		var after *shared.AwsLambdaPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.AwsLambdaPluginAfter{
 				Access: access,
@@ -264,8 +264,8 @@ func (r *GatewayPluginAwsLambdaResourceModel) ToSharedAwsLambdaPlugin(ctx contex
 		var before *shared.AwsLambdaPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.AwsLambdaPluginBefore{
 				Access: access1,
@@ -279,22 +279,22 @@ func (r *GatewayPluginAwsLambdaResourceModel) ToSharedAwsLambdaPlugin(ctx contex
 	var partials []shared.AwsLambdaPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.AwsLambdaPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -308,8 +308,8 @@ func (r *GatewayPluginAwsLambdaResourceModel) ToSharedAwsLambdaPlugin(ctx contex
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)

--- a/internal/provider/gatewaypluginazurefunctions_resource.go
+++ b/internal/provider/gatewaypluginazurefunctions_resource.go
@@ -524,7 +524,10 @@ func (r *GatewayPluginAzureFunctionsResource) Delete(ctx context.Context, req re
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginazurefunctions_resource_sdk.go
+++ b/internal/provider/gatewaypluginazurefunctions_resource_sdk.go
@@ -211,8 +211,8 @@ func (r *GatewayPluginAzureFunctionsResourceModel) ToSharedAzureFunctionsPlugin(
 		var after *shared.AzureFunctionsPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.AzureFunctionsPluginAfter{
 				Access: access,
@@ -221,8 +221,8 @@ func (r *GatewayPluginAzureFunctionsResourceModel) ToSharedAzureFunctionsPlugin(
 		var before *shared.AzureFunctionsPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.AzureFunctionsPluginBefore{
 				Access: access1,
@@ -236,22 +236,22 @@ func (r *GatewayPluginAzureFunctionsResourceModel) ToSharedAzureFunctionsPlugin(
 	var partials []shared.AzureFunctionsPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.AzureFunctionsPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -265,8 +265,8 @@ func (r *GatewayPluginAzureFunctionsResourceModel) ToSharedAzureFunctionsPlugin(
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)

--- a/internal/provider/gatewaypluginbasicauth_resource.go
+++ b/internal/provider/gatewaypluginbasicauth_resource.go
@@ -480,7 +480,10 @@ func (r *GatewayPluginBasicAuthResource) Delete(ctx context.Context, req resourc
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginbasicauth_resource_sdk.go
+++ b/internal/provider/gatewaypluginbasicauth_resource_sdk.go
@@ -203,8 +203,8 @@ func (r *GatewayPluginBasicAuthResourceModel) ToSharedBasicAuthPlugin(ctx contex
 		var after *shared.BasicAuthPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.BasicAuthPluginAfter{
 				Access: access,
@@ -213,8 +213,8 @@ func (r *GatewayPluginBasicAuthResourceModel) ToSharedBasicAuthPlugin(ctx contex
 		var before *shared.BasicAuthPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.BasicAuthPluginBefore{
 				Access: access1,
@@ -228,22 +228,22 @@ func (r *GatewayPluginBasicAuthResourceModel) ToSharedBasicAuthPlugin(ctx contex
 	var partials []shared.BasicAuthPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.BasicAuthPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -257,8 +257,8 @@ func (r *GatewayPluginBasicAuthResourceModel) ToSharedBasicAuthPlugin(ctx contex
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)

--- a/internal/provider/gatewaypluginbotdetection_resource.go
+++ b/internal/provider/gatewaypluginbotdetection_resource.go
@@ -479,7 +479,10 @@ func (r *GatewayPluginBotDetectionResource) Delete(ctx context.Context, req reso
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginbotdetection_resource_sdk.go
+++ b/internal/provider/gatewaypluginbotdetection_resource_sdk.go
@@ -208,8 +208,8 @@ func (r *GatewayPluginBotDetectionResourceModel) ToSharedBotDetectionPlugin(ctx 
 		var after *shared.BotDetectionPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.BotDetectionPluginAfter{
 				Access: access,
@@ -218,8 +218,8 @@ func (r *GatewayPluginBotDetectionResourceModel) ToSharedBotDetectionPlugin(ctx 
 		var before *shared.BotDetectionPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.BotDetectionPluginBefore{
 				Access: access1,
@@ -233,22 +233,22 @@ func (r *GatewayPluginBotDetectionResourceModel) ToSharedBotDetectionPlugin(ctx 
 	var partials []shared.BotDetectionPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.BotDetectionPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -262,8 +262,8 @@ func (r *GatewayPluginBotDetectionResourceModel) ToSharedBotDetectionPlugin(ctx 
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -275,12 +275,12 @@ func (r *GatewayPluginBotDetectionResourceModel) ToSharedBotDetectionPlugin(ctx 
 	var config *shared.BotDetectionPluginConfig
 	if r.Config != nil {
 		allow := make([]string, 0, len(r.Config.Allow))
-		for _, allowItem := range r.Config.Allow {
-			allow = append(allow, allowItem.ValueString())
+		for allowIndex := range r.Config.Allow {
+			allow = append(allow, r.Config.Allow[allowIndex].ValueString())
 		}
 		deny := make([]string, 0, len(r.Config.Deny))
-		for _, denyItem := range r.Config.Deny {
-			deny = append(deny, denyItem.ValueString())
+		for denyIndex := range r.Config.Deny {
+			deny = append(deny, r.Config.Deny[denyIndex].ValueString())
 		}
 		config = &shared.BotDetectionPluginConfig{
 			Allow: allow,

--- a/internal/provider/gatewayplugincanary_resource.go
+++ b/internal/provider/gatewayplugincanary_resource.go
@@ -563,7 +563,10 @@ func (r *GatewayPluginCanaryResource) Delete(ctx context.Context, req resource.D
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewayplugincanary_resource_sdk.go
+++ b/internal/provider/gatewayplugincanary_resource_sdk.go
@@ -221,8 +221,8 @@ func (r *GatewayPluginCanaryResourceModel) ToSharedCanaryPlugin(ctx context.Cont
 		var after *shared.CanaryPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.CanaryPluginAfter{
 				Access: access,
@@ -231,8 +231,8 @@ func (r *GatewayPluginCanaryResourceModel) ToSharedCanaryPlugin(ctx context.Cont
 		var before *shared.CanaryPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.CanaryPluginBefore{
 				Access: access1,
@@ -246,22 +246,22 @@ func (r *GatewayPluginCanaryResourceModel) ToSharedCanaryPlugin(ctx context.Cont
 	var partials []shared.CanaryPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.CanaryPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -275,8 +275,8 @@ func (r *GatewayPluginCanaryResourceModel) ToSharedCanaryPlugin(ctx context.Cont
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -302,8 +302,8 @@ func (r *GatewayPluginCanaryResourceModel) ToSharedCanaryPlugin(ctx context.Cont
 		var groups []string
 		if r.Config.Groups != nil {
 			groups = make([]string, 0, len(r.Config.Groups))
-			for _, groupsItem := range r.Config.Groups {
-				groups = append(groups, groupsItem.ValueString())
+			for groupsIndex := range r.Config.Groups {
+				groups = append(groups, r.Config.Groups[groupsIndex].ValueString())
 			}
 		}
 		hash := new(shared.Hash)

--- a/internal/provider/gatewaypluginconfluent_resource.go
+++ b/internal/provider/gatewaypluginconfluent_resource.go
@@ -1046,7 +1046,10 @@ func (r *GatewayPluginConfluentResource) Delete(ctx context.Context, req resourc
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginconfluent_resource_sdk.go
+++ b/internal/provider/gatewaypluginconfluent_resource_sdk.go
@@ -356,8 +356,8 @@ func (r *GatewayPluginConfluentResourceModel) ToSharedConfluentPlugin(ctx contex
 		var after *shared.ConfluentPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.ConfluentPluginAfter{
 				Access: access,
@@ -366,8 +366,8 @@ func (r *GatewayPluginConfluentResourceModel) ToSharedConfluentPlugin(ctx contex
 		var before *shared.ConfluentPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.ConfluentPluginBefore{
 				Access: access1,
@@ -381,22 +381,22 @@ func (r *GatewayPluginConfluentResourceModel) ToSharedConfluentPlugin(ctx contex
 	var partials []shared.ConfluentPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.ConfluentPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -410,8 +410,8 @@ func (r *GatewayPluginConfluentResourceModel) ToSharedConfluentPlugin(ctx contex
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -423,19 +423,19 @@ func (r *GatewayPluginConfluentResourceModel) ToSharedConfluentPlugin(ctx contex
 	var allowedTopics []string
 	if r.Config.AllowedTopics != nil {
 		allowedTopics = make([]string, 0, len(r.Config.AllowedTopics))
-		for _, allowedTopicsItem := range r.Config.AllowedTopics {
-			allowedTopics = append(allowedTopics, allowedTopicsItem.ValueString())
+		for allowedTopicsIndex := range r.Config.AllowedTopics {
+			allowedTopics = append(allowedTopics, r.Config.AllowedTopics[allowedTopicsIndex].ValueString())
 		}
 	}
 	var bootstrapServers []shared.BootstrapServers
 	if r.Config.BootstrapServers != nil {
 		bootstrapServers = make([]shared.BootstrapServers, 0, len(r.Config.BootstrapServers))
-		for _, bootstrapServersItem := range r.Config.BootstrapServers {
+		for bootstrapServersIndex := range r.Config.BootstrapServers {
 			var host string
-			host = bootstrapServersItem.Host.ValueString()
+			host = r.Config.BootstrapServers[bootstrapServersIndex].Host.ValueString()
 
 			var port int64
-			port = bootstrapServersItem.Port.ValueInt64()
+			port = r.Config.BootstrapServers[bootstrapServersIndex].Port.ValueInt64()
 
 			bootstrapServers = append(bootstrapServers, shared.BootstrapServers{
 				Host: host,
@@ -512,8 +512,8 @@ func (r *GatewayPluginConfluentResourceModel) ToSharedConfluentPlugin(ctx contex
 	var messageByLuaFunctions []string
 	if r.Config.MessageByLuaFunctions != nil {
 		messageByLuaFunctions = make([]string, 0, len(r.Config.MessageByLuaFunctions))
-		for _, messageByLuaFunctionsItem := range r.Config.MessageByLuaFunctions {
-			messageByLuaFunctions = append(messageByLuaFunctions, messageByLuaFunctionsItem.ValueString())
+		for messageByLuaFunctionsIndex := range r.Config.MessageByLuaFunctions {
+			messageByLuaFunctions = append(messageByLuaFunctions, r.Config.MessageByLuaFunctions[messageByLuaFunctionsIndex].ValueString())
 		}
 	}
 	producerAsync := new(bool)
@@ -598,8 +598,8 @@ func (r *GatewayPluginConfluentResourceModel) ToSharedConfluentPlugin(ctx contex
 				var oauth2 *shared.Oauth2
 				if r.Config.SchemaRegistry.Confluent.Authentication.Oauth2 != nil {
 					audience := make([]string, 0, len(r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.Audience))
-					for _, audienceItem := range r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.Audience {
-						audience = append(audience, audienceItem.ValueString())
+					for audienceIndex := range r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.Audience {
+						audience = append(audience, r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.Audience[audienceIndex].ValueString())
 					}
 					clientID := new(string)
 					if !r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.ClientID.IsUnknown() && !r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.ClientID.IsNull() {
@@ -626,8 +626,8 @@ func (r *GatewayPluginConfluentResourceModel) ToSharedConfluentPlugin(ctx contex
 						password1 = nil
 					}
 					scopes := make([]string, 0, len(r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.Scopes))
-					for _, scopesItem := range r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.Scopes {
-						scopes = append(scopes, scopesItem.ValueString())
+					for scopesIndex := range r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.Scopes {
+						scopes = append(scopes, r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.Scopes[scopesIndex].ValueString())
 					}
 					var tokenEndpoint string
 					tokenEndpoint = r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.TokenEndpoint.ValueString()
@@ -635,9 +635,9 @@ func (r *GatewayPluginConfluentResourceModel) ToSharedConfluentPlugin(ctx contex
 					var tokenHeaders map[string]string
 					if r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.TokenHeaders != nil {
 						tokenHeaders = make(map[string]string)
-						for tokenHeadersKey, tokenHeadersValue := range r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.TokenHeaders {
+						for tokenHeadersKey := range r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.TokenHeaders {
 							var tokenHeadersInst string
-							tokenHeadersInst = tokenHeadersValue.ValueString()
+							tokenHeadersInst = r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.TokenHeaders[tokenHeadersKey].ValueString()
 
 							tokenHeaders[tokenHeadersKey] = tokenHeadersInst
 						}
@@ -645,9 +645,9 @@ func (r *GatewayPluginConfluentResourceModel) ToSharedConfluentPlugin(ctx contex
 					var tokenPostArgs map[string]string
 					if r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.TokenPostArgs != nil {
 						tokenPostArgs = make(map[string]string)
-						for tokenPostArgsKey, tokenPostArgsValue := range r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.TokenPostArgs {
+						for tokenPostArgsKey := range r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.TokenPostArgs {
 							var tokenPostArgsInst string
-							tokenPostArgsInst = tokenPostArgsValue.ValueString()
+							tokenPostArgsInst = r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.TokenPostArgs[tokenPostArgsKey].ValueString()
 
 							tokenPostArgs[tokenPostArgsKey] = tokenPostArgsInst
 						}

--- a/internal/provider/gatewaypluginconfluentconsume_resource.go
+++ b/internal/provider/gatewaypluginconfluentconsume_resource.go
@@ -1428,7 +1428,10 @@ func (r *GatewayPluginConfluentConsumeResource) Delete(ctx context.Context, req 
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginconfluentconsume_resource_sdk.go
+++ b/internal/provider/gatewaypluginconfluentconsume_resource_sdk.go
@@ -436,8 +436,8 @@ func (r *GatewayPluginConfluentConsumeResourceModel) ToSharedConfluentConsumePlu
 		var after *shared.ConfluentConsumePluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.ConfluentConsumePluginAfter{
 				Access: access,
@@ -446,8 +446,8 @@ func (r *GatewayPluginConfluentConsumeResourceModel) ToSharedConfluentConsumePlu
 		var before *shared.ConfluentConsumePluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.ConfluentConsumePluginBefore{
 				Access: access1,
@@ -461,22 +461,22 @@ func (r *GatewayPluginConfluentConsumeResourceModel) ToSharedConfluentConsumePlu
 	var partials []shared.ConfluentConsumePluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.ConfluentConsumePluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -490,8 +490,8 @@ func (r *GatewayPluginConfluentConsumeResourceModel) ToSharedConfluentConsumePlu
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -509,12 +509,12 @@ func (r *GatewayPluginConfluentConsumeResourceModel) ToSharedConfluentConsumePlu
 	var bootstrapServers []shared.ConfluentConsumePluginBootstrapServers
 	if r.Config.BootstrapServers != nil {
 		bootstrapServers = make([]shared.ConfluentConsumePluginBootstrapServers, 0, len(r.Config.BootstrapServers))
-		for _, bootstrapServersItem := range r.Config.BootstrapServers {
+		for bootstrapServersIndex := range r.Config.BootstrapServers {
 			var host string
-			host = bootstrapServersItem.Host.ValueString()
+			host = r.Config.BootstrapServers[bootstrapServersIndex].Host.ValueString()
 
 			var port int64
-			port = bootstrapServersItem.Port.ValueInt64()
+			port = r.Config.BootstrapServers[bootstrapServersIndex].Port.ValueInt64()
 
 			bootstrapServers = append(bootstrapServers, shared.ConfluentConsumePluginBootstrapServers{
 				Host: host,
@@ -579,8 +579,8 @@ func (r *GatewayPluginConfluentConsumeResourceModel) ToSharedConfluentConsumePlu
 	var messageByLuaFunctions []string
 	if r.Config.MessageByLuaFunctions != nil {
 		messageByLuaFunctions = make([]string, 0, len(r.Config.MessageByLuaFunctions))
-		for _, messageByLuaFunctionsItem := range r.Config.MessageByLuaFunctions {
-			messageByLuaFunctions = append(messageByLuaFunctions, messageByLuaFunctionsItem.ValueString())
+		for messageByLuaFunctionsIndex := range r.Config.MessageByLuaFunctions {
+			messageByLuaFunctions = append(messageByLuaFunctions, r.Config.MessageByLuaFunctions[messageByLuaFunctionsIndex].ValueString())
 		}
 	}
 	messageDeserializer := new(shared.MessageDeserializer)
@@ -623,8 +623,8 @@ func (r *GatewayPluginConfluentConsumeResourceModel) ToSharedConfluentConsumePlu
 				var oauth2 *shared.ConfluentConsumePluginOauth2
 				if r.Config.SchemaRegistry.Confluent.Authentication.Oauth2 != nil {
 					audience := make([]string, 0, len(r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.Audience))
-					for _, audienceItem := range r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.Audience {
-						audience = append(audience, audienceItem.ValueString())
+					for audienceIndex := range r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.Audience {
+						audience = append(audience, r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.Audience[audienceIndex].ValueString())
 					}
 					clientID := new(string)
 					if !r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.ClientID.IsUnknown() && !r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.ClientID.IsNull() {
@@ -651,8 +651,8 @@ func (r *GatewayPluginConfluentConsumeResourceModel) ToSharedConfluentConsumePlu
 						password1 = nil
 					}
 					scopes := make([]string, 0, len(r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.Scopes))
-					for _, scopesItem := range r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.Scopes {
-						scopes = append(scopes, scopesItem.ValueString())
+					for scopesIndex := range r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.Scopes {
+						scopes = append(scopes, r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.Scopes[scopesIndex].ValueString())
 					}
 					var tokenEndpoint string
 					tokenEndpoint = r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.TokenEndpoint.ValueString()
@@ -660,9 +660,9 @@ func (r *GatewayPluginConfluentConsumeResourceModel) ToSharedConfluentConsumePlu
 					var tokenHeaders map[string]string
 					if r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.TokenHeaders != nil {
 						tokenHeaders = make(map[string]string)
-						for tokenHeadersKey, tokenHeadersValue := range r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.TokenHeaders {
+						for tokenHeadersKey := range r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.TokenHeaders {
 							var tokenHeadersInst string
-							tokenHeadersInst = tokenHeadersValue.ValueString()
+							tokenHeadersInst = r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.TokenHeaders[tokenHeadersKey].ValueString()
 
 							tokenHeaders[tokenHeadersKey] = tokenHeadersInst
 						}
@@ -670,9 +670,9 @@ func (r *GatewayPluginConfluentConsumeResourceModel) ToSharedConfluentConsumePlu
 					var tokenPostArgs map[string]string
 					if r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.TokenPostArgs != nil {
 						tokenPostArgs = make(map[string]string)
-						for tokenPostArgsKey, tokenPostArgsValue := range r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.TokenPostArgs {
+						for tokenPostArgsKey := range r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.TokenPostArgs {
 							var tokenPostArgsInst string
-							tokenPostArgsInst = tokenPostArgsValue.ValueString()
+							tokenPostArgsInst = r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.TokenPostArgs[tokenPostArgsKey].ValueString()
 
 							tokenPostArgs[tokenPostArgsKey] = tokenPostArgsInst
 						}
@@ -821,23 +821,23 @@ func (r *GatewayPluginConfluentConsumeResourceModel) ToSharedConfluentConsumePlu
 		timeout1 = nil
 	}
 	topics := make([]shared.Topics, 0, len(r.Config.Topics))
-	for _, topicsItem := range r.Config.Topics {
+	for topicsIndex := range r.Config.Topics {
 		var name1 string
-		name1 = topicsItem.Name.ValueString()
+		name1 = r.Config.Topics[topicsIndex].Name.ValueString()
 
 		var schemaRegistry1 *shared.ConfluentConsumePluginConfigSchemaRegistry
-		if topicsItem.SchemaRegistry != nil {
+		if r.Config.Topics[topicsIndex].SchemaRegistry != nil {
 			var confluent1 *shared.ConfluentConsumePluginConfigConfluent
-			if topicsItem.SchemaRegistry.Confluent != nil {
+			if r.Config.Topics[topicsIndex].SchemaRegistry.Confluent != nil {
 				var authentication1 *shared.ConfluentConsumePluginConfigAuthentication
-				if topicsItem.SchemaRegistry.Confluent.Authentication != nil {
+				if r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication != nil {
 					var basic1 *shared.ConfluentConsumePluginConfigBasic
-					if topicsItem.SchemaRegistry.Confluent.Authentication.Basic != nil {
+					if r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Basic != nil {
 						var password2 string
-						password2 = topicsItem.SchemaRegistry.Confluent.Authentication.Basic.Password.ValueString()
+						password2 = r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Basic.Password.ValueString()
 
 						var username2 string
-						username2 = topicsItem.SchemaRegistry.Confluent.Authentication.Basic.Username.ValueString()
+						username2 = r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Basic.Username.ValueString()
 
 						basic1 = &shared.ConfluentConsumePluginConfigBasic{
 							Password: password2,
@@ -845,71 +845,71 @@ func (r *GatewayPluginConfluentConsumeResourceModel) ToSharedConfluentConsumePlu
 						}
 					}
 					mode2 := new(shared.ConfluentConsumePluginConfigTopicsMode)
-					if !topicsItem.SchemaRegistry.Confluent.Authentication.Mode.IsUnknown() && !topicsItem.SchemaRegistry.Confluent.Authentication.Mode.IsNull() {
-						*mode2 = shared.ConfluentConsumePluginConfigTopicsMode(topicsItem.SchemaRegistry.Confluent.Authentication.Mode.ValueString())
+					if !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Mode.IsUnknown() && !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Mode.IsNull() {
+						*mode2 = shared.ConfluentConsumePluginConfigTopicsMode(r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Mode.ValueString())
 					} else {
 						mode2 = nil
 					}
 					var oauth21 *shared.ConfluentConsumePluginConfigOauth2
-					if topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2 != nil {
-						audience1 := make([]string, 0, len(topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2.Audience))
-						for _, audienceItem1 := range topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2.Audience {
-							audience1 = append(audience1, audienceItem1.ValueString())
+					if r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2 != nil {
+						audience1 := make([]string, 0, len(r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.Audience))
+						for audienceIndex1 := range r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.Audience {
+							audience1 = append(audience1, r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.Audience[audienceIndex1].ValueString())
 						}
 						clientId1 := new(string)
-						if !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2.ClientID.IsUnknown() && !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2.ClientID.IsNull() {
-							*clientId1 = topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2.ClientID.ValueString()
+						if !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.ClientID.IsUnknown() && !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.ClientID.IsNull() {
+							*clientId1 = r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.ClientID.ValueString()
 						} else {
 							clientId1 = nil
 						}
 						clientSecret1 := new(string)
-						if !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2.ClientSecret.IsUnknown() && !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2.ClientSecret.IsNull() {
-							*clientSecret1 = topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2.ClientSecret.ValueString()
+						if !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.ClientSecret.IsUnknown() && !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.ClientSecret.IsNull() {
+							*clientSecret1 = r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.ClientSecret.ValueString()
 						} else {
 							clientSecret1 = nil
 						}
 						grantType1 := new(shared.ConfluentConsumePluginConfigGrantType)
-						if !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2.GrantType.IsUnknown() && !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2.GrantType.IsNull() {
-							*grantType1 = shared.ConfluentConsumePluginConfigGrantType(topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2.GrantType.ValueString())
+						if !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.GrantType.IsUnknown() && !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.GrantType.IsNull() {
+							*grantType1 = shared.ConfluentConsumePluginConfigGrantType(r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.GrantType.ValueString())
 						} else {
 							grantType1 = nil
 						}
 						password3 := new(string)
-						if !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2.Password.IsUnknown() && !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2.Password.IsNull() {
-							*password3 = topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2.Password.ValueString()
+						if !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.Password.IsUnknown() && !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.Password.IsNull() {
+							*password3 = r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.Password.ValueString()
 						} else {
 							password3 = nil
 						}
-						scopes1 := make([]string, 0, len(topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2.Scopes))
-						for _, scopesItem1 := range topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2.Scopes {
-							scopes1 = append(scopes1, scopesItem1.ValueString())
+						scopes1 := make([]string, 0, len(r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.Scopes))
+						for scopesIndex1 := range r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.Scopes {
+							scopes1 = append(scopes1, r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.Scopes[scopesIndex1].ValueString())
 						}
 						var tokenEndpoint1 string
-						tokenEndpoint1 = topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2.TokenEndpoint.ValueString()
+						tokenEndpoint1 = r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.TokenEndpoint.ValueString()
 
 						var tokenHeaders1 map[string]string
-						if topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2.TokenHeaders != nil {
+						if r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.TokenHeaders != nil {
 							tokenHeaders1 = make(map[string]string)
-							for tokenHeadersKey1, tokenHeadersValue1 := range topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2.TokenHeaders {
+							for tokenHeadersKey1 := range r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.TokenHeaders {
 								var tokenHeadersInst1 string
-								tokenHeadersInst1 = tokenHeadersValue1.ValueString()
+								tokenHeadersInst1 = r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.TokenHeaders[tokenHeadersKey1].ValueString()
 
 								tokenHeaders1[tokenHeadersKey1] = tokenHeadersInst1
 							}
 						}
 						var tokenPostArgs1 map[string]string
-						if topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2.TokenPostArgs != nil {
+						if r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.TokenPostArgs != nil {
 							tokenPostArgs1 = make(map[string]string)
-							for tokenPostArgsKey1, tokenPostArgsValue1 := range topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2.TokenPostArgs {
+							for tokenPostArgsKey1 := range r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.TokenPostArgs {
 								var tokenPostArgsInst1 string
-								tokenPostArgsInst1 = tokenPostArgsValue1.ValueString()
+								tokenPostArgsInst1 = r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.TokenPostArgs[tokenPostArgsKey1].ValueString()
 
 								tokenPostArgs1[tokenPostArgsKey1] = tokenPostArgsInst1
 							}
 						}
 						username3 := new(string)
-						if !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2.Username.IsUnknown() && !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2.Username.IsNull() {
-							*username3 = topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2.Username.ValueString()
+						if !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.Username.IsUnknown() && !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.Username.IsNull() {
+							*username3 = r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.Username.ValueString()
 						} else {
 							username3 = nil
 						}
@@ -927,70 +927,70 @@ func (r *GatewayPluginConfluentConsumeResourceModel) ToSharedConfluentConsumePlu
 						}
 					}
 					var oauth2Client1 *shared.ConfluentConsumePluginConfigOauth2Client
-					if topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client != nil {
+					if r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client != nil {
 						authMethod1 := new(shared.ConfluentConsumePluginConfigAuthMethod)
-						if !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.AuthMethod.IsUnknown() && !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.AuthMethod.IsNull() {
-							*authMethod1 = shared.ConfluentConsumePluginConfigAuthMethod(topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.AuthMethod.ValueString())
+						if !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.AuthMethod.IsUnknown() && !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.AuthMethod.IsNull() {
+							*authMethod1 = shared.ConfluentConsumePluginConfigAuthMethod(r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.AuthMethod.ValueString())
 						} else {
 							authMethod1 = nil
 						}
 						clientSecretJwtAlg1 := new(shared.ConfluentConsumePluginConfigClientSecretJwtAlg)
-						if !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.ClientSecretJwtAlg.IsUnknown() && !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.ClientSecretJwtAlg.IsNull() {
-							*clientSecretJwtAlg1 = shared.ConfluentConsumePluginConfigClientSecretJwtAlg(topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.ClientSecretJwtAlg.ValueString())
+						if !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.ClientSecretJwtAlg.IsUnknown() && !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.ClientSecretJwtAlg.IsNull() {
+							*clientSecretJwtAlg1 = shared.ConfluentConsumePluginConfigClientSecretJwtAlg(r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.ClientSecretJwtAlg.ValueString())
 						} else {
 							clientSecretJwtAlg1 = nil
 						}
 						httpProxy1 := new(string)
-						if !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPProxy.IsUnknown() && !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPProxy.IsNull() {
-							*httpProxy1 = topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPProxy.ValueString()
+						if !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPProxy.IsUnknown() && !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPProxy.IsNull() {
+							*httpProxy1 = r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPProxy.ValueString()
 						} else {
 							httpProxy1 = nil
 						}
 						httpProxyAuthorization1 := new(string)
-						if !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPProxyAuthorization.IsUnknown() && !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPProxyAuthorization.IsNull() {
-							*httpProxyAuthorization1 = topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPProxyAuthorization.ValueString()
+						if !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPProxyAuthorization.IsUnknown() && !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPProxyAuthorization.IsNull() {
+							*httpProxyAuthorization1 = r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPProxyAuthorization.ValueString()
 						} else {
 							httpProxyAuthorization1 = nil
 						}
 						httpVersion1 := new(float64)
-						if !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPVersion.IsUnknown() && !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPVersion.IsNull() {
-							*httpVersion1 = topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPVersion.ValueFloat64()
+						if !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPVersion.IsUnknown() && !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPVersion.IsNull() {
+							*httpVersion1 = r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPVersion.ValueFloat64()
 						} else {
 							httpVersion1 = nil
 						}
 						httpsProxy1 := new(string)
-						if !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPSProxy.IsUnknown() && !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPSProxy.IsNull() {
-							*httpsProxy1 = topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPSProxy.ValueString()
+						if !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPSProxy.IsUnknown() && !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPSProxy.IsNull() {
+							*httpsProxy1 = r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPSProxy.ValueString()
 						} else {
 							httpsProxy1 = nil
 						}
 						httpsProxyAuthorization1 := new(string)
-						if !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPSProxyAuthorization.IsUnknown() && !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPSProxyAuthorization.IsNull() {
-							*httpsProxyAuthorization1 = topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPSProxyAuthorization.ValueString()
+						if !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPSProxyAuthorization.IsUnknown() && !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPSProxyAuthorization.IsNull() {
+							*httpsProxyAuthorization1 = r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPSProxyAuthorization.ValueString()
 						} else {
 							httpsProxyAuthorization1 = nil
 						}
 						keepAlive1 := new(bool)
-						if !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.KeepAlive.IsUnknown() && !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.KeepAlive.IsNull() {
-							*keepAlive1 = topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.KeepAlive.ValueBool()
+						if !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.KeepAlive.IsUnknown() && !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.KeepAlive.IsNull() {
+							*keepAlive1 = r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.KeepAlive.ValueBool()
 						} else {
 							keepAlive1 = nil
 						}
 						noProxy1 := new(string)
-						if !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.NoProxy.IsUnknown() && !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.NoProxy.IsNull() {
-							*noProxy1 = topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.NoProxy.ValueString()
+						if !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.NoProxy.IsUnknown() && !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.NoProxy.IsNull() {
+							*noProxy1 = r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.NoProxy.ValueString()
 						} else {
 							noProxy1 = nil
 						}
 						sslVerify2 := new(bool)
-						if !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.SslVerify.IsUnknown() && !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.SslVerify.IsNull() {
-							*sslVerify2 = topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.SslVerify.ValueBool()
+						if !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.SslVerify.IsUnknown() && !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.SslVerify.IsNull() {
+							*sslVerify2 = r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.SslVerify.ValueBool()
 						} else {
 							sslVerify2 = nil
 						}
 						timeout2 := new(int64)
-						if !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.Timeout.IsUnknown() && !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.Timeout.IsNull() {
-							*timeout2 = topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.Timeout.ValueInt64()
+						if !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.Timeout.IsUnknown() && !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.Timeout.IsNull() {
+							*timeout2 = r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.Timeout.ValueInt64()
 						} else {
 							timeout2 = nil
 						}
@@ -1016,20 +1016,20 @@ func (r *GatewayPluginConfluentConsumeResourceModel) ToSharedConfluentConsumePlu
 					}
 				}
 				sslVerify3 := new(bool)
-				if !topicsItem.SchemaRegistry.Confluent.SslVerify.IsUnknown() && !topicsItem.SchemaRegistry.Confluent.SslVerify.IsNull() {
-					*sslVerify3 = topicsItem.SchemaRegistry.Confluent.SslVerify.ValueBool()
+				if !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.SslVerify.IsUnknown() && !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.SslVerify.IsNull() {
+					*sslVerify3 = r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.SslVerify.ValueBool()
 				} else {
 					sslVerify3 = nil
 				}
 				ttl1 := new(float64)
-				if !topicsItem.SchemaRegistry.Confluent.TTL.IsUnknown() && !topicsItem.SchemaRegistry.Confluent.TTL.IsNull() {
-					*ttl1 = topicsItem.SchemaRegistry.Confluent.TTL.ValueFloat64()
+				if !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.TTL.IsUnknown() && !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.TTL.IsNull() {
+					*ttl1 = r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.TTL.ValueFloat64()
 				} else {
 					ttl1 = nil
 				}
 				url1 := new(string)
-				if !topicsItem.SchemaRegistry.Confluent.URL.IsUnknown() && !topicsItem.SchemaRegistry.Confluent.URL.IsNull() {
-					*url1 = topicsItem.SchemaRegistry.Confluent.URL.ValueString()
+				if !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.URL.IsUnknown() && !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.URL.IsNull() {
+					*url1 = r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.URL.ValueString()
 				} else {
 					url1 = nil
 				}

--- a/internal/provider/gatewayplugincorrelationid_resource.go
+++ b/internal/provider/gatewayplugincorrelationid_resource.go
@@ -502,7 +502,10 @@ func (r *GatewayPluginCorrelationIDResource) Delete(ctx context.Context, req res
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewayplugincorrelationid_resource_sdk.go
+++ b/internal/provider/gatewayplugincorrelationid_resource_sdk.go
@@ -213,8 +213,8 @@ func (r *GatewayPluginCorrelationIDResourceModel) ToSharedCorrelationIDPlugin(ct
 		var after *shared.CorrelationIDPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.CorrelationIDPluginAfter{
 				Access: access,
@@ -223,8 +223,8 @@ func (r *GatewayPluginCorrelationIDResourceModel) ToSharedCorrelationIDPlugin(ct
 		var before *shared.CorrelationIDPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.CorrelationIDPluginBefore{
 				Access: access1,
@@ -238,22 +238,22 @@ func (r *GatewayPluginCorrelationIDResourceModel) ToSharedCorrelationIDPlugin(ct
 	var partials []shared.CorrelationIDPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.CorrelationIDPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -267,8 +267,8 @@ func (r *GatewayPluginCorrelationIDResourceModel) ToSharedCorrelationIDPlugin(ct
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)

--- a/internal/provider/gatewayplugincors_resource.go
+++ b/internal/provider/gatewayplugincors_resource.go
@@ -536,7 +536,10 @@ func (r *GatewayPluginCorsResource) Delete(ctx context.Context, req resource.Del
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewayplugincors_resource_sdk.go
+++ b/internal/provider/gatewayplugincors_resource_sdk.go
@@ -227,8 +227,8 @@ func (r *GatewayPluginCorsResourceModel) ToSharedCorsPlugin(ctx context.Context)
 		var after *shared.CorsPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.CorsPluginAfter{
 				Access: access,
@@ -237,8 +237,8 @@ func (r *GatewayPluginCorsResourceModel) ToSharedCorsPlugin(ctx context.Context)
 		var before *shared.CorsPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.CorsPluginBefore{
 				Access: access1,
@@ -252,22 +252,22 @@ func (r *GatewayPluginCorsResourceModel) ToSharedCorsPlugin(ctx context.Context)
 	var partials []shared.CorsPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.CorsPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -281,8 +281,8 @@ func (r *GatewayPluginCorsResourceModel) ToSharedCorsPlugin(ctx context.Context)
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -308,15 +308,15 @@ func (r *GatewayPluginCorsResourceModel) ToSharedCorsPlugin(ctx context.Context)
 		var exposedHeaders []string
 		if r.Config.ExposedHeaders != nil {
 			exposedHeaders = make([]string, 0, len(r.Config.ExposedHeaders))
-			for _, exposedHeadersItem := range r.Config.ExposedHeaders {
-				exposedHeaders = append(exposedHeaders, exposedHeadersItem.ValueString())
+			for exposedHeadersIndex := range r.Config.ExposedHeaders {
+				exposedHeaders = append(exposedHeaders, r.Config.ExposedHeaders[exposedHeadersIndex].ValueString())
 			}
 		}
 		var headers []string
 		if r.Config.Headers != nil {
 			headers = make([]string, 0, len(r.Config.Headers))
-			for _, headersItem := range r.Config.Headers {
-				headers = append(headers, headersItem.ValueString())
+			for headersIndex := range r.Config.Headers {
+				headers = append(headers, r.Config.Headers[headersIndex].ValueString())
 			}
 		}
 		maxAge := new(float64)
@@ -332,8 +332,8 @@ func (r *GatewayPluginCorsResourceModel) ToSharedCorsPlugin(ctx context.Context)
 		var origins []string
 		if r.Config.Origins != nil {
 			origins = make([]string, 0, len(r.Config.Origins))
-			for _, originsItem := range r.Config.Origins {
-				origins = append(origins, originsItem.ValueString())
+			for originsIndex := range r.Config.Origins {
+				origins = append(origins, r.Config.Origins[originsIndex].ValueString())
 			}
 		}
 		preflightContinue := new(bool)

--- a/internal/provider/gatewayplugindatadog_resource.go
+++ b/internal/provider/gatewayplugindatadog_resource.go
@@ -704,7 +704,10 @@ func (r *GatewayPluginDatadogResource) Delete(ctx context.Context, req resource.
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewayplugindatadog_resource_sdk.go
+++ b/internal/provider/gatewayplugindatadog_resource_sdk.go
@@ -252,8 +252,8 @@ func (r *GatewayPluginDatadogResourceModel) ToSharedDatadogPlugin(ctx context.Co
 		var after *shared.DatadogPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.DatadogPluginAfter{
 				Access: access,
@@ -262,8 +262,8 @@ func (r *GatewayPluginDatadogResourceModel) ToSharedDatadogPlugin(ctx context.Co
 		var before *shared.DatadogPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.DatadogPluginBefore{
 				Access: access1,
@@ -277,22 +277,22 @@ func (r *GatewayPluginDatadogResourceModel) ToSharedDatadogPlugin(ctx context.Co
 	var partials []shared.DatadogPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.DatadogPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -306,8 +306,8 @@ func (r *GatewayPluginDatadogResourceModel) ToSharedDatadogPlugin(ctx context.Co
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -337,24 +337,24 @@ func (r *GatewayPluginDatadogResourceModel) ToSharedDatadogPlugin(ctx context.Co
 			host = nil
 		}
 		metrics := make([]shared.Metrics, 0, len(r.Config.Metrics))
-		for _, metricsItem := range r.Config.Metrics {
+		for metricsIndex := range r.Config.Metrics {
 			consumerIdentifier := new(shared.ConsumerIdentifier)
-			if !metricsItem.ConsumerIdentifier.IsUnknown() && !metricsItem.ConsumerIdentifier.IsNull() {
-				*consumerIdentifier = shared.ConsumerIdentifier(metricsItem.ConsumerIdentifier.ValueString())
+			if !r.Config.Metrics[metricsIndex].ConsumerIdentifier.IsUnknown() && !r.Config.Metrics[metricsIndex].ConsumerIdentifier.IsNull() {
+				*consumerIdentifier = shared.ConsumerIdentifier(r.Config.Metrics[metricsIndex].ConsumerIdentifier.ValueString())
 			} else {
 				consumerIdentifier = nil
 			}
-			name1 := shared.DatadogPluginName(metricsItem.Name.ValueString())
+			name1 := shared.DatadogPluginName(r.Config.Metrics[metricsIndex].Name.ValueString())
 			sampleRate := new(float64)
-			if !metricsItem.SampleRate.IsUnknown() && !metricsItem.SampleRate.IsNull() {
-				*sampleRate = metricsItem.SampleRate.ValueFloat64()
+			if !r.Config.Metrics[metricsIndex].SampleRate.IsUnknown() && !r.Config.Metrics[metricsIndex].SampleRate.IsNull() {
+				*sampleRate = r.Config.Metrics[metricsIndex].SampleRate.ValueFloat64()
 			} else {
 				sampleRate = nil
 			}
-			statType := shared.StatType(metricsItem.StatType.ValueString())
-			tags1 := make([]string, 0, len(metricsItem.Tags))
-			for _, tagsItem1 := range metricsItem.Tags {
-				tags1 = append(tags1, tagsItem1.ValueString())
+			statType := shared.StatType(r.Config.Metrics[metricsIndex].StatType.ValueString())
+			tags1 := make([]string, 0, len(r.Config.Metrics[metricsIndex].Tags))
+			for tagsIndex1 := range r.Config.Metrics[metricsIndex].Tags {
+				tags1 = append(tags1, r.Config.Metrics[metricsIndex].Tags[tagsIndex1].ValueString())
 			}
 			metrics = append(metrics, shared.Metrics{
 				ConsumerIdentifier: consumerIdentifier,

--- a/internal/provider/gatewayplugindatakit_resource.go
+++ b/internal/provider/gatewayplugindatakit_resource.go
@@ -88,7 +88,6 @@ func (r *GatewayPluginDatakitResource) Schema(ctx context.Context, req resource.
 							},
 							Attributes: map[string]schema.Attribute{
 								"branch": schema.SingleNestedAttribute{
-									Computed: true,
 									Optional: true,
 									Attributes: map[string]schema.Attribute{
 										"else": schema.ListAttribute{
@@ -161,7 +160,6 @@ func (r *GatewayPluginDatakitResource) Schema(ctx context.Context, req resource.
 									},
 								},
 								"cache": schema.SingleNestedAttribute{
-									Computed: true,
 									Optional: true,
 									Attributes: map[string]schema.Attribute{
 										"bypass_on_error": schema.BoolAttribute{
@@ -279,7 +277,6 @@ func (r *GatewayPluginDatakitResource) Schema(ctx context.Context, req resource.
 									},
 								},
 								"call": schema.SingleNestedAttribute{
-									Computed: true,
 									Optional: true,
 									Attributes: map[string]schema.Attribute{
 										"input": schema.StringAttribute{
@@ -411,7 +408,6 @@ func (r *GatewayPluginDatakitResource) Schema(ctx context.Context, req resource.
 									},
 								},
 								"exit": schema.SingleNestedAttribute{
-									Computed: true,
 									Optional: true,
 									Attributes: map[string]schema.Attribute{
 										"input": schema.StringAttribute{
@@ -479,7 +475,6 @@ func (r *GatewayPluginDatakitResource) Schema(ctx context.Context, req resource.
 									},
 								},
 								"jq": schema.SingleNestedAttribute{
-									Computed: true,
 									Optional: true,
 									Attributes: map[string]schema.Attribute{
 										"input": schema.StringAttribute{
@@ -531,7 +526,6 @@ func (r *GatewayPluginDatakitResource) Schema(ctx context.Context, req resource.
 									},
 								},
 								"property": schema.SingleNestedAttribute{
-									Computed: true,
 									Optional: true,
 									Attributes: map[string]schema.Attribute{
 										"content_type": schema.StringAttribute{
@@ -590,7 +584,6 @@ func (r *GatewayPluginDatakitResource) Schema(ctx context.Context, req resource.
 									},
 								},
 								"static": schema.SingleNestedAttribute{
-									Computed: true,
 									Optional: true,
 									Attributes: map[string]schema.Attribute{
 										"name": schema.StringAttribute{
@@ -1414,7 +1407,10 @@ func (r *GatewayPluginDatakitResource) Delete(ctx context.Context, req resource.
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewayplugindatakit_resource_sdk.go
+++ b/internal/provider/gatewayplugindatakit_resource_sdk.go
@@ -422,8 +422,8 @@ func (r *GatewayPluginDatakitResourceModel) ToSharedDatakitPlugin(ctx context.Co
 		var after *shared.DatakitPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.DatakitPluginAfter{
 				Access: access,
@@ -432,8 +432,8 @@ func (r *GatewayPluginDatakitResourceModel) ToSharedDatakitPlugin(ctx context.Co
 		var before *shared.DatakitPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.DatakitPluginBefore{
 				Access: access1,
@@ -447,22 +447,22 @@ func (r *GatewayPluginDatakitResourceModel) ToSharedDatakitPlugin(ctx context.Co
 	var partials []shared.DatakitPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.DatakitPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -476,8 +476,8 @@ func (r *GatewayPluginDatakitResourceModel) ToSharedDatakitPlugin(ctx context.Co
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -493,44 +493,44 @@ func (r *GatewayPluginDatakitResourceModel) ToSharedDatakitPlugin(ctx context.Co
 		debug = nil
 	}
 	nodes := make([]shared.Nodes, 0, len(r.Config.Nodes))
-	for _, nodesItem := range r.Config.Nodes {
-		if nodesItem.Branch != nil {
+	for nodesItem := range r.Config.Nodes {
+		if r.Config.Nodes[nodesItem].Branch != nil {
 			var elseVar []string
-			if nodesItem.Branch.Else != nil {
-				elseVar = make([]string, 0, len(nodesItem.Branch.Else))
-				for _, elseItem := range nodesItem.Branch.Else {
-					elseVar = append(elseVar, elseItem.ValueString())
+			if r.Config.Nodes[nodesItem].Branch.Else != nil {
+				elseVar = make([]string, 0, len(r.Config.Nodes[nodesItem].Branch.Else))
+				for elseIndex := range r.Config.Nodes[nodesItem].Branch.Else {
+					elseVar = append(elseVar, r.Config.Nodes[nodesItem].Branch.Else[elseIndex].ValueString())
 				}
 			}
 			input := new(string)
-			if !nodesItem.Branch.Input.IsUnknown() && !nodesItem.Branch.Input.IsNull() {
-				*input = nodesItem.Branch.Input.ValueString()
+			if !r.Config.Nodes[nodesItem].Branch.Input.IsUnknown() && !r.Config.Nodes[nodesItem].Branch.Input.IsNull() {
+				*input = r.Config.Nodes[nodesItem].Branch.Input.ValueString()
 			} else {
 				input = nil
 			}
 			name1 := new(string)
-			if !nodesItem.Branch.Name.IsUnknown() && !nodesItem.Branch.Name.IsNull() {
-				*name1 = nodesItem.Branch.Name.ValueString()
+			if !r.Config.Nodes[nodesItem].Branch.Name.IsUnknown() && !r.Config.Nodes[nodesItem].Branch.Name.IsNull() {
+				*name1 = r.Config.Nodes[nodesItem].Branch.Name.ValueString()
 			} else {
 				name1 = nil
 			}
 			output := new(string)
-			if !nodesItem.Branch.Output.IsUnknown() && !nodesItem.Branch.Output.IsNull() {
-				*output = nodesItem.Branch.Output.ValueString()
+			if !r.Config.Nodes[nodesItem].Branch.Output.IsUnknown() && !r.Config.Nodes[nodesItem].Branch.Output.IsNull() {
+				*output = r.Config.Nodes[nodesItem].Branch.Output.ValueString()
 			} else {
 				output = nil
 			}
 			var outputs *shared.Outputs
-			if nodesItem.Branch.Outputs != nil {
+			if r.Config.Nodes[nodesItem].Branch.Outputs != nil {
 				elseVar1 := new(string)
-				if !nodesItem.Branch.Outputs.Else.IsUnknown() && !nodesItem.Branch.Outputs.Else.IsNull() {
-					*elseVar1 = nodesItem.Branch.Outputs.Else.ValueString()
+				if !r.Config.Nodes[nodesItem].Branch.Outputs.Else.IsUnknown() && !r.Config.Nodes[nodesItem].Branch.Outputs.Else.IsNull() {
+					*elseVar1 = r.Config.Nodes[nodesItem].Branch.Outputs.Else.ValueString()
 				} else {
 					elseVar1 = nil
 				}
 				then := new(string)
-				if !nodesItem.Branch.Outputs.Then.IsUnknown() && !nodesItem.Branch.Outputs.Then.IsNull() {
-					*then = nodesItem.Branch.Outputs.Then.ValueString()
+				if !r.Config.Nodes[nodesItem].Branch.Outputs.Then.IsUnknown() && !r.Config.Nodes[nodesItem].Branch.Outputs.Then.IsNull() {
+					*then = r.Config.Nodes[nodesItem].Branch.Outputs.Then.ValueString()
 				} else {
 					then = nil
 				}
@@ -540,10 +540,10 @@ func (r *GatewayPluginDatakitResourceModel) ToSharedDatakitPlugin(ctx context.Co
 				}
 			}
 			var then1 []string
-			if nodesItem.Branch.Then != nil {
-				then1 = make([]string, 0, len(nodesItem.Branch.Then))
-				for _, thenItem := range nodesItem.Branch.Then {
-					then1 = append(then1, thenItem.ValueString())
+			if r.Config.Nodes[nodesItem].Branch.Then != nil {
+				then1 = make([]string, 0, len(r.Config.Nodes[nodesItem].Branch.Then))
+				for thenIndex := range r.Config.Nodes[nodesItem].Branch.Then {
+					then1 = append(then1, r.Config.Nodes[nodesItem].Branch.Then[thenIndex].ValueString())
 				}
 			}
 			branch := shared.Branch{
@@ -558,36 +558,36 @@ func (r *GatewayPluginDatakitResourceModel) ToSharedDatakitPlugin(ctx context.Co
 				Branch: &branch,
 			})
 		}
-		if nodesItem.Cache != nil {
+		if r.Config.Nodes[nodesItem].Cache != nil {
 			bypassOnError := new(bool)
-			if !nodesItem.Cache.BypassOnError.IsUnknown() && !nodesItem.Cache.BypassOnError.IsNull() {
-				*bypassOnError = nodesItem.Cache.BypassOnError.ValueBool()
+			if !r.Config.Nodes[nodesItem].Cache.BypassOnError.IsUnknown() && !r.Config.Nodes[nodesItem].Cache.BypassOnError.IsNull() {
+				*bypassOnError = r.Config.Nodes[nodesItem].Cache.BypassOnError.ValueBool()
 			} else {
 				bypassOnError = nil
 			}
 			input1 := new(string)
-			if !nodesItem.Cache.Input.IsUnknown() && !nodesItem.Cache.Input.IsNull() {
-				*input1 = nodesItem.Cache.Input.ValueString()
+			if !r.Config.Nodes[nodesItem].Cache.Input.IsUnknown() && !r.Config.Nodes[nodesItem].Cache.Input.IsNull() {
+				*input1 = r.Config.Nodes[nodesItem].Cache.Input.ValueString()
 			} else {
 				input1 = nil
 			}
 			var inputs *shared.Inputs
-			if nodesItem.Cache.Inputs != nil {
+			if r.Config.Nodes[nodesItem].Cache.Inputs != nil {
 				data := new(string)
-				if !nodesItem.Cache.Inputs.Data.IsUnknown() && !nodesItem.Cache.Inputs.Data.IsNull() {
-					*data = nodesItem.Cache.Inputs.Data.ValueString()
+				if !r.Config.Nodes[nodesItem].Cache.Inputs.Data.IsUnknown() && !r.Config.Nodes[nodesItem].Cache.Inputs.Data.IsNull() {
+					*data = r.Config.Nodes[nodesItem].Cache.Inputs.Data.ValueString()
 				} else {
 					data = nil
 				}
 				key := new(string)
-				if !nodesItem.Cache.Inputs.Key.IsUnknown() && !nodesItem.Cache.Inputs.Key.IsNull() {
-					*key = nodesItem.Cache.Inputs.Key.ValueString()
+				if !r.Config.Nodes[nodesItem].Cache.Inputs.Key.IsUnknown() && !r.Config.Nodes[nodesItem].Cache.Inputs.Key.IsNull() {
+					*key = r.Config.Nodes[nodesItem].Cache.Inputs.Key.ValueString()
 				} else {
 					key = nil
 				}
 				ttl := new(string)
-				if !nodesItem.Cache.Inputs.TTL.IsUnknown() && !nodesItem.Cache.Inputs.TTL.IsNull() {
-					*ttl = nodesItem.Cache.Inputs.TTL.ValueString()
+				if !r.Config.Nodes[nodesItem].Cache.Inputs.TTL.IsUnknown() && !r.Config.Nodes[nodesItem].Cache.Inputs.TTL.IsNull() {
+					*ttl = r.Config.Nodes[nodesItem].Cache.Inputs.TTL.ValueString()
 				} else {
 					ttl = nil
 				}
@@ -598,40 +598,40 @@ func (r *GatewayPluginDatakitResourceModel) ToSharedDatakitPlugin(ctx context.Co
 				}
 			}
 			name2 := new(string)
-			if !nodesItem.Cache.Name.IsUnknown() && !nodesItem.Cache.Name.IsNull() {
-				*name2 = nodesItem.Cache.Name.ValueString()
+			if !r.Config.Nodes[nodesItem].Cache.Name.IsUnknown() && !r.Config.Nodes[nodesItem].Cache.Name.IsNull() {
+				*name2 = r.Config.Nodes[nodesItem].Cache.Name.ValueString()
 			} else {
 				name2 = nil
 			}
 			output1 := new(string)
-			if !nodesItem.Cache.Output.IsUnknown() && !nodesItem.Cache.Output.IsNull() {
-				*output1 = nodesItem.Cache.Output.ValueString()
+			if !r.Config.Nodes[nodesItem].Cache.Output.IsUnknown() && !r.Config.Nodes[nodesItem].Cache.Output.IsNull() {
+				*output1 = r.Config.Nodes[nodesItem].Cache.Output.ValueString()
 			} else {
 				output1 = nil
 			}
 			var outputs1 *shared.NodesOutputs
-			if nodesItem.Cache.Outputs != nil {
+			if r.Config.Nodes[nodesItem].Cache.Outputs != nil {
 				data1 := new(string)
-				if !nodesItem.Cache.Outputs.Data.IsUnknown() && !nodesItem.Cache.Outputs.Data.IsNull() {
-					*data1 = nodesItem.Cache.Outputs.Data.ValueString()
+				if !r.Config.Nodes[nodesItem].Cache.Outputs.Data.IsUnknown() && !r.Config.Nodes[nodesItem].Cache.Outputs.Data.IsNull() {
+					*data1 = r.Config.Nodes[nodesItem].Cache.Outputs.Data.ValueString()
 				} else {
 					data1 = nil
 				}
 				hit := new(string)
-				if !nodesItem.Cache.Outputs.Hit.IsUnknown() && !nodesItem.Cache.Outputs.Hit.IsNull() {
-					*hit = nodesItem.Cache.Outputs.Hit.ValueString()
+				if !r.Config.Nodes[nodesItem].Cache.Outputs.Hit.IsUnknown() && !r.Config.Nodes[nodesItem].Cache.Outputs.Hit.IsNull() {
+					*hit = r.Config.Nodes[nodesItem].Cache.Outputs.Hit.ValueString()
 				} else {
 					hit = nil
 				}
 				miss := new(string)
-				if !nodesItem.Cache.Outputs.Miss.IsUnknown() && !nodesItem.Cache.Outputs.Miss.IsNull() {
-					*miss = nodesItem.Cache.Outputs.Miss.ValueString()
+				if !r.Config.Nodes[nodesItem].Cache.Outputs.Miss.IsUnknown() && !r.Config.Nodes[nodesItem].Cache.Outputs.Miss.IsNull() {
+					*miss = r.Config.Nodes[nodesItem].Cache.Outputs.Miss.ValueString()
 				} else {
 					miss = nil
 				}
 				stored := new(string)
-				if !nodesItem.Cache.Outputs.Stored.IsUnknown() && !nodesItem.Cache.Outputs.Stored.IsNull() {
-					*stored = nodesItem.Cache.Outputs.Stored.ValueString()
+				if !r.Config.Nodes[nodesItem].Cache.Outputs.Stored.IsUnknown() && !r.Config.Nodes[nodesItem].Cache.Outputs.Stored.IsNull() {
+					*stored = r.Config.Nodes[nodesItem].Cache.Outputs.Stored.ValueString()
 				} else {
 					stored = nil
 				}
@@ -643,8 +643,8 @@ func (r *GatewayPluginDatakitResourceModel) ToSharedDatakitPlugin(ctx context.Co
 				}
 			}
 			ttl1 := new(int64)
-			if !nodesItem.Cache.TTL.IsUnknown() && !nodesItem.Cache.TTL.IsNull() {
-				*ttl1 = nodesItem.Cache.TTL.ValueInt64()
+			if !r.Config.Nodes[nodesItem].Cache.TTL.IsUnknown() && !r.Config.Nodes[nodesItem].Cache.TTL.IsNull() {
+				*ttl1 = r.Config.Nodes[nodesItem].Cache.TTL.ValueInt64()
 			} else {
 				ttl1 = nil
 			}
@@ -661,30 +661,30 @@ func (r *GatewayPluginDatakitResourceModel) ToSharedDatakitPlugin(ctx context.Co
 				NodesCache: &nodesCache,
 			})
 		}
-		if nodesItem.Call != nil {
+		if r.Config.Nodes[nodesItem].Call != nil {
 			input2 := new(string)
-			if !nodesItem.Call.Input.IsUnknown() && !nodesItem.Call.Input.IsNull() {
-				*input2 = nodesItem.Call.Input.ValueString()
+			if !r.Config.Nodes[nodesItem].Call.Input.IsUnknown() && !r.Config.Nodes[nodesItem].Call.Input.IsNull() {
+				*input2 = r.Config.Nodes[nodesItem].Call.Input.ValueString()
 			} else {
 				input2 = nil
 			}
 			var inputs1 *shared.NodesInputs
-			if nodesItem.Call.Inputs != nil {
+			if r.Config.Nodes[nodesItem].Call.Inputs != nil {
 				body := new(string)
-				if !nodesItem.Call.Inputs.Body.IsUnknown() && !nodesItem.Call.Inputs.Body.IsNull() {
-					*body = nodesItem.Call.Inputs.Body.ValueString()
+				if !r.Config.Nodes[nodesItem].Call.Inputs.Body.IsUnknown() && !r.Config.Nodes[nodesItem].Call.Inputs.Body.IsNull() {
+					*body = r.Config.Nodes[nodesItem].Call.Inputs.Body.ValueString()
 				} else {
 					body = nil
 				}
 				headers := new(string)
-				if !nodesItem.Call.Inputs.Headers.IsUnknown() && !nodesItem.Call.Inputs.Headers.IsNull() {
-					*headers = nodesItem.Call.Inputs.Headers.ValueString()
+				if !r.Config.Nodes[nodesItem].Call.Inputs.Headers.IsUnknown() && !r.Config.Nodes[nodesItem].Call.Inputs.Headers.IsNull() {
+					*headers = r.Config.Nodes[nodesItem].Call.Inputs.Headers.ValueString()
 				} else {
 					headers = nil
 				}
 				query := new(string)
-				if !nodesItem.Call.Inputs.Query.IsUnknown() && !nodesItem.Call.Inputs.Query.IsNull() {
-					*query = nodesItem.Call.Inputs.Query.ValueString()
+				if !r.Config.Nodes[nodesItem].Call.Inputs.Query.IsUnknown() && !r.Config.Nodes[nodesItem].Call.Inputs.Query.IsNull() {
+					*query = r.Config.Nodes[nodesItem].Call.Inputs.Query.ValueString()
 				} else {
 					query = nil
 				}
@@ -695,40 +695,40 @@ func (r *GatewayPluginDatakitResourceModel) ToSharedDatakitPlugin(ctx context.Co
 				}
 			}
 			method := new(string)
-			if !nodesItem.Call.Method.IsUnknown() && !nodesItem.Call.Method.IsNull() {
-				*method = nodesItem.Call.Method.ValueString()
+			if !r.Config.Nodes[nodesItem].Call.Method.IsUnknown() && !r.Config.Nodes[nodesItem].Call.Method.IsNull() {
+				*method = r.Config.Nodes[nodesItem].Call.Method.ValueString()
 			} else {
 				method = nil
 			}
 			name3 := new(string)
-			if !nodesItem.Call.Name.IsUnknown() && !nodesItem.Call.Name.IsNull() {
-				*name3 = nodesItem.Call.Name.ValueString()
+			if !r.Config.Nodes[nodesItem].Call.Name.IsUnknown() && !r.Config.Nodes[nodesItem].Call.Name.IsNull() {
+				*name3 = r.Config.Nodes[nodesItem].Call.Name.ValueString()
 			} else {
 				name3 = nil
 			}
 			output2 := new(string)
-			if !nodesItem.Call.Output.IsUnknown() && !nodesItem.Call.Output.IsNull() {
-				*output2 = nodesItem.Call.Output.ValueString()
+			if !r.Config.Nodes[nodesItem].Call.Output.IsUnknown() && !r.Config.Nodes[nodesItem].Call.Output.IsNull() {
+				*output2 = r.Config.Nodes[nodesItem].Call.Output.ValueString()
 			} else {
 				output2 = nil
 			}
 			var outputs2 *shared.DatakitPluginNodesOutputs
-			if nodesItem.Call.Outputs != nil {
+			if r.Config.Nodes[nodesItem].Call.Outputs != nil {
 				body1 := new(string)
-				if !nodesItem.Call.Outputs.Body.IsUnknown() && !nodesItem.Call.Outputs.Body.IsNull() {
-					*body1 = nodesItem.Call.Outputs.Body.ValueString()
+				if !r.Config.Nodes[nodesItem].Call.Outputs.Body.IsUnknown() && !r.Config.Nodes[nodesItem].Call.Outputs.Body.IsNull() {
+					*body1 = r.Config.Nodes[nodesItem].Call.Outputs.Body.ValueString()
 				} else {
 					body1 = nil
 				}
 				headers1 := new(string)
-				if !nodesItem.Call.Outputs.Headers.IsUnknown() && !nodesItem.Call.Outputs.Headers.IsNull() {
-					*headers1 = nodesItem.Call.Outputs.Headers.ValueString()
+				if !r.Config.Nodes[nodesItem].Call.Outputs.Headers.IsUnknown() && !r.Config.Nodes[nodesItem].Call.Outputs.Headers.IsNull() {
+					*headers1 = r.Config.Nodes[nodesItem].Call.Outputs.Headers.ValueString()
 				} else {
 					headers1 = nil
 				}
 				status := new(string)
-				if !nodesItem.Call.Outputs.Status.IsUnknown() && !nodesItem.Call.Outputs.Status.IsNull() {
-					*status = nodesItem.Call.Outputs.Status.ValueString()
+				if !r.Config.Nodes[nodesItem].Call.Outputs.Status.IsUnknown() && !r.Config.Nodes[nodesItem].Call.Outputs.Status.IsNull() {
+					*status = r.Config.Nodes[nodesItem].Call.Outputs.Status.ValueString()
 				} else {
 					status = nil
 				}
@@ -739,19 +739,19 @@ func (r *GatewayPluginDatakitResourceModel) ToSharedDatakitPlugin(ctx context.Co
 				}
 			}
 			sslServerName := new(string)
-			if !nodesItem.Call.SslServerName.IsUnknown() && !nodesItem.Call.SslServerName.IsNull() {
-				*sslServerName = nodesItem.Call.SslServerName.ValueString()
+			if !r.Config.Nodes[nodesItem].Call.SslServerName.IsUnknown() && !r.Config.Nodes[nodesItem].Call.SslServerName.IsNull() {
+				*sslServerName = r.Config.Nodes[nodesItem].Call.SslServerName.ValueString()
 			} else {
 				sslServerName = nil
 			}
 			timeout := new(int64)
-			if !nodesItem.Call.Timeout.IsUnknown() && !nodesItem.Call.Timeout.IsNull() {
-				*timeout = nodesItem.Call.Timeout.ValueInt64()
+			if !r.Config.Nodes[nodesItem].Call.Timeout.IsUnknown() && !r.Config.Nodes[nodesItem].Call.Timeout.IsNull() {
+				*timeout = r.Config.Nodes[nodesItem].Call.Timeout.ValueInt64()
 			} else {
 				timeout = nil
 			}
 			var url string
-			url = nodesItem.Call.URL.ValueString()
+			url = r.Config.Nodes[nodesItem].Call.URL.ValueString()
 
 			call := shared.Call{
 				Input:         input2,
@@ -768,24 +768,24 @@ func (r *GatewayPluginDatakitResourceModel) ToSharedDatakitPlugin(ctx context.Co
 				Call: &call,
 			})
 		}
-		if nodesItem.Exit != nil {
+		if r.Config.Nodes[nodesItem].Exit != nil {
 			input3 := new(string)
-			if !nodesItem.Exit.Input.IsUnknown() && !nodesItem.Exit.Input.IsNull() {
-				*input3 = nodesItem.Exit.Input.ValueString()
+			if !r.Config.Nodes[nodesItem].Exit.Input.IsUnknown() && !r.Config.Nodes[nodesItem].Exit.Input.IsNull() {
+				*input3 = r.Config.Nodes[nodesItem].Exit.Input.ValueString()
 			} else {
 				input3 = nil
 			}
 			var inputs2 *shared.DatakitPluginNodesInputs
-			if nodesItem.Exit.Inputs != nil {
+			if r.Config.Nodes[nodesItem].Exit.Inputs != nil {
 				body2 := new(string)
-				if !nodesItem.Exit.Inputs.Body.IsUnknown() && !nodesItem.Exit.Inputs.Body.IsNull() {
-					*body2 = nodesItem.Exit.Inputs.Body.ValueString()
+				if !r.Config.Nodes[nodesItem].Exit.Inputs.Body.IsUnknown() && !r.Config.Nodes[nodesItem].Exit.Inputs.Body.IsNull() {
+					*body2 = r.Config.Nodes[nodesItem].Exit.Inputs.Body.ValueString()
 				} else {
 					body2 = nil
 				}
 				headers2 := new(string)
-				if !nodesItem.Exit.Inputs.Headers.IsUnknown() && !nodesItem.Exit.Inputs.Headers.IsNull() {
-					*headers2 = nodesItem.Exit.Inputs.Headers.ValueString()
+				if !r.Config.Nodes[nodesItem].Exit.Inputs.Headers.IsUnknown() && !r.Config.Nodes[nodesItem].Exit.Inputs.Headers.IsNull() {
+					*headers2 = r.Config.Nodes[nodesItem].Exit.Inputs.Headers.ValueString()
 				} else {
 					headers2 = nil
 				}
@@ -795,20 +795,20 @@ func (r *GatewayPluginDatakitResourceModel) ToSharedDatakitPlugin(ctx context.Co
 				}
 			}
 			name4 := new(string)
-			if !nodesItem.Exit.Name.IsUnknown() && !nodesItem.Exit.Name.IsNull() {
-				*name4 = nodesItem.Exit.Name.ValueString()
+			if !r.Config.Nodes[nodesItem].Exit.Name.IsUnknown() && !r.Config.Nodes[nodesItem].Exit.Name.IsNull() {
+				*name4 = r.Config.Nodes[nodesItem].Exit.Name.ValueString()
 			} else {
 				name4 = nil
 			}
 			status1 := new(int64)
-			if !nodesItem.Exit.Status.IsUnknown() && !nodesItem.Exit.Status.IsNull() {
-				*status1 = nodesItem.Exit.Status.ValueInt64()
+			if !r.Config.Nodes[nodesItem].Exit.Status.IsUnknown() && !r.Config.Nodes[nodesItem].Exit.Status.IsNull() {
+				*status1 = r.Config.Nodes[nodesItem].Exit.Status.ValueInt64()
 			} else {
 				status1 = nil
 			}
 			warnHeadersSent := new(bool)
-			if !nodesItem.Exit.WarnHeadersSent.IsUnknown() && !nodesItem.Exit.WarnHeadersSent.IsNull() {
-				*warnHeadersSent = nodesItem.Exit.WarnHeadersSent.ValueBool()
+			if !r.Config.Nodes[nodesItem].Exit.WarnHeadersSent.IsUnknown() && !r.Config.Nodes[nodesItem].Exit.WarnHeadersSent.IsNull() {
+				*warnHeadersSent = r.Config.Nodes[nodesItem].Exit.WarnHeadersSent.ValueBool()
 			} else {
 				warnHeadersSent = nil
 			}
@@ -823,35 +823,35 @@ func (r *GatewayPluginDatakitResourceModel) ToSharedDatakitPlugin(ctx context.Co
 				Exit: &exit,
 			})
 		}
-		if nodesItem.Jq != nil {
+		if r.Config.Nodes[nodesItem].Jq != nil {
 			input4 := new(string)
-			if !nodesItem.Jq.Input.IsUnknown() && !nodesItem.Jq.Input.IsNull() {
-				*input4 = nodesItem.Jq.Input.ValueString()
+			if !r.Config.Nodes[nodesItem].Jq.Input.IsUnknown() && !r.Config.Nodes[nodesItem].Jq.Input.IsNull() {
+				*input4 = r.Config.Nodes[nodesItem].Jq.Input.ValueString()
 			} else {
 				input4 = nil
 			}
 			var inputs3 map[string]string
-			if nodesItem.Jq.Inputs != nil {
+			if r.Config.Nodes[nodesItem].Jq.Inputs != nil {
 				inputs3 = make(map[string]string)
-				for inputsKey, inputsValue := range nodesItem.Jq.Inputs {
+				for inputsKey := range r.Config.Nodes[nodesItem].Jq.Inputs {
 					var inputsInst string
-					inputsInst = inputsValue.ValueString()
+					inputsInst = r.Config.Nodes[nodesItem].Jq.Inputs[inputsKey].ValueString()
 
 					inputs3[inputsKey] = inputsInst
 				}
 			}
 			var jq1 string
-			jq1 = nodesItem.Jq.Jq.ValueString()
+			jq1 = r.Config.Nodes[nodesItem].Jq.Jq.ValueString()
 
 			name5 := new(string)
-			if !nodesItem.Jq.Name.IsUnknown() && !nodesItem.Jq.Name.IsNull() {
-				*name5 = nodesItem.Jq.Name.ValueString()
+			if !r.Config.Nodes[nodesItem].Jq.Name.IsUnknown() && !r.Config.Nodes[nodesItem].Jq.Name.IsNull() {
+				*name5 = r.Config.Nodes[nodesItem].Jq.Name.ValueString()
 			} else {
 				name5 = nil
 			}
 			output3 := new(string)
-			if !nodesItem.Jq.Output.IsUnknown() && !nodesItem.Jq.Output.IsNull() {
-				*output3 = nodesItem.Jq.Output.ValueString()
+			if !r.Config.Nodes[nodesItem].Jq.Output.IsUnknown() && !r.Config.Nodes[nodesItem].Jq.Output.IsNull() {
+				*output3 = r.Config.Nodes[nodesItem].Jq.Output.ValueString()
 			} else {
 				output3 = nil
 			}
@@ -866,33 +866,33 @@ func (r *GatewayPluginDatakitResourceModel) ToSharedDatakitPlugin(ctx context.Co
 				Jq: &jq,
 			})
 		}
-		if nodesItem.Property != nil {
+		if r.Config.Nodes[nodesItem].Property != nil {
 			contentType := new(shared.NodesContentType)
-			if !nodesItem.Property.ContentType.IsUnknown() && !nodesItem.Property.ContentType.IsNull() {
-				*contentType = shared.NodesContentType(nodesItem.Property.ContentType.ValueString())
+			if !r.Config.Nodes[nodesItem].Property.ContentType.IsUnknown() && !r.Config.Nodes[nodesItem].Property.ContentType.IsNull() {
+				*contentType = shared.NodesContentType(r.Config.Nodes[nodesItem].Property.ContentType.ValueString())
 			} else {
 				contentType = nil
 			}
 			input5 := new(string)
-			if !nodesItem.Property.Input.IsUnknown() && !nodesItem.Property.Input.IsNull() {
-				*input5 = nodesItem.Property.Input.ValueString()
+			if !r.Config.Nodes[nodesItem].Property.Input.IsUnknown() && !r.Config.Nodes[nodesItem].Property.Input.IsNull() {
+				*input5 = r.Config.Nodes[nodesItem].Property.Input.ValueString()
 			} else {
 				input5 = nil
 			}
 			name6 := new(string)
-			if !nodesItem.Property.Name.IsUnknown() && !nodesItem.Property.Name.IsNull() {
-				*name6 = nodesItem.Property.Name.ValueString()
+			if !r.Config.Nodes[nodesItem].Property.Name.IsUnknown() && !r.Config.Nodes[nodesItem].Property.Name.IsNull() {
+				*name6 = r.Config.Nodes[nodesItem].Property.Name.ValueString()
 			} else {
 				name6 = nil
 			}
 			output4 := new(string)
-			if !nodesItem.Property.Output.IsUnknown() && !nodesItem.Property.Output.IsNull() {
-				*output4 = nodesItem.Property.Output.ValueString()
+			if !r.Config.Nodes[nodesItem].Property.Output.IsUnknown() && !r.Config.Nodes[nodesItem].Property.Output.IsNull() {
+				*output4 = r.Config.Nodes[nodesItem].Property.Output.ValueString()
 			} else {
 				output4 = nil
 			}
 			var property1 string
-			property1 = nodesItem.Property.Property.ValueString()
+			property1 = r.Config.Nodes[nodesItem].Property.Property.ValueString()
 
 			property := shared.Property{
 				ContentType: contentType,
@@ -905,31 +905,31 @@ func (r *GatewayPluginDatakitResourceModel) ToSharedDatakitPlugin(ctx context.Co
 				Property: &property,
 			})
 		}
-		if nodesItem.Static != nil {
+		if r.Config.Nodes[nodesItem].Static != nil {
 			name7 := new(string)
-			if !nodesItem.Static.Name.IsUnknown() && !nodesItem.Static.Name.IsNull() {
-				*name7 = nodesItem.Static.Name.ValueString()
+			if !r.Config.Nodes[nodesItem].Static.Name.IsUnknown() && !r.Config.Nodes[nodesItem].Static.Name.IsNull() {
+				*name7 = r.Config.Nodes[nodesItem].Static.Name.ValueString()
 			} else {
 				name7 = nil
 			}
 			output5 := new(string)
-			if !nodesItem.Static.Output.IsUnknown() && !nodesItem.Static.Output.IsNull() {
-				*output5 = nodesItem.Static.Output.ValueString()
+			if !r.Config.Nodes[nodesItem].Static.Output.IsUnknown() && !r.Config.Nodes[nodesItem].Static.Output.IsNull() {
+				*output5 = r.Config.Nodes[nodesItem].Static.Output.ValueString()
 			} else {
 				output5 = nil
 			}
 			var outputs3 map[string]string
-			if nodesItem.Static.Outputs != nil {
+			if r.Config.Nodes[nodesItem].Static.Outputs != nil {
 				outputs3 = make(map[string]string)
-				for outputsKey, outputsValue := range nodesItem.Static.Outputs {
+				for outputsKey := range r.Config.Nodes[nodesItem].Static.Outputs {
 					var outputsInst string
-					outputsInst = outputsValue.ValueString()
+					outputsInst = r.Config.Nodes[nodesItem].Static.Outputs[outputsKey].ValueString()
 
 					outputs3[outputsKey] = outputsInst
 				}
 			}
 			var values string
-			values = nodesItem.Static.Values.ValueString()
+			values = r.Config.Nodes[nodesItem].Static.Values.ValueString()
 
 			static := shared.Static{
 				Name:    name7,
@@ -969,16 +969,16 @@ func (r *GatewayPluginDatakitResourceModel) ToSharedDatakitPlugin(ctx context.Co
 				var clusterNodes []shared.DatakitPluginClusterNodes
 				if r.Config.Resources.Cache.Redis.ClusterNodes != nil {
 					clusterNodes = make([]shared.DatakitPluginClusterNodes, 0, len(r.Config.Resources.Cache.Redis.ClusterNodes))
-					for _, clusterNodesItem := range r.Config.Resources.Cache.Redis.ClusterNodes {
+					for clusterNodesIndex := range r.Config.Resources.Cache.Redis.ClusterNodes {
 						ip := new(string)
-						if !clusterNodesItem.IP.IsUnknown() && !clusterNodesItem.IP.IsNull() {
-							*ip = clusterNodesItem.IP.ValueString()
+						if !r.Config.Resources.Cache.Redis.ClusterNodes[clusterNodesIndex].IP.IsUnknown() && !r.Config.Resources.Cache.Redis.ClusterNodes[clusterNodesIndex].IP.IsNull() {
+							*ip = r.Config.Resources.Cache.Redis.ClusterNodes[clusterNodesIndex].IP.ValueString()
 						} else {
 							ip = nil
 						}
 						port := new(int64)
-						if !clusterNodesItem.Port.IsUnknown() && !clusterNodesItem.Port.IsNull() {
-							*port = clusterNodesItem.Port.ValueInt64()
+						if !r.Config.Resources.Cache.Redis.ClusterNodes[clusterNodesIndex].Port.IsUnknown() && !r.Config.Resources.Cache.Redis.ClusterNodes[clusterNodesIndex].Port.IsNull() {
+							*port = r.Config.Resources.Cache.Redis.ClusterNodes[clusterNodesIndex].Port.ValueInt64()
 						} else {
 							port = nil
 						}
@@ -1057,16 +1057,16 @@ func (r *GatewayPluginDatakitResourceModel) ToSharedDatakitPlugin(ctx context.Co
 				var sentinelNodes []shared.DatakitPluginSentinelNodes
 				if r.Config.Resources.Cache.Redis.SentinelNodes != nil {
 					sentinelNodes = make([]shared.DatakitPluginSentinelNodes, 0, len(r.Config.Resources.Cache.Redis.SentinelNodes))
-					for _, sentinelNodesItem := range r.Config.Resources.Cache.Redis.SentinelNodes {
+					for sentinelNodesIndex := range r.Config.Resources.Cache.Redis.SentinelNodes {
 						host1 := new(string)
-						if !sentinelNodesItem.Host.IsUnknown() && !sentinelNodesItem.Host.IsNull() {
-							*host1 = sentinelNodesItem.Host.ValueString()
+						if !r.Config.Resources.Cache.Redis.SentinelNodes[sentinelNodesIndex].Host.IsUnknown() && !r.Config.Resources.Cache.Redis.SentinelNodes[sentinelNodesIndex].Host.IsNull() {
+							*host1 = r.Config.Resources.Cache.Redis.SentinelNodes[sentinelNodesIndex].Host.ValueString()
 						} else {
 							host1 = nil
 						}
 						port2 := new(int64)
-						if !sentinelNodesItem.Port.IsUnknown() && !sentinelNodesItem.Port.IsNull() {
-							*port2 = sentinelNodesItem.Port.ValueInt64()
+						if !r.Config.Resources.Cache.Redis.SentinelNodes[sentinelNodesIndex].Port.IsUnknown() && !r.Config.Resources.Cache.Redis.SentinelNodes[sentinelNodesIndex].Port.IsNull() {
+							*port2 = r.Config.Resources.Cache.Redis.SentinelNodes[sentinelNodesIndex].Port.ValueInt64()
 						} else {
 							port2 = nil
 						}
@@ -1157,9 +1157,9 @@ func (r *GatewayPluginDatakitResourceModel) ToSharedDatakitPlugin(ctx context.Co
 		var vault map[string]string
 		if r.Config.Resources.Vault != nil {
 			vault = make(map[string]string)
-			for vaultKey, vaultValue := range r.Config.Resources.Vault {
+			for vaultKey := range r.Config.Resources.Vault {
 				var vaultInst string
-				vaultInst = vaultValue.ValueString()
+				vaultInst = r.Config.Resources.Vault[vaultKey].ValueString()
 
 				vault[vaultKey] = vaultInst
 			}

--- a/internal/provider/gatewayplugindegraphql_resource.go
+++ b/internal/provider/gatewayplugindegraphql_resource.go
@@ -466,7 +466,10 @@ func (r *GatewayPluginDegraphqlResource) Delete(ctx context.Context, req resourc
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewayplugindegraphql_resource_sdk.go
+++ b/internal/provider/gatewayplugindegraphql_resource_sdk.go
@@ -201,8 +201,8 @@ func (r *GatewayPluginDegraphqlResourceModel) ToSharedDegraphqlPlugin(ctx contex
 		var after *shared.DegraphqlPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.DegraphqlPluginAfter{
 				Access: access,
@@ -211,8 +211,8 @@ func (r *GatewayPluginDegraphqlResourceModel) ToSharedDegraphqlPlugin(ctx contex
 		var before *shared.DegraphqlPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.DegraphqlPluginBefore{
 				Access: access1,
@@ -226,22 +226,22 @@ func (r *GatewayPluginDegraphqlResourceModel) ToSharedDegraphqlPlugin(ctx contex
 	var partials []shared.DegraphqlPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.DegraphqlPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -255,8 +255,8 @@ func (r *GatewayPluginDegraphqlResourceModel) ToSharedDegraphqlPlugin(ctx contex
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)

--- a/internal/provider/gatewaypluginexittransformer_resource.go
+++ b/internal/provider/gatewaypluginexittransformer_resource.go
@@ -486,7 +486,10 @@ func (r *GatewayPluginExitTransformerResource) Delete(ctx context.Context, req r
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginexittransformer_resource_sdk.go
+++ b/internal/provider/gatewaypluginexittransformer_resource_sdk.go
@@ -207,8 +207,8 @@ func (r *GatewayPluginExitTransformerResourceModel) ToSharedExitTransformerPlugi
 		var after *shared.ExitTransformerPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.ExitTransformerPluginAfter{
 				Access: access,
@@ -217,8 +217,8 @@ func (r *GatewayPluginExitTransformerResourceModel) ToSharedExitTransformerPlugi
 		var before *shared.ExitTransformerPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.ExitTransformerPluginBefore{
 				Access: access1,
@@ -232,22 +232,22 @@ func (r *GatewayPluginExitTransformerResourceModel) ToSharedExitTransformerPlugi
 	var partials []shared.ExitTransformerPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.ExitTransformerPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -261,8 +261,8 @@ func (r *GatewayPluginExitTransformerResourceModel) ToSharedExitTransformerPlugi
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -272,8 +272,8 @@ func (r *GatewayPluginExitTransformerResourceModel) ToSharedExitTransformerPlugi
 		updatedAt = nil
 	}
 	functions := make([]string, 0, len(r.Config.Functions))
-	for _, functionsItem := range r.Config.Functions {
-		functions = append(functions, functionsItem.ValueString())
+	for functionsIndex := range r.Config.Functions {
+		functions = append(functions, r.Config.Functions[functionsIndex].ValueString())
 	}
 	handleUnexpected := new(bool)
 	if !r.Config.HandleUnexpected.IsUnknown() && !r.Config.HandleUnexpected.IsNull() {

--- a/internal/provider/gatewaypluginfilelog_resource.go
+++ b/internal/provider/gatewaypluginfilelog_resource.go
@@ -486,7 +486,10 @@ func (r *GatewayPluginFileLogResource) Delete(ctx context.Context, req resource.
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginfilelog_resource_sdk.go
+++ b/internal/provider/gatewaypluginfilelog_resource_sdk.go
@@ -209,8 +209,8 @@ func (r *GatewayPluginFileLogResourceModel) ToSharedFileLogPlugin(ctx context.Co
 		var after *shared.FileLogPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.FileLogPluginAfter{
 				Access: access,
@@ -219,8 +219,8 @@ func (r *GatewayPluginFileLogResourceModel) ToSharedFileLogPlugin(ctx context.Co
 		var before *shared.FileLogPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.FileLogPluginBefore{
 				Access: access1,
@@ -234,22 +234,22 @@ func (r *GatewayPluginFileLogResourceModel) ToSharedFileLogPlugin(ctx context.Co
 	var partials []shared.FileLogPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.FileLogPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -263,8 +263,8 @@ func (r *GatewayPluginFileLogResourceModel) ToSharedFileLogPlugin(ctx context.Co
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -274,9 +274,9 @@ func (r *GatewayPluginFileLogResourceModel) ToSharedFileLogPlugin(ctx context.Co
 		updatedAt = nil
 	}
 	customFieldsByLua := make(map[string]string)
-	for customFieldsByLuaKey, customFieldsByLuaValue := range r.Config.CustomFieldsByLua {
+	for customFieldsByLuaKey := range r.Config.CustomFieldsByLua {
 		var customFieldsByLuaInst string
-		customFieldsByLuaInst = customFieldsByLuaValue.ValueString()
+		customFieldsByLuaInst = r.Config.CustomFieldsByLua[customFieldsByLuaKey].ValueString()
 
 		customFieldsByLua[customFieldsByLuaKey] = customFieldsByLuaInst
 	}

--- a/internal/provider/gatewaypluginforwardproxy_resource.go
+++ b/internal/provider/gatewaypluginforwardproxy_resource.go
@@ -544,7 +544,10 @@ func (r *GatewayPluginForwardProxyResource) Delete(ctx context.Context, req reso
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginforwardproxy_resource_sdk.go
+++ b/internal/provider/gatewaypluginforwardproxy_resource_sdk.go
@@ -223,8 +223,8 @@ func (r *GatewayPluginForwardProxyResourceModel) ToSharedForwardProxyPlugin(ctx 
 		var after *shared.ForwardProxyPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.ForwardProxyPluginAfter{
 				Access: access,
@@ -233,8 +233,8 @@ func (r *GatewayPluginForwardProxyResourceModel) ToSharedForwardProxyPlugin(ctx 
 		var before *shared.ForwardProxyPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.ForwardProxyPluginBefore{
 				Access: access1,
@@ -248,22 +248,22 @@ func (r *GatewayPluginForwardProxyResourceModel) ToSharedForwardProxyPlugin(ctx 
 	var partials []shared.ForwardProxyPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.ForwardProxyPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -277,8 +277,8 @@ func (r *GatewayPluginForwardProxyResourceModel) ToSharedForwardProxyPlugin(ctx 
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)

--- a/internal/provider/gatewayplugingraphqlproxycacheadvanced_resource.go
+++ b/internal/provider/gatewayplugingraphqlproxycacheadvanced_resource.go
@@ -789,7 +789,10 @@ func (r *GatewayPluginGraphqlProxyCacheAdvancedResource) Delete(ctx context.Cont
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewayplugingraphqlproxycacheadvanced_resource_sdk.go
+++ b/internal/provider/gatewayplugingraphqlproxycacheadvanced_resource_sdk.go
@@ -277,8 +277,8 @@ func (r *GatewayPluginGraphqlProxyCacheAdvancedResourceModel) ToSharedGraphqlPro
 		var after *shared.GraphqlProxyCacheAdvancedPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.GraphqlProxyCacheAdvancedPluginAfter{
 				Access: access,
@@ -287,8 +287,8 @@ func (r *GatewayPluginGraphqlProxyCacheAdvancedResourceModel) ToSharedGraphqlPro
 		var before *shared.GraphqlProxyCacheAdvancedPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.GraphqlProxyCacheAdvancedPluginBefore{
 				Access: access1,
@@ -302,22 +302,22 @@ func (r *GatewayPluginGraphqlProxyCacheAdvancedResourceModel) ToSharedGraphqlPro
 	var partials []shared.GraphqlProxyCacheAdvancedPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.GraphqlProxyCacheAdvancedPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -331,8 +331,8 @@ func (r *GatewayPluginGraphqlProxyCacheAdvancedResourceModel) ToSharedGraphqlPro
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -378,16 +378,16 @@ func (r *GatewayPluginGraphqlProxyCacheAdvancedResourceModel) ToSharedGraphqlPro
 			var clusterNodes []shared.GraphqlProxyCacheAdvancedPluginClusterNodes
 			if r.Config.Redis.ClusterNodes != nil {
 				clusterNodes = make([]shared.GraphqlProxyCacheAdvancedPluginClusterNodes, 0, len(r.Config.Redis.ClusterNodes))
-				for _, clusterNodesItem := range r.Config.Redis.ClusterNodes {
+				for clusterNodesIndex := range r.Config.Redis.ClusterNodes {
 					ip := new(string)
-					if !clusterNodesItem.IP.IsUnknown() && !clusterNodesItem.IP.IsNull() {
-						*ip = clusterNodesItem.IP.ValueString()
+					if !r.Config.Redis.ClusterNodes[clusterNodesIndex].IP.IsUnknown() && !r.Config.Redis.ClusterNodes[clusterNodesIndex].IP.IsNull() {
+						*ip = r.Config.Redis.ClusterNodes[clusterNodesIndex].IP.ValueString()
 					} else {
 						ip = nil
 					}
 					port := new(int64)
-					if !clusterNodesItem.Port.IsUnknown() && !clusterNodesItem.Port.IsNull() {
-						*port = clusterNodesItem.Port.ValueInt64()
+					if !r.Config.Redis.ClusterNodes[clusterNodesIndex].Port.IsUnknown() && !r.Config.Redis.ClusterNodes[clusterNodesIndex].Port.IsNull() {
+						*port = r.Config.Redis.ClusterNodes[clusterNodesIndex].Port.ValueInt64()
 					} else {
 						port = nil
 					}
@@ -466,16 +466,16 @@ func (r *GatewayPluginGraphqlProxyCacheAdvancedResourceModel) ToSharedGraphqlPro
 			var sentinelNodes []shared.GraphqlProxyCacheAdvancedPluginSentinelNodes
 			if r.Config.Redis.SentinelNodes != nil {
 				sentinelNodes = make([]shared.GraphqlProxyCacheAdvancedPluginSentinelNodes, 0, len(r.Config.Redis.SentinelNodes))
-				for _, sentinelNodesItem := range r.Config.Redis.SentinelNodes {
+				for sentinelNodesIndex := range r.Config.Redis.SentinelNodes {
 					host1 := new(string)
-					if !sentinelNodesItem.Host.IsUnknown() && !sentinelNodesItem.Host.IsNull() {
-						*host1 = sentinelNodesItem.Host.ValueString()
+					if !r.Config.Redis.SentinelNodes[sentinelNodesIndex].Host.IsUnknown() && !r.Config.Redis.SentinelNodes[sentinelNodesIndex].Host.IsNull() {
+						*host1 = r.Config.Redis.SentinelNodes[sentinelNodesIndex].Host.ValueString()
 					} else {
 						host1 = nil
 					}
 					port2 := new(int64)
-					if !sentinelNodesItem.Port.IsUnknown() && !sentinelNodesItem.Port.IsNull() {
-						*port2 = sentinelNodesItem.Port.ValueInt64()
+					if !r.Config.Redis.SentinelNodes[sentinelNodesIndex].Port.IsUnknown() && !r.Config.Redis.SentinelNodes[sentinelNodesIndex].Port.IsNull() {
+						*port2 = r.Config.Redis.SentinelNodes[sentinelNodesIndex].Port.ValueInt64()
 					} else {
 						port2 = nil
 					}
@@ -560,8 +560,8 @@ func (r *GatewayPluginGraphqlProxyCacheAdvancedResourceModel) ToSharedGraphqlPro
 		var varyHeaders []string
 		if r.Config.VaryHeaders != nil {
 			varyHeaders = make([]string, 0, len(r.Config.VaryHeaders))
-			for _, varyHeadersItem := range r.Config.VaryHeaders {
-				varyHeaders = append(varyHeaders, varyHeadersItem.ValueString())
+			for varyHeadersIndex := range r.Config.VaryHeaders {
+				varyHeaders = append(varyHeaders, r.Config.VaryHeaders[varyHeadersIndex].ValueString())
 			}
 		}
 		config = &shared.GraphqlProxyCacheAdvancedPluginConfig{

--- a/internal/provider/gatewayplugingraphqlratelimitingadvanced_resource.go
+++ b/internal/provider/gatewayplugingraphqlratelimitingadvanced_resource.go
@@ -790,7 +790,10 @@ func (r *GatewayPluginGraphqlRateLimitingAdvancedResource) Delete(ctx context.Co
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewayplugingraphqlratelimitingadvanced_resource_sdk.go
+++ b/internal/provider/gatewayplugingraphqlratelimitingadvanced_resource_sdk.go
@@ -288,8 +288,8 @@ func (r *GatewayPluginGraphqlRateLimitingAdvancedResourceModel) ToSharedGraphqlR
 		var after *shared.GraphqlRateLimitingAdvancedPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.GraphqlRateLimitingAdvancedPluginAfter{
 				Access: access,
@@ -298,8 +298,8 @@ func (r *GatewayPluginGraphqlRateLimitingAdvancedResourceModel) ToSharedGraphqlR
 		var before *shared.GraphqlRateLimitingAdvancedPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.GraphqlRateLimitingAdvancedPluginBefore{
 				Access: access1,
@@ -313,22 +313,22 @@ func (r *GatewayPluginGraphqlRateLimitingAdvancedResourceModel) ToSharedGraphqlR
 	var partials []shared.GraphqlRateLimitingAdvancedPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.GraphqlRateLimitingAdvancedPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -342,8 +342,8 @@ func (r *GatewayPluginGraphqlRateLimitingAdvancedResourceModel) ToSharedGraphqlR
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -377,8 +377,8 @@ func (r *GatewayPluginGraphqlRateLimitingAdvancedResourceModel) ToSharedGraphqlR
 		identifier = nil
 	}
 	limit := make([]float64, 0, len(r.Config.Limit))
-	for _, limitItem := range r.Config.Limit {
-		limit = append(limit, limitItem.ValueFloat64())
+	for limitIndex := range r.Config.Limit {
+		limit = append(limit, r.Config.Limit[limitIndex].ValueFloat64())
 	}
 	maxCost := new(float64)
 	if !r.Config.MaxCost.IsUnknown() && !r.Config.MaxCost.IsNull() {
@@ -409,16 +409,16 @@ func (r *GatewayPluginGraphqlRateLimitingAdvancedResourceModel) ToSharedGraphqlR
 		var clusterNodes []shared.GraphqlRateLimitingAdvancedPluginClusterNodes
 		if r.Config.Redis.ClusterNodes != nil {
 			clusterNodes = make([]shared.GraphqlRateLimitingAdvancedPluginClusterNodes, 0, len(r.Config.Redis.ClusterNodes))
-			for _, clusterNodesItem := range r.Config.Redis.ClusterNodes {
+			for clusterNodesIndex := range r.Config.Redis.ClusterNodes {
 				ip := new(string)
-				if !clusterNodesItem.IP.IsUnknown() && !clusterNodesItem.IP.IsNull() {
-					*ip = clusterNodesItem.IP.ValueString()
+				if !r.Config.Redis.ClusterNodes[clusterNodesIndex].IP.IsUnknown() && !r.Config.Redis.ClusterNodes[clusterNodesIndex].IP.IsNull() {
+					*ip = r.Config.Redis.ClusterNodes[clusterNodesIndex].IP.ValueString()
 				} else {
 					ip = nil
 				}
 				port := new(int64)
-				if !clusterNodesItem.Port.IsUnknown() && !clusterNodesItem.Port.IsNull() {
-					*port = clusterNodesItem.Port.ValueInt64()
+				if !r.Config.Redis.ClusterNodes[clusterNodesIndex].Port.IsUnknown() && !r.Config.Redis.ClusterNodes[clusterNodesIndex].Port.IsNull() {
+					*port = r.Config.Redis.ClusterNodes[clusterNodesIndex].Port.ValueInt64()
 				} else {
 					port = nil
 				}
@@ -497,16 +497,16 @@ func (r *GatewayPluginGraphqlRateLimitingAdvancedResourceModel) ToSharedGraphqlR
 		var sentinelNodes []shared.GraphqlRateLimitingAdvancedPluginSentinelNodes
 		if r.Config.Redis.SentinelNodes != nil {
 			sentinelNodes = make([]shared.GraphqlRateLimitingAdvancedPluginSentinelNodes, 0, len(r.Config.Redis.SentinelNodes))
-			for _, sentinelNodesItem := range r.Config.Redis.SentinelNodes {
+			for sentinelNodesIndex := range r.Config.Redis.SentinelNodes {
 				host1 := new(string)
-				if !sentinelNodesItem.Host.IsUnknown() && !sentinelNodesItem.Host.IsNull() {
-					*host1 = sentinelNodesItem.Host.ValueString()
+				if !r.Config.Redis.SentinelNodes[sentinelNodesIndex].Host.IsUnknown() && !r.Config.Redis.SentinelNodes[sentinelNodesIndex].Host.IsNull() {
+					*host1 = r.Config.Redis.SentinelNodes[sentinelNodesIndex].Host.ValueString()
 				} else {
 					host1 = nil
 				}
 				port2 := new(int64)
-				if !sentinelNodesItem.Port.IsUnknown() && !sentinelNodesItem.Port.IsNull() {
-					*port2 = sentinelNodesItem.Port.ValueInt64()
+				if !r.Config.Redis.SentinelNodes[sentinelNodesIndex].Port.IsUnknown() && !r.Config.Redis.SentinelNodes[sentinelNodesIndex].Port.IsNull() {
+					*port2 = r.Config.Redis.SentinelNodes[sentinelNodesIndex].Port.ValueInt64()
 				} else {
 					port2 = nil
 				}
@@ -598,8 +598,8 @@ func (r *GatewayPluginGraphqlRateLimitingAdvancedResourceModel) ToSharedGraphqlR
 	syncRate = r.Config.SyncRate.ValueFloat64()
 
 	windowSize := make([]float64, 0, len(r.Config.WindowSize))
-	for _, windowSizeItem := range r.Config.WindowSize {
-		windowSize = append(windowSize, windowSizeItem.ValueFloat64())
+	for windowSizeIndex := range r.Config.WindowSize {
+		windowSize = append(windowSize, r.Config.WindowSize[windowSizeIndex].ValueFloat64())
 	}
 	windowType := new(shared.GraphqlRateLimitingAdvancedPluginWindowType)
 	if !r.Config.WindowType.IsUnknown() && !r.Config.WindowType.IsNull() {

--- a/internal/provider/gatewayplugingrpcgateway_resource.go
+++ b/internal/provider/gatewayplugingrpcgateway_resource.go
@@ -478,7 +478,10 @@ func (r *GatewayPluginGrpcGatewayResource) Delete(ctx context.Context, req resou
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewayplugingrpcgateway_resource_sdk.go
+++ b/internal/provider/gatewayplugingrpcgateway_resource_sdk.go
@@ -207,8 +207,8 @@ func (r *GatewayPluginGrpcGatewayResourceModel) ToSharedGrpcGatewayPlugin(ctx co
 		var after *shared.GrpcGatewayPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.GrpcGatewayPluginAfter{
 				Access: access,
@@ -217,8 +217,8 @@ func (r *GatewayPluginGrpcGatewayResourceModel) ToSharedGrpcGatewayPlugin(ctx co
 		var before *shared.GrpcGatewayPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.GrpcGatewayPluginBefore{
 				Access: access1,
@@ -232,22 +232,22 @@ func (r *GatewayPluginGrpcGatewayResourceModel) ToSharedGrpcGatewayPlugin(ctx co
 	var partials []shared.GrpcGatewayPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.GrpcGatewayPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -261,8 +261,8 @@ func (r *GatewayPluginGrpcGatewayResourceModel) ToSharedGrpcGatewayPlugin(ctx co
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)

--- a/internal/provider/gatewayplugingrpcweb_resource.go
+++ b/internal/provider/gatewayplugingrpcweb_resource.go
@@ -491,7 +491,10 @@ func (r *GatewayPluginGrpcWebResource) Delete(ctx context.Context, req resource.
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewayplugingrpcweb_resource_sdk.go
+++ b/internal/provider/gatewayplugingrpcweb_resource_sdk.go
@@ -209,8 +209,8 @@ func (r *GatewayPluginGrpcWebResourceModel) ToSharedGrpcWebPlugin(ctx context.Co
 		var after *shared.GrpcWebPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.GrpcWebPluginAfter{
 				Access: access,
@@ -219,8 +219,8 @@ func (r *GatewayPluginGrpcWebResourceModel) ToSharedGrpcWebPlugin(ctx context.Co
 		var before *shared.GrpcWebPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.GrpcWebPluginBefore{
 				Access: access1,
@@ -234,22 +234,22 @@ func (r *GatewayPluginGrpcWebResourceModel) ToSharedGrpcWebPlugin(ctx context.Co
 	var partials []shared.GrpcWebPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.GrpcWebPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -263,8 +263,8 @@ func (r *GatewayPluginGrpcWebResourceModel) ToSharedGrpcWebPlugin(ctx context.Co
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)

--- a/internal/provider/gatewaypluginheadercertauth_resource.go
+++ b/internal/provider/gatewaypluginheadercertauth_resource.go
@@ -576,7 +576,10 @@ func (r *GatewayPluginHeaderCertAuthResource) Delete(ctx context.Context, req re
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginheadercertauth_resource_sdk.go
+++ b/internal/provider/gatewaypluginheadercertauth_resource_sdk.go
@@ -227,8 +227,8 @@ func (r *GatewayPluginHeaderCertAuthResourceModel) ToSharedHeaderCertAuthPlugin(
 		var after *shared.HeaderCertAuthPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.HeaderCertAuthPluginAfter{
 				Access: access,
@@ -237,8 +237,8 @@ func (r *GatewayPluginHeaderCertAuthResourceModel) ToSharedHeaderCertAuthPlugin(
 		var before *shared.HeaderCertAuthPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.HeaderCertAuthPluginBefore{
 				Access: access1,
@@ -252,22 +252,22 @@ func (r *GatewayPluginHeaderCertAuthResourceModel) ToSharedHeaderCertAuthPlugin(
 	var partials []shared.HeaderCertAuthPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.HeaderCertAuthPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -281,8 +281,8 @@ func (r *GatewayPluginHeaderCertAuthResourceModel) ToSharedHeaderCertAuthPlugin(
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -310,8 +310,8 @@ func (r *GatewayPluginHeaderCertAuthResourceModel) ToSharedHeaderCertAuthPlugin(
 		authenticatedGroupBy = nil
 	}
 	caCertificates := make([]string, 0, len(r.Config.CaCertificates))
-	for _, caCertificatesItem := range r.Config.CaCertificates {
-		caCertificates = append(caCertificates, caCertificatesItem.ValueString())
+	for caCertificatesIndex := range r.Config.CaCertificates {
+		caCertificates = append(caCertificates, r.Config.CaCertificates[caCertificatesIndex].ValueString())
 	}
 	cacheTTL := new(float64)
 	if !r.Config.CacheTTL.IsUnknown() && !r.Config.CacheTTL.IsNull() {

--- a/internal/provider/gatewaypluginhmacauth_resource.go
+++ b/internal/provider/gatewaypluginhmacauth_resource.go
@@ -518,7 +518,10 @@ func (r *GatewayPluginHmacAuthResource) Delete(ctx context.Context, req resource
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginhmacauth_resource_sdk.go
+++ b/internal/provider/gatewaypluginhmacauth_resource_sdk.go
@@ -213,8 +213,8 @@ func (r *GatewayPluginHmacAuthResourceModel) ToSharedHmacAuthPlugin(ctx context.
 		var after *shared.HmacAuthPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.HmacAuthPluginAfter{
 				Access: access,
@@ -223,8 +223,8 @@ func (r *GatewayPluginHmacAuthResourceModel) ToSharedHmacAuthPlugin(ctx context.
 		var before *shared.HmacAuthPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.HmacAuthPluginBefore{
 				Access: access1,
@@ -238,22 +238,22 @@ func (r *GatewayPluginHmacAuthResourceModel) ToSharedHmacAuthPlugin(ctx context.
 	var partials []shared.HmacAuthPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.HmacAuthPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -267,8 +267,8 @@ func (r *GatewayPluginHmacAuthResourceModel) ToSharedHmacAuthPlugin(ctx context.
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -296,8 +296,8 @@ func (r *GatewayPluginHmacAuthResourceModel) ToSharedHmacAuthPlugin(ctx context.
 			clockSkew = nil
 		}
 		enforceHeaders := make([]string, 0, len(r.Config.EnforceHeaders))
-		for _, enforceHeadersItem := range r.Config.EnforceHeaders {
-			enforceHeaders = append(enforceHeaders, enforceHeadersItem.ValueString())
+		for enforceHeadersIndex := range r.Config.EnforceHeaders {
+			enforceHeaders = append(enforceHeaders, r.Config.EnforceHeaders[enforceHeadersIndex].ValueString())
 		}
 		hideCredentials := new(bool)
 		if !r.Config.HideCredentials.IsUnknown() && !r.Config.HideCredentials.IsNull() {

--- a/internal/provider/gatewaypluginhttplog_resource.go
+++ b/internal/provider/gatewaypluginhttplog_resource.go
@@ -617,7 +617,10 @@ func (r *GatewayPluginHTTPLogResource) Delete(ctx context.Context, req resource.
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginhttplog_resource_sdk.go
+++ b/internal/provider/gatewaypluginhttplog_resource_sdk.go
@@ -246,8 +246,8 @@ func (r *GatewayPluginHTTPLogResourceModel) ToSharedHTTPLogPlugin(ctx context.Co
 		var after *shared.HTTPLogPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.HTTPLogPluginAfter{
 				Access: access,
@@ -256,8 +256,8 @@ func (r *GatewayPluginHTTPLogResourceModel) ToSharedHTTPLogPlugin(ctx context.Co
 		var before *shared.HTTPLogPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.HTTPLogPluginBefore{
 				Access: access1,
@@ -271,22 +271,22 @@ func (r *GatewayPluginHTTPLogResourceModel) ToSharedHTTPLogPlugin(ctx context.Co
 	var partials []shared.HTTPLogPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.HTTPLogPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -300,8 +300,8 @@ func (r *GatewayPluginHTTPLogResourceModel) ToSharedHTTPLogPlugin(ctx context.Co
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -319,9 +319,9 @@ func (r *GatewayPluginHTTPLogResourceModel) ToSharedHTTPLogPlugin(ctx context.Co
 	var customFieldsByLua map[string]string
 	if r.Config.CustomFieldsByLua != nil {
 		customFieldsByLua = make(map[string]string)
-		for customFieldsByLuaKey, customFieldsByLuaValue := range r.Config.CustomFieldsByLua {
+		for customFieldsByLuaKey := range r.Config.CustomFieldsByLua {
 			var customFieldsByLuaInst string
-			customFieldsByLuaInst = customFieldsByLuaValue.ValueString()
+			customFieldsByLuaInst = r.Config.CustomFieldsByLua[customFieldsByLuaKey].ValueString()
 
 			customFieldsByLua[customFieldsByLuaKey] = customFieldsByLuaInst
 		}
@@ -335,9 +335,9 @@ func (r *GatewayPluginHTTPLogResourceModel) ToSharedHTTPLogPlugin(ctx context.Co
 	var headers map[string]string
 	if r.Config.Headers != nil {
 		headers = make(map[string]string)
-		for headersKey, headersValue := range r.Config.Headers {
+		for headersKey := range r.Config.Headers {
 			var headersInst string
-			headersInst = headersValue.ValueString()
+			headersInst = r.Config.Headers[headersKey].ValueString()
 
 			headers[headersKey] = headersInst
 		}

--- a/internal/provider/gatewayplugininjectionprotection_resource.go
+++ b/internal/provider/gatewayplugininjectionprotection_resource.go
@@ -548,7 +548,10 @@ func (r *GatewayPluginInjectionProtectionResource) Delete(ctx context.Context, r
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewayplugininjectionprotection_resource_sdk.go
+++ b/internal/provider/gatewayplugininjectionprotection_resource_sdk.go
@@ -227,8 +227,8 @@ func (r *GatewayPluginInjectionProtectionResourceModel) ToSharedInjectionProtect
 		var after *shared.InjectionProtectionPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.InjectionProtectionPluginAfter{
 				Access: access,
@@ -237,8 +237,8 @@ func (r *GatewayPluginInjectionProtectionResourceModel) ToSharedInjectionProtect
 		var before *shared.InjectionProtectionPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.InjectionProtectionPluginBefore{
 				Access: access1,
@@ -252,22 +252,22 @@ func (r *GatewayPluginInjectionProtectionResourceModel) ToSharedInjectionProtect
 	var partials []shared.InjectionProtectionPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.InjectionProtectionPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -281,8 +281,8 @@ func (r *GatewayPluginInjectionProtectionResourceModel) ToSharedInjectionProtect
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -296,12 +296,12 @@ func (r *GatewayPluginInjectionProtectionResourceModel) ToSharedInjectionProtect
 		var customInjections []shared.CustomInjections
 		if r.Config.CustomInjections != nil {
 			customInjections = make([]shared.CustomInjections, 0, len(r.Config.CustomInjections))
-			for _, customInjectionsItem := range r.Config.CustomInjections {
+			for customInjectionsIndex := range r.Config.CustomInjections {
 				var name1 string
-				name1 = customInjectionsItem.Name.ValueString()
+				name1 = r.Config.CustomInjections[customInjectionsIndex].Name.ValueString()
 
 				var regex string
-				regex = customInjectionsItem.Regex.ValueString()
+				regex = r.Config.CustomInjections[customInjectionsIndex].Regex.ValueString()
 
 				customInjections = append(customInjections, shared.CustomInjections{
 					Name:  name1,

--- a/internal/provider/gatewaypluginiprestriction_resource.go
+++ b/internal/provider/gatewaypluginiprestriction_resource.go
@@ -516,7 +516,10 @@ func (r *GatewayPluginIPRestrictionResource) Delete(ctx context.Context, req res
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginiprestriction_resource_sdk.go
+++ b/internal/provider/gatewaypluginiprestriction_resource_sdk.go
@@ -226,8 +226,8 @@ func (r *GatewayPluginIPRestrictionResourceModel) ToSharedIPRestrictionPlugin(ct
 		var after *shared.IPRestrictionPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.IPRestrictionPluginAfter{
 				Access: access,
@@ -236,8 +236,8 @@ func (r *GatewayPluginIPRestrictionResourceModel) ToSharedIPRestrictionPlugin(ct
 		var before *shared.IPRestrictionPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.IPRestrictionPluginBefore{
 				Access: access1,
@@ -251,22 +251,22 @@ func (r *GatewayPluginIPRestrictionResourceModel) ToSharedIPRestrictionPlugin(ct
 	var partials []shared.IPRestrictionPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.IPRestrictionPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -280,8 +280,8 @@ func (r *GatewayPluginIPRestrictionResourceModel) ToSharedIPRestrictionPlugin(ct
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -295,15 +295,15 @@ func (r *GatewayPluginIPRestrictionResourceModel) ToSharedIPRestrictionPlugin(ct
 		var allow []string
 		if r.Config.Allow != nil {
 			allow = make([]string, 0, len(r.Config.Allow))
-			for _, allowItem := range r.Config.Allow {
-				allow = append(allow, allowItem.ValueString())
+			for allowIndex := range r.Config.Allow {
+				allow = append(allow, r.Config.Allow[allowIndex].ValueString())
 			}
 		}
 		var deny []string
 		if r.Config.Deny != nil {
 			deny = make([]string, 0, len(r.Config.Deny))
-			for _, denyItem := range r.Config.Deny {
-				deny = append(deny, denyItem.ValueString())
+			for denyIndex := range r.Config.Deny {
+				deny = append(deny, r.Config.Deny[denyIndex].ValueString())
 			}
 		}
 		message := new(string)

--- a/internal/provider/gatewaypluginjq_resource.go
+++ b/internal/provider/gatewaypluginjq_resource.go
@@ -616,7 +616,10 @@ func (r *GatewayPluginJqResource) Delete(ctx context.Context, req resource.Delet
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginjq_resource_sdk.go
+++ b/internal/provider/gatewaypluginjq_resource_sdk.go
@@ -240,8 +240,8 @@ func (r *GatewayPluginJqResourceModel) ToSharedJqPlugin(ctx context.Context) (*s
 		var after *shared.JqPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.JqPluginAfter{
 				Access: access,
@@ -250,8 +250,8 @@ func (r *GatewayPluginJqResourceModel) ToSharedJqPlugin(ctx context.Context) (*s
 		var before *shared.JqPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.JqPluginBefore{
 				Access: access1,
@@ -265,22 +265,22 @@ func (r *GatewayPluginJqResourceModel) ToSharedJqPlugin(ctx context.Context) (*s
 	var partials []shared.JqPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.JqPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -294,8 +294,8 @@ func (r *GatewayPluginJqResourceModel) ToSharedJqPlugin(ctx context.Context) (*s
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -307,8 +307,8 @@ func (r *GatewayPluginJqResourceModel) ToSharedJqPlugin(ctx context.Context) (*s
 	var config *shared.JqPluginConfig
 	if r.Config != nil {
 		requestIfMediaType := make([]string, 0, len(r.Config.RequestIfMediaType))
-		for _, requestIfMediaTypeItem := range r.Config.RequestIfMediaType {
-			requestIfMediaType = append(requestIfMediaType, requestIfMediaTypeItem.ValueString())
+		for requestIfMediaTypeIndex := range r.Config.RequestIfMediaType {
+			requestIfMediaType = append(requestIfMediaType, r.Config.RequestIfMediaType[requestIfMediaTypeIndex].ValueString())
 		}
 		requestJqProgram := new(string)
 		if !r.Config.RequestJqProgram.IsUnknown() && !r.Config.RequestJqProgram.IsNull() {
@@ -357,12 +357,12 @@ func (r *GatewayPluginJqResourceModel) ToSharedJqPlugin(ctx context.Context) (*s
 			}
 		}
 		responseIfMediaType := make([]string, 0, len(r.Config.ResponseIfMediaType))
-		for _, responseIfMediaTypeItem := range r.Config.ResponseIfMediaType {
-			responseIfMediaType = append(responseIfMediaType, responseIfMediaTypeItem.ValueString())
+		for responseIfMediaTypeIndex := range r.Config.ResponseIfMediaType {
+			responseIfMediaType = append(responseIfMediaType, r.Config.ResponseIfMediaType[responseIfMediaTypeIndex].ValueString())
 		}
 		responseIfStatusCode := make([]int64, 0, len(r.Config.ResponseIfStatusCode))
-		for _, responseIfStatusCodeItem := range r.Config.ResponseIfStatusCode {
-			responseIfStatusCode = append(responseIfStatusCode, responseIfStatusCodeItem.ValueInt64())
+		for responseIfStatusCodeIndex := range r.Config.ResponseIfStatusCode {
+			responseIfStatusCode = append(responseIfStatusCode, r.Config.ResponseIfStatusCode[responseIfStatusCodeIndex].ValueInt64())
 		}
 		responseJqProgram := new(string)
 		if !r.Config.ResponseJqProgram.IsUnknown() && !r.Config.ResponseJqProgram.IsNull() {

--- a/internal/provider/gatewaypluginjsonthreatprotection_resource.go
+++ b/internal/provider/gatewaypluginjsonthreatprotection_resource.go
@@ -558,7 +558,10 @@ func (r *GatewayPluginJSONThreatProtectionResource) Delete(ctx context.Context, 
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginjsonthreatprotection_resource_sdk.go
+++ b/internal/provider/gatewaypluginjsonthreatprotection_resource_sdk.go
@@ -214,8 +214,8 @@ func (r *GatewayPluginJSONThreatProtectionResourceModel) ToSharedJSONThreatProte
 		var after *shared.JSONThreatProtectionPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.JSONThreatProtectionPluginAfter{
 				Access: access,
@@ -224,8 +224,8 @@ func (r *GatewayPluginJSONThreatProtectionResourceModel) ToSharedJSONThreatProte
 		var before *shared.JSONThreatProtectionPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.JSONThreatProtectionPluginBefore{
 				Access: access1,
@@ -239,22 +239,22 @@ func (r *GatewayPluginJSONThreatProtectionResourceModel) ToSharedJSONThreatProte
 	var partials []shared.JSONThreatProtectionPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.JSONThreatProtectionPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -268,8 +268,8 @@ func (r *GatewayPluginJSONThreatProtectionResourceModel) ToSharedJSONThreatProte
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)

--- a/internal/provider/gatewaypluginjwedecrypt_resource.go
+++ b/internal/provider/gatewaypluginjwedecrypt_resource.go
@@ -479,7 +479,10 @@ func (r *GatewayPluginJweDecryptResource) Delete(ctx context.Context, req resour
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginjwedecrypt_resource_sdk.go
+++ b/internal/provider/gatewaypluginjwedecrypt_resource_sdk.go
@@ -202,8 +202,8 @@ func (r *GatewayPluginJweDecryptResourceModel) ToSharedJweDecryptPlugin(ctx cont
 		var after *shared.JweDecryptPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.JweDecryptPluginAfter{
 				Access: access,
@@ -212,8 +212,8 @@ func (r *GatewayPluginJweDecryptResourceModel) ToSharedJweDecryptPlugin(ctx cont
 		var before *shared.JweDecryptPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.JweDecryptPluginBefore{
 				Access: access1,
@@ -227,22 +227,22 @@ func (r *GatewayPluginJweDecryptResourceModel) ToSharedJweDecryptPlugin(ctx cont
 	var partials []shared.JweDecryptPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.JweDecryptPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -256,8 +256,8 @@ func (r *GatewayPluginJweDecryptResourceModel) ToSharedJweDecryptPlugin(ctx cont
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -273,8 +273,8 @@ func (r *GatewayPluginJweDecryptResourceModel) ToSharedJweDecryptPlugin(ctx cont
 		forwardHeaderName = nil
 	}
 	keySets := make([]string, 0, len(r.Config.KeySets))
-	for _, keySetsItem := range r.Config.KeySets {
-		keySets = append(keySets, keySetsItem.ValueString())
+	for keySetsIndex := range r.Config.KeySets {
+		keySets = append(keySets, r.Config.KeySets[keySetsIndex].ValueString())
 	}
 	lookupHeaderName := new(string)
 	if !r.Config.LookupHeaderName.IsUnknown() && !r.Config.LookupHeaderName.IsNull() {

--- a/internal/provider/gatewaypluginjwt_resource.go
+++ b/internal/provider/gatewaypluginjwt_resource.go
@@ -541,7 +541,10 @@ func (r *GatewayPluginJwtResource) Delete(ctx context.Context, req resource.Dele
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginjwt_resource_sdk.go
+++ b/internal/provider/gatewaypluginjwt_resource_sdk.go
@@ -224,8 +224,8 @@ func (r *GatewayPluginJwtResourceModel) ToSharedJwtPlugin(ctx context.Context) (
 		var after *shared.JwtPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.JwtPluginAfter{
 				Access: access,
@@ -234,8 +234,8 @@ func (r *GatewayPluginJwtResourceModel) ToSharedJwtPlugin(ctx context.Context) (
 		var before *shared.JwtPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.JwtPluginBefore{
 				Access: access1,
@@ -249,22 +249,22 @@ func (r *GatewayPluginJwtResourceModel) ToSharedJwtPlugin(ctx context.Context) (
 	var partials []shared.JwtPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.JwtPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -278,8 +278,8 @@ func (r *GatewayPluginJwtResourceModel) ToSharedJwtPlugin(ctx context.Context) (
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -304,12 +304,12 @@ func (r *GatewayPluginJwtResourceModel) ToSharedJwtPlugin(ctx context.Context) (
 			}
 		}
 		cookieNames := make([]string, 0, len(r.Config.CookieNames))
-		for _, cookieNamesItem := range r.Config.CookieNames {
-			cookieNames = append(cookieNames, cookieNamesItem.ValueString())
+		for cookieNamesIndex := range r.Config.CookieNames {
+			cookieNames = append(cookieNames, r.Config.CookieNames[cookieNamesIndex].ValueString())
 		}
 		headerNames := make([]string, 0, len(r.Config.HeaderNames))
-		for _, headerNamesItem := range r.Config.HeaderNames {
-			headerNames = append(headerNames, headerNamesItem.ValueString())
+		for headerNamesIndex := range r.Config.HeaderNames {
+			headerNames = append(headerNames, r.Config.HeaderNames[headerNamesIndex].ValueString())
 		}
 		keyClaimName := new(string)
 		if !r.Config.KeyClaimName.IsUnknown() && !r.Config.KeyClaimName.IsNull() {
@@ -342,8 +342,8 @@ func (r *GatewayPluginJwtResourceModel) ToSharedJwtPlugin(ctx context.Context) (
 			secretIsBase64 = nil
 		}
 		uriParamNames := make([]string, 0, len(r.Config.URIParamNames))
-		for _, uriParamNamesItem := range r.Config.URIParamNames {
-			uriParamNames = append(uriParamNames, uriParamNamesItem.ValueString())
+		for uriParamNamesIndex := range r.Config.URIParamNames {
+			uriParamNames = append(uriParamNames, r.Config.URIParamNames[uriParamNamesIndex].ValueString())
 		}
 		config = &shared.JwtPluginConfig{
 			Anonymous:         anonymous,

--- a/internal/provider/gatewaypluginjwtsigner_resource.go
+++ b/internal/provider/gatewaypluginjwtsigner_resource.go
@@ -1720,7 +1720,10 @@ func (r *GatewayPluginJwtSignerResource) Delete(ctx context.Context, req resourc
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginjwtsigner_resource_sdk.go
+++ b/internal/provider/gatewaypluginjwtsigner_resource_sdk.go
@@ -689,8 +689,8 @@ func (r *GatewayPluginJwtSignerResourceModel) ToSharedJwtSignerPlugin(ctx contex
 		var after *shared.JwtSignerPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.JwtSignerPluginAfter{
 				Access: access,
@@ -699,8 +699,8 @@ func (r *GatewayPluginJwtSignerResourceModel) ToSharedJwtSignerPlugin(ctx contex
 		var before *shared.JwtSignerPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.JwtSignerPluginBefore{
 				Access: access1,
@@ -714,22 +714,22 @@ func (r *GatewayPluginJwtSignerResourceModel) ToSharedJwtSignerPlugin(ctx contex
 	var partials []shared.JwtSignerPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.JwtSignerPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -743,8 +743,8 @@ func (r *GatewayPluginJwtSignerResourceModel) ToSharedJwtSignerPlugin(ctx contex
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -756,14 +756,14 @@ func (r *GatewayPluginJwtSignerResourceModel) ToSharedJwtSignerPlugin(ctx contex
 	var config *shared.JwtSignerPluginConfig
 	if r.Config != nil {
 		accessTokenAudienceClaim := make([]string, 0, len(r.Config.AccessTokenAudienceClaim))
-		for _, accessTokenAudienceClaimItem := range r.Config.AccessTokenAudienceClaim {
-			accessTokenAudienceClaim = append(accessTokenAudienceClaim, accessTokenAudienceClaimItem.ValueString())
+		for accessTokenAudienceClaimIndex := range r.Config.AccessTokenAudienceClaim {
+			accessTokenAudienceClaim = append(accessTokenAudienceClaim, r.Config.AccessTokenAudienceClaim[accessTokenAudienceClaimIndex].ValueString())
 		}
 		var accessTokenAudiencesAllowed []string
 		if r.Config.AccessTokenAudiencesAllowed != nil {
 			accessTokenAudiencesAllowed = make([]string, 0, len(r.Config.AccessTokenAudiencesAllowed))
-			for _, accessTokenAudiencesAllowedItem := range r.Config.AccessTokenAudiencesAllowed {
-				accessTokenAudiencesAllowed = append(accessTokenAudiencesAllowed, accessTokenAudiencesAllowedItem.ValueString())
+			for accessTokenAudiencesAllowedIndex := range r.Config.AccessTokenAudiencesAllowed {
+				accessTokenAudiencesAllowed = append(accessTokenAudiencesAllowed, r.Config.AccessTokenAudiencesAllowed[accessTokenAudiencesAllowedIndex].ValueString())
 			}
 		}
 		accessTokenConsumerBy := make([]shared.AccessTokenConsumerBy, 0, len(r.Config.AccessTokenConsumerBy))
@@ -773,23 +773,23 @@ func (r *GatewayPluginJwtSignerResourceModel) ToSharedJwtSignerPlugin(ctx contex
 		var accessTokenConsumerClaim []string
 		if r.Config.AccessTokenConsumerClaim != nil {
 			accessTokenConsumerClaim = make([]string, 0, len(r.Config.AccessTokenConsumerClaim))
-			for _, accessTokenConsumerClaimItem := range r.Config.AccessTokenConsumerClaim {
-				accessTokenConsumerClaim = append(accessTokenConsumerClaim, accessTokenConsumerClaimItem.ValueString())
+			for accessTokenConsumerClaimIndex := range r.Config.AccessTokenConsumerClaim {
+				accessTokenConsumerClaim = append(accessTokenConsumerClaim, r.Config.AccessTokenConsumerClaim[accessTokenConsumerClaimIndex].ValueString())
 			}
 		}
 		accessTokenExpiryClaim := make([]string, 0, len(r.Config.AccessTokenExpiryClaim))
-		for _, accessTokenExpiryClaimItem := range r.Config.AccessTokenExpiryClaim {
-			accessTokenExpiryClaim = append(accessTokenExpiryClaim, accessTokenExpiryClaimItem.ValueString())
+		for accessTokenExpiryClaimIndex := range r.Config.AccessTokenExpiryClaim {
+			accessTokenExpiryClaim = append(accessTokenExpiryClaim, r.Config.AccessTokenExpiryClaim[accessTokenExpiryClaimIndex].ValueString())
 		}
 		accessTokenIntrospectionAudienceClaim := make([]string, 0, len(r.Config.AccessTokenIntrospectionAudienceClaim))
-		for _, accessTokenIntrospectionAudienceClaimItem := range r.Config.AccessTokenIntrospectionAudienceClaim {
-			accessTokenIntrospectionAudienceClaim = append(accessTokenIntrospectionAudienceClaim, accessTokenIntrospectionAudienceClaimItem.ValueString())
+		for accessTokenIntrospectionAudienceClaimIndex := range r.Config.AccessTokenIntrospectionAudienceClaim {
+			accessTokenIntrospectionAudienceClaim = append(accessTokenIntrospectionAudienceClaim, r.Config.AccessTokenIntrospectionAudienceClaim[accessTokenIntrospectionAudienceClaimIndex].ValueString())
 		}
 		var accessTokenIntrospectionAudiencesAllowed []string
 		if r.Config.AccessTokenIntrospectionAudiencesAllowed != nil {
 			accessTokenIntrospectionAudiencesAllowed = make([]string, 0, len(r.Config.AccessTokenIntrospectionAudiencesAllowed))
-			for _, accessTokenIntrospectionAudiencesAllowedItem := range r.Config.AccessTokenIntrospectionAudiencesAllowed {
-				accessTokenIntrospectionAudiencesAllowed = append(accessTokenIntrospectionAudiencesAllowed, accessTokenIntrospectionAudiencesAllowedItem.ValueString())
+			for accessTokenIntrospectionAudiencesAllowedIndex := range r.Config.AccessTokenIntrospectionAudiencesAllowed {
+				accessTokenIntrospectionAudiencesAllowed = append(accessTokenIntrospectionAudiencesAllowed, r.Config.AccessTokenIntrospectionAudiencesAllowed[accessTokenIntrospectionAudiencesAllowedIndex].ValueString())
 			}
 		}
 		accessTokenIntrospectionAuthorization := new(string)
@@ -811,8 +811,8 @@ func (r *GatewayPluginJwtSignerResourceModel) ToSharedJwtSignerPlugin(ctx contex
 		var accessTokenIntrospectionConsumerClaim []string
 		if r.Config.AccessTokenIntrospectionConsumerClaim != nil {
 			accessTokenIntrospectionConsumerClaim = make([]string, 0, len(r.Config.AccessTokenIntrospectionConsumerClaim))
-			for _, accessTokenIntrospectionConsumerClaimItem := range r.Config.AccessTokenIntrospectionConsumerClaim {
-				accessTokenIntrospectionConsumerClaim = append(accessTokenIntrospectionConsumerClaim, accessTokenIntrospectionConsumerClaimItem.ValueString())
+			for accessTokenIntrospectionConsumerClaimIndex := range r.Config.AccessTokenIntrospectionConsumerClaim {
+				accessTokenIntrospectionConsumerClaim = append(accessTokenIntrospectionConsumerClaim, r.Config.AccessTokenIntrospectionConsumerClaim[accessTokenIntrospectionConsumerClaimIndex].ValueString())
 			}
 		}
 		accessTokenIntrospectionEndpoint := new(string)
@@ -822,8 +822,8 @@ func (r *GatewayPluginJwtSignerResourceModel) ToSharedJwtSignerPlugin(ctx contex
 			accessTokenIntrospectionEndpoint = nil
 		}
 		accessTokenIntrospectionExpiryClaim := make([]string, 0, len(r.Config.AccessTokenIntrospectionExpiryClaim))
-		for _, accessTokenIntrospectionExpiryClaimItem := range r.Config.AccessTokenIntrospectionExpiryClaim {
-			accessTokenIntrospectionExpiryClaim = append(accessTokenIntrospectionExpiryClaim, accessTokenIntrospectionExpiryClaimItem.ValueString())
+		for accessTokenIntrospectionExpiryClaimIndex := range r.Config.AccessTokenIntrospectionExpiryClaim {
+			accessTokenIntrospectionExpiryClaim = append(accessTokenIntrospectionExpiryClaim, r.Config.AccessTokenIntrospectionExpiryClaim[accessTokenIntrospectionExpiryClaimIndex].ValueString())
 		}
 		accessTokenIntrospectionHint := new(string)
 		if !r.Config.AccessTokenIntrospectionHint.IsUnknown() && !r.Config.AccessTokenIntrospectionHint.IsNull() {
@@ -832,21 +832,21 @@ func (r *GatewayPluginJwtSignerResourceModel) ToSharedJwtSignerPlugin(ctx contex
 			accessTokenIntrospectionHint = nil
 		}
 		accessTokenIntrospectionIssuerClaim := make([]string, 0, len(r.Config.AccessTokenIntrospectionIssuerClaim))
-		for _, accessTokenIntrospectionIssuerClaimItem := range r.Config.AccessTokenIntrospectionIssuerClaim {
-			accessTokenIntrospectionIssuerClaim = append(accessTokenIntrospectionIssuerClaim, accessTokenIntrospectionIssuerClaimItem.ValueString())
+		for accessTokenIntrospectionIssuerClaimIndex := range r.Config.AccessTokenIntrospectionIssuerClaim {
+			accessTokenIntrospectionIssuerClaim = append(accessTokenIntrospectionIssuerClaim, r.Config.AccessTokenIntrospectionIssuerClaim[accessTokenIntrospectionIssuerClaimIndex].ValueString())
 		}
 		var accessTokenIntrospectionIssuersAllowed []string
 		if r.Config.AccessTokenIntrospectionIssuersAllowed != nil {
 			accessTokenIntrospectionIssuersAllowed = make([]string, 0, len(r.Config.AccessTokenIntrospectionIssuersAllowed))
-			for _, accessTokenIntrospectionIssuersAllowedItem := range r.Config.AccessTokenIntrospectionIssuersAllowed {
-				accessTokenIntrospectionIssuersAllowed = append(accessTokenIntrospectionIssuersAllowed, accessTokenIntrospectionIssuersAllowedItem.ValueString())
+			for accessTokenIntrospectionIssuersAllowedIndex := range r.Config.AccessTokenIntrospectionIssuersAllowed {
+				accessTokenIntrospectionIssuersAllowed = append(accessTokenIntrospectionIssuersAllowed, r.Config.AccessTokenIntrospectionIssuersAllowed[accessTokenIntrospectionIssuersAllowedIndex].ValueString())
 			}
 		}
 		var accessTokenIntrospectionJwtClaim []string
 		if r.Config.AccessTokenIntrospectionJwtClaim != nil {
 			accessTokenIntrospectionJwtClaim = make([]string, 0, len(r.Config.AccessTokenIntrospectionJwtClaim))
-			for _, accessTokenIntrospectionJwtClaimItem := range r.Config.AccessTokenIntrospectionJwtClaim {
-				accessTokenIntrospectionJwtClaim = append(accessTokenIntrospectionJwtClaim, accessTokenIntrospectionJwtClaimItem.ValueString())
+			for accessTokenIntrospectionJwtClaimIndex := range r.Config.AccessTokenIntrospectionJwtClaim {
+				accessTokenIntrospectionJwtClaim = append(accessTokenIntrospectionJwtClaim, r.Config.AccessTokenIntrospectionJwtClaim[accessTokenIntrospectionJwtClaimIndex].ValueString())
 			}
 		}
 		accessTokenIntrospectionLeeway := new(float64)
@@ -856,16 +856,16 @@ func (r *GatewayPluginJwtSignerResourceModel) ToSharedJwtSignerPlugin(ctx contex
 			accessTokenIntrospectionLeeway = nil
 		}
 		accessTokenIntrospectionNotbeforeClaim := make([]string, 0, len(r.Config.AccessTokenIntrospectionNotbeforeClaim))
-		for _, accessTokenIntrospectionNotbeforeClaimItem := range r.Config.AccessTokenIntrospectionNotbeforeClaim {
-			accessTokenIntrospectionNotbeforeClaim = append(accessTokenIntrospectionNotbeforeClaim, accessTokenIntrospectionNotbeforeClaimItem.ValueString())
+		for accessTokenIntrospectionNotbeforeClaimIndex := range r.Config.AccessTokenIntrospectionNotbeforeClaim {
+			accessTokenIntrospectionNotbeforeClaim = append(accessTokenIntrospectionNotbeforeClaim, r.Config.AccessTokenIntrospectionNotbeforeClaim[accessTokenIntrospectionNotbeforeClaimIndex].ValueString())
 		}
 		var accessTokenIntrospectionOptionalClaims [][]string
 		if r.Config.AccessTokenIntrospectionOptionalClaims != nil {
 			accessTokenIntrospectionOptionalClaims = make([][]string, 0, len(r.Config.AccessTokenIntrospectionOptionalClaims))
-			for _, accessTokenIntrospectionOptionalClaimsItem := range r.Config.AccessTokenIntrospectionOptionalClaims {
-				accessTokenIntrospectionOptionalClaimsTmp := make([]string, 0, len(accessTokenIntrospectionOptionalClaimsItem))
-				for _, item := range accessTokenIntrospectionOptionalClaimsItem {
-					accessTokenIntrospectionOptionalClaimsTmp = append(accessTokenIntrospectionOptionalClaimsTmp, item.ValueString())
+			for accessTokenIntrospectionOptionalClaimsIndex := range r.Config.AccessTokenIntrospectionOptionalClaims {
+				accessTokenIntrospectionOptionalClaimsTmp := make([]string, 0, len(r.Config.AccessTokenIntrospectionOptionalClaims[accessTokenIntrospectionOptionalClaimsIndex]))
+				for index := range r.Config.AccessTokenIntrospectionOptionalClaims[accessTokenIntrospectionOptionalClaimsIndex] {
+					accessTokenIntrospectionOptionalClaimsTmp = append(accessTokenIntrospectionOptionalClaimsTmp, r.Config.AccessTokenIntrospectionOptionalClaims[accessTokenIntrospectionOptionalClaimsIndex][index].ValueString())
 				}
 				accessTokenIntrospectionOptionalClaims = append(accessTokenIntrospectionOptionalClaims, accessTokenIntrospectionOptionalClaimsTmp)
 			}
@@ -873,34 +873,34 @@ func (r *GatewayPluginJwtSignerResourceModel) ToSharedJwtSignerPlugin(ctx contex
 		var accessTokenIntrospectionRequiredClaims [][]string
 		if r.Config.AccessTokenIntrospectionRequiredClaims != nil {
 			accessTokenIntrospectionRequiredClaims = make([][]string, 0, len(r.Config.AccessTokenIntrospectionRequiredClaims))
-			for _, accessTokenIntrospectionRequiredClaimsItem := range r.Config.AccessTokenIntrospectionRequiredClaims {
-				accessTokenIntrospectionRequiredClaimsTmp := make([]string, 0, len(accessTokenIntrospectionRequiredClaimsItem))
-				for _, item1 := range accessTokenIntrospectionRequiredClaimsItem {
-					accessTokenIntrospectionRequiredClaimsTmp = append(accessTokenIntrospectionRequiredClaimsTmp, item1.ValueString())
+			for accessTokenIntrospectionRequiredClaimsIndex := range r.Config.AccessTokenIntrospectionRequiredClaims {
+				accessTokenIntrospectionRequiredClaimsTmp := make([]string, 0, len(r.Config.AccessTokenIntrospectionRequiredClaims[accessTokenIntrospectionRequiredClaimsIndex]))
+				for index1 := range r.Config.AccessTokenIntrospectionRequiredClaims[accessTokenIntrospectionRequiredClaimsIndex] {
+					accessTokenIntrospectionRequiredClaimsTmp = append(accessTokenIntrospectionRequiredClaimsTmp, r.Config.AccessTokenIntrospectionRequiredClaims[accessTokenIntrospectionRequiredClaimsIndex][index1].ValueString())
 				}
 				accessTokenIntrospectionRequiredClaims = append(accessTokenIntrospectionRequiredClaims, accessTokenIntrospectionRequiredClaimsTmp)
 			}
 		}
 		accessTokenIntrospectionScopesClaim := make([]string, 0, len(r.Config.AccessTokenIntrospectionScopesClaim))
-		for _, accessTokenIntrospectionScopesClaimItem := range r.Config.AccessTokenIntrospectionScopesClaim {
-			accessTokenIntrospectionScopesClaim = append(accessTokenIntrospectionScopesClaim, accessTokenIntrospectionScopesClaimItem.ValueString())
+		for accessTokenIntrospectionScopesClaimIndex := range r.Config.AccessTokenIntrospectionScopesClaim {
+			accessTokenIntrospectionScopesClaim = append(accessTokenIntrospectionScopesClaim, r.Config.AccessTokenIntrospectionScopesClaim[accessTokenIntrospectionScopesClaimIndex].ValueString())
 		}
 		var accessTokenIntrospectionScopesRequired []string
 		if r.Config.AccessTokenIntrospectionScopesRequired != nil {
 			accessTokenIntrospectionScopesRequired = make([]string, 0, len(r.Config.AccessTokenIntrospectionScopesRequired))
-			for _, accessTokenIntrospectionScopesRequiredItem := range r.Config.AccessTokenIntrospectionScopesRequired {
-				accessTokenIntrospectionScopesRequired = append(accessTokenIntrospectionScopesRequired, accessTokenIntrospectionScopesRequiredItem.ValueString())
+			for accessTokenIntrospectionScopesRequiredIndex := range r.Config.AccessTokenIntrospectionScopesRequired {
+				accessTokenIntrospectionScopesRequired = append(accessTokenIntrospectionScopesRequired, r.Config.AccessTokenIntrospectionScopesRequired[accessTokenIntrospectionScopesRequiredIndex].ValueString())
 			}
 		}
 		accessTokenIntrospectionSubjectClaim := make([]string, 0, len(r.Config.AccessTokenIntrospectionSubjectClaim))
-		for _, accessTokenIntrospectionSubjectClaimItem := range r.Config.AccessTokenIntrospectionSubjectClaim {
-			accessTokenIntrospectionSubjectClaim = append(accessTokenIntrospectionSubjectClaim, accessTokenIntrospectionSubjectClaimItem.ValueString())
+		for accessTokenIntrospectionSubjectClaimIndex := range r.Config.AccessTokenIntrospectionSubjectClaim {
+			accessTokenIntrospectionSubjectClaim = append(accessTokenIntrospectionSubjectClaim, r.Config.AccessTokenIntrospectionSubjectClaim[accessTokenIntrospectionSubjectClaimIndex].ValueString())
 		}
 		var accessTokenIntrospectionSubjectsAllowed []string
 		if r.Config.AccessTokenIntrospectionSubjectsAllowed != nil {
 			accessTokenIntrospectionSubjectsAllowed = make([]string, 0, len(r.Config.AccessTokenIntrospectionSubjectsAllowed))
-			for _, accessTokenIntrospectionSubjectsAllowedItem := range r.Config.AccessTokenIntrospectionSubjectsAllowed {
-				accessTokenIntrospectionSubjectsAllowed = append(accessTokenIntrospectionSubjectsAllowed, accessTokenIntrospectionSubjectsAllowedItem.ValueString())
+			for accessTokenIntrospectionSubjectsAllowedIndex := range r.Config.AccessTokenIntrospectionSubjectsAllowed {
+				accessTokenIntrospectionSubjectsAllowed = append(accessTokenIntrospectionSubjectsAllowed, r.Config.AccessTokenIntrospectionSubjectsAllowed[accessTokenIntrospectionSubjectsAllowedIndex].ValueString())
 			}
 		}
 		accessTokenIntrospectionTimeout := new(float64)
@@ -916,14 +916,14 @@ func (r *GatewayPluginJwtSignerResourceModel) ToSharedJwtSignerPlugin(ctx contex
 			accessTokenIssuer = nil
 		}
 		accessTokenIssuerClaim := make([]string, 0, len(r.Config.AccessTokenIssuerClaim))
-		for _, accessTokenIssuerClaimItem := range r.Config.AccessTokenIssuerClaim {
-			accessTokenIssuerClaim = append(accessTokenIssuerClaim, accessTokenIssuerClaimItem.ValueString())
+		for accessTokenIssuerClaimIndex := range r.Config.AccessTokenIssuerClaim {
+			accessTokenIssuerClaim = append(accessTokenIssuerClaim, r.Config.AccessTokenIssuerClaim[accessTokenIssuerClaimIndex].ValueString())
 		}
 		var accessTokenIssuersAllowed []string
 		if r.Config.AccessTokenIssuersAllowed != nil {
 			accessTokenIssuersAllowed = make([]string, 0, len(r.Config.AccessTokenIssuersAllowed))
-			for _, accessTokenIssuersAllowedItem := range r.Config.AccessTokenIssuersAllowed {
-				accessTokenIssuersAllowed = append(accessTokenIssuersAllowed, accessTokenIssuersAllowedItem.ValueString())
+			for accessTokenIssuersAllowedIndex := range r.Config.AccessTokenIssuersAllowed {
+				accessTokenIssuersAllowed = append(accessTokenIssuersAllowed, r.Config.AccessTokenIssuersAllowed[accessTokenIssuersAllowedIndex].ValueString())
 			}
 		}
 		accessTokenJwksURI := new(string)
@@ -1005,8 +1005,8 @@ func (r *GatewayPluginJwtSignerResourceModel) ToSharedJwtSignerPlugin(ctx contex
 			accessTokenLeeway = nil
 		}
 		accessTokenNotbeforeClaim := make([]string, 0, len(r.Config.AccessTokenNotbeforeClaim))
-		for _, accessTokenNotbeforeClaimItem := range r.Config.AccessTokenNotbeforeClaim {
-			accessTokenNotbeforeClaim = append(accessTokenNotbeforeClaim, accessTokenNotbeforeClaimItem.ValueString())
+		for accessTokenNotbeforeClaimIndex := range r.Config.AccessTokenNotbeforeClaim {
+			accessTokenNotbeforeClaim = append(accessTokenNotbeforeClaim, r.Config.AccessTokenNotbeforeClaim[accessTokenNotbeforeClaimIndex].ValueString())
 		}
 		accessTokenOptional := new(bool)
 		if !r.Config.AccessTokenOptional.IsUnknown() && !r.Config.AccessTokenOptional.IsNull() {
@@ -1017,10 +1017,10 @@ func (r *GatewayPluginJwtSignerResourceModel) ToSharedJwtSignerPlugin(ctx contex
 		var accessTokenOptionalClaims [][]string
 		if r.Config.AccessTokenOptionalClaims != nil {
 			accessTokenOptionalClaims = make([][]string, 0, len(r.Config.AccessTokenOptionalClaims))
-			for _, accessTokenOptionalClaimsItem := range r.Config.AccessTokenOptionalClaims {
-				accessTokenOptionalClaimsTmp := make([]string, 0, len(accessTokenOptionalClaimsItem))
-				for _, item2 := range accessTokenOptionalClaimsItem {
-					accessTokenOptionalClaimsTmp = append(accessTokenOptionalClaimsTmp, item2.ValueString())
+			for accessTokenOptionalClaimsIndex := range r.Config.AccessTokenOptionalClaims {
+				accessTokenOptionalClaimsTmp := make([]string, 0, len(r.Config.AccessTokenOptionalClaims[accessTokenOptionalClaimsIndex]))
+				for index2 := range r.Config.AccessTokenOptionalClaims[accessTokenOptionalClaimsIndex] {
+					accessTokenOptionalClaimsTmp = append(accessTokenOptionalClaimsTmp, r.Config.AccessTokenOptionalClaims[accessTokenOptionalClaimsIndex][index2].ValueString())
 				}
 				accessTokenOptionalClaims = append(accessTokenOptionalClaims, accessTokenOptionalClaimsTmp)
 			}
@@ -1034,23 +1034,23 @@ func (r *GatewayPluginJwtSignerResourceModel) ToSharedJwtSignerPlugin(ctx contex
 		var accessTokenRequiredClaims [][]string
 		if r.Config.AccessTokenRequiredClaims != nil {
 			accessTokenRequiredClaims = make([][]string, 0, len(r.Config.AccessTokenRequiredClaims))
-			for _, accessTokenRequiredClaimsItem := range r.Config.AccessTokenRequiredClaims {
-				accessTokenRequiredClaimsTmp := make([]string, 0, len(accessTokenRequiredClaimsItem))
-				for _, item3 := range accessTokenRequiredClaimsItem {
-					accessTokenRequiredClaimsTmp = append(accessTokenRequiredClaimsTmp, item3.ValueString())
+			for accessTokenRequiredClaimsIndex := range r.Config.AccessTokenRequiredClaims {
+				accessTokenRequiredClaimsTmp := make([]string, 0, len(r.Config.AccessTokenRequiredClaims[accessTokenRequiredClaimsIndex]))
+				for index3 := range r.Config.AccessTokenRequiredClaims[accessTokenRequiredClaimsIndex] {
+					accessTokenRequiredClaimsTmp = append(accessTokenRequiredClaimsTmp, r.Config.AccessTokenRequiredClaims[accessTokenRequiredClaimsIndex][index3].ValueString())
 				}
 				accessTokenRequiredClaims = append(accessTokenRequiredClaims, accessTokenRequiredClaimsTmp)
 			}
 		}
 		accessTokenScopesClaim := make([]string, 0, len(r.Config.AccessTokenScopesClaim))
-		for _, accessTokenScopesClaimItem := range r.Config.AccessTokenScopesClaim {
-			accessTokenScopesClaim = append(accessTokenScopesClaim, accessTokenScopesClaimItem.ValueString())
+		for accessTokenScopesClaimIndex := range r.Config.AccessTokenScopesClaim {
+			accessTokenScopesClaim = append(accessTokenScopesClaim, r.Config.AccessTokenScopesClaim[accessTokenScopesClaimIndex].ValueString())
 		}
 		var accessTokenScopesRequired []string
 		if r.Config.AccessTokenScopesRequired != nil {
 			accessTokenScopesRequired = make([]string, 0, len(r.Config.AccessTokenScopesRequired))
-			for _, accessTokenScopesRequiredItem := range r.Config.AccessTokenScopesRequired {
-				accessTokenScopesRequired = append(accessTokenScopesRequired, accessTokenScopesRequiredItem.ValueString())
+			for accessTokenScopesRequiredIndex := range r.Config.AccessTokenScopesRequired {
+				accessTokenScopesRequired = append(accessTokenScopesRequired, r.Config.AccessTokenScopesRequired[accessTokenScopesRequiredIndex].ValueString())
 			}
 		}
 		accessTokenSigning := new(bool)
@@ -1066,14 +1066,14 @@ func (r *GatewayPluginJwtSignerResourceModel) ToSharedJwtSignerPlugin(ctx contex
 			accessTokenSigningAlgorithm = nil
 		}
 		accessTokenSubjectClaim := make([]string, 0, len(r.Config.AccessTokenSubjectClaim))
-		for _, accessTokenSubjectClaimItem := range r.Config.AccessTokenSubjectClaim {
-			accessTokenSubjectClaim = append(accessTokenSubjectClaim, accessTokenSubjectClaimItem.ValueString())
+		for accessTokenSubjectClaimIndex := range r.Config.AccessTokenSubjectClaim {
+			accessTokenSubjectClaim = append(accessTokenSubjectClaim, r.Config.AccessTokenSubjectClaim[accessTokenSubjectClaimIndex].ValueString())
 		}
 		var accessTokenSubjectsAllowed []string
 		if r.Config.AccessTokenSubjectsAllowed != nil {
 			accessTokenSubjectsAllowed = make([]string, 0, len(r.Config.AccessTokenSubjectsAllowed))
-			for _, accessTokenSubjectsAllowedItem := range r.Config.AccessTokenSubjectsAllowed {
-				accessTokenSubjectsAllowed = append(accessTokenSubjectsAllowed, accessTokenSubjectsAllowedItem.ValueString())
+			for accessTokenSubjectsAllowedIndex := range r.Config.AccessTokenSubjectsAllowed {
+				accessTokenSubjectsAllowed = append(accessTokenSubjectsAllowed, r.Config.AccessTokenSubjectsAllowed[accessTokenSubjectsAllowedIndex].ValueString())
 			}
 		}
 		accessTokenUpstreamHeader := new(string)
@@ -1091,9 +1091,9 @@ func (r *GatewayPluginJwtSignerResourceModel) ToSharedJwtSignerPlugin(ctx contex
 		var addAccessTokenClaims map[string]string
 		if r.Config.AddAccessTokenClaims != nil {
 			addAccessTokenClaims = make(map[string]string)
-			for addAccessTokenClaimsKey, addAccessTokenClaimsValue := range r.Config.AddAccessTokenClaims {
+			for addAccessTokenClaimsKey := range r.Config.AddAccessTokenClaims {
 				var addAccessTokenClaimsInst string
-				addAccessTokenClaimsInst = addAccessTokenClaimsValue.ValueString()
+				addAccessTokenClaimsInst = r.Config.AddAccessTokenClaims[addAccessTokenClaimsKey].ValueString()
 
 				addAccessTokenClaims[addAccessTokenClaimsKey] = addAccessTokenClaimsInst
 			}
@@ -1101,9 +1101,9 @@ func (r *GatewayPluginJwtSignerResourceModel) ToSharedJwtSignerPlugin(ctx contex
 		var addChannelTokenClaims map[string]string
 		if r.Config.AddChannelTokenClaims != nil {
 			addChannelTokenClaims = make(map[string]string)
-			for addChannelTokenClaimsKey, addChannelTokenClaimsValue := range r.Config.AddChannelTokenClaims {
+			for addChannelTokenClaimsKey := range r.Config.AddChannelTokenClaims {
 				var addChannelTokenClaimsInst string
-				addChannelTokenClaimsInst = addChannelTokenClaimsValue.ValueString()
+				addChannelTokenClaimsInst = r.Config.AddChannelTokenClaims[addChannelTokenClaimsKey].ValueString()
 
 				addChannelTokenClaims[addChannelTokenClaimsKey] = addChannelTokenClaimsInst
 			}
@@ -1111,9 +1111,9 @@ func (r *GatewayPluginJwtSignerResourceModel) ToSharedJwtSignerPlugin(ctx contex
 		var addClaims map[string]string
 		if r.Config.AddClaims != nil {
 			addClaims = make(map[string]string)
-			for addClaimsKey, addClaimsValue := range r.Config.AddClaims {
+			for addClaimsKey := range r.Config.AddClaims {
 				var addClaimsInst string
-				addClaimsInst = addClaimsValue.ValueString()
+				addClaimsInst = r.Config.AddClaims[addClaimsKey].ValueString()
 
 				addClaims[addClaimsKey] = addClaimsInst
 			}
@@ -1131,14 +1131,14 @@ func (r *GatewayPluginJwtSignerResourceModel) ToSharedJwtSignerPlugin(ctx contex
 			cacheChannelTokenIntrospection = nil
 		}
 		channelTokenAudienceClaim := make([]string, 0, len(r.Config.ChannelTokenAudienceClaim))
-		for _, channelTokenAudienceClaimItem := range r.Config.ChannelTokenAudienceClaim {
-			channelTokenAudienceClaim = append(channelTokenAudienceClaim, channelTokenAudienceClaimItem.ValueString())
+		for channelTokenAudienceClaimIndex := range r.Config.ChannelTokenAudienceClaim {
+			channelTokenAudienceClaim = append(channelTokenAudienceClaim, r.Config.ChannelTokenAudienceClaim[channelTokenAudienceClaimIndex].ValueString())
 		}
 		var channelTokenAudiencesAllowed []string
 		if r.Config.ChannelTokenAudiencesAllowed != nil {
 			channelTokenAudiencesAllowed = make([]string, 0, len(r.Config.ChannelTokenAudiencesAllowed))
-			for _, channelTokenAudiencesAllowedItem := range r.Config.ChannelTokenAudiencesAllowed {
-				channelTokenAudiencesAllowed = append(channelTokenAudiencesAllowed, channelTokenAudiencesAllowedItem.ValueString())
+			for channelTokenAudiencesAllowedIndex := range r.Config.ChannelTokenAudiencesAllowed {
+				channelTokenAudiencesAllowed = append(channelTokenAudiencesAllowed, r.Config.ChannelTokenAudiencesAllowed[channelTokenAudiencesAllowedIndex].ValueString())
 			}
 		}
 		channelTokenConsumerBy := make([]shared.ChannelTokenConsumerBy, 0, len(r.Config.ChannelTokenConsumerBy))
@@ -1148,23 +1148,23 @@ func (r *GatewayPluginJwtSignerResourceModel) ToSharedJwtSignerPlugin(ctx contex
 		var channelTokenConsumerClaim []string
 		if r.Config.ChannelTokenConsumerClaim != nil {
 			channelTokenConsumerClaim = make([]string, 0, len(r.Config.ChannelTokenConsumerClaim))
-			for _, channelTokenConsumerClaimItem := range r.Config.ChannelTokenConsumerClaim {
-				channelTokenConsumerClaim = append(channelTokenConsumerClaim, channelTokenConsumerClaimItem.ValueString())
+			for channelTokenConsumerClaimIndex := range r.Config.ChannelTokenConsumerClaim {
+				channelTokenConsumerClaim = append(channelTokenConsumerClaim, r.Config.ChannelTokenConsumerClaim[channelTokenConsumerClaimIndex].ValueString())
 			}
 		}
 		channelTokenExpiryClaim := make([]string, 0, len(r.Config.ChannelTokenExpiryClaim))
-		for _, channelTokenExpiryClaimItem := range r.Config.ChannelTokenExpiryClaim {
-			channelTokenExpiryClaim = append(channelTokenExpiryClaim, channelTokenExpiryClaimItem.ValueString())
+		for channelTokenExpiryClaimIndex := range r.Config.ChannelTokenExpiryClaim {
+			channelTokenExpiryClaim = append(channelTokenExpiryClaim, r.Config.ChannelTokenExpiryClaim[channelTokenExpiryClaimIndex].ValueString())
 		}
 		channelTokenIntrospectionAudienceClaim := make([]string, 0, len(r.Config.ChannelTokenIntrospectionAudienceClaim))
-		for _, channelTokenIntrospectionAudienceClaimItem := range r.Config.ChannelTokenIntrospectionAudienceClaim {
-			channelTokenIntrospectionAudienceClaim = append(channelTokenIntrospectionAudienceClaim, channelTokenIntrospectionAudienceClaimItem.ValueString())
+		for channelTokenIntrospectionAudienceClaimIndex := range r.Config.ChannelTokenIntrospectionAudienceClaim {
+			channelTokenIntrospectionAudienceClaim = append(channelTokenIntrospectionAudienceClaim, r.Config.ChannelTokenIntrospectionAudienceClaim[channelTokenIntrospectionAudienceClaimIndex].ValueString())
 		}
 		var channelTokenIntrospectionAudiencesAllowed []string
 		if r.Config.ChannelTokenIntrospectionAudiencesAllowed != nil {
 			channelTokenIntrospectionAudiencesAllowed = make([]string, 0, len(r.Config.ChannelTokenIntrospectionAudiencesAllowed))
-			for _, channelTokenIntrospectionAudiencesAllowedItem := range r.Config.ChannelTokenIntrospectionAudiencesAllowed {
-				channelTokenIntrospectionAudiencesAllowed = append(channelTokenIntrospectionAudiencesAllowed, channelTokenIntrospectionAudiencesAllowedItem.ValueString())
+			for channelTokenIntrospectionAudiencesAllowedIndex := range r.Config.ChannelTokenIntrospectionAudiencesAllowed {
+				channelTokenIntrospectionAudiencesAllowed = append(channelTokenIntrospectionAudiencesAllowed, r.Config.ChannelTokenIntrospectionAudiencesAllowed[channelTokenIntrospectionAudiencesAllowedIndex].ValueString())
 			}
 		}
 		channelTokenIntrospectionAuthorization := new(string)
@@ -1186,8 +1186,8 @@ func (r *GatewayPluginJwtSignerResourceModel) ToSharedJwtSignerPlugin(ctx contex
 		var channelTokenIntrospectionConsumerClaim []string
 		if r.Config.ChannelTokenIntrospectionConsumerClaim != nil {
 			channelTokenIntrospectionConsumerClaim = make([]string, 0, len(r.Config.ChannelTokenIntrospectionConsumerClaim))
-			for _, channelTokenIntrospectionConsumerClaimItem := range r.Config.ChannelTokenIntrospectionConsumerClaim {
-				channelTokenIntrospectionConsumerClaim = append(channelTokenIntrospectionConsumerClaim, channelTokenIntrospectionConsumerClaimItem.ValueString())
+			for channelTokenIntrospectionConsumerClaimIndex := range r.Config.ChannelTokenIntrospectionConsumerClaim {
+				channelTokenIntrospectionConsumerClaim = append(channelTokenIntrospectionConsumerClaim, r.Config.ChannelTokenIntrospectionConsumerClaim[channelTokenIntrospectionConsumerClaimIndex].ValueString())
 			}
 		}
 		channelTokenIntrospectionEndpoint := new(string)
@@ -1197,8 +1197,8 @@ func (r *GatewayPluginJwtSignerResourceModel) ToSharedJwtSignerPlugin(ctx contex
 			channelTokenIntrospectionEndpoint = nil
 		}
 		channelTokenIntrospectionExpiryClaim := make([]string, 0, len(r.Config.ChannelTokenIntrospectionExpiryClaim))
-		for _, channelTokenIntrospectionExpiryClaimItem := range r.Config.ChannelTokenIntrospectionExpiryClaim {
-			channelTokenIntrospectionExpiryClaim = append(channelTokenIntrospectionExpiryClaim, channelTokenIntrospectionExpiryClaimItem.ValueString())
+		for channelTokenIntrospectionExpiryClaimIndex := range r.Config.ChannelTokenIntrospectionExpiryClaim {
+			channelTokenIntrospectionExpiryClaim = append(channelTokenIntrospectionExpiryClaim, r.Config.ChannelTokenIntrospectionExpiryClaim[channelTokenIntrospectionExpiryClaimIndex].ValueString())
 		}
 		channelTokenIntrospectionHint := new(string)
 		if !r.Config.ChannelTokenIntrospectionHint.IsUnknown() && !r.Config.ChannelTokenIntrospectionHint.IsNull() {
@@ -1207,21 +1207,21 @@ func (r *GatewayPluginJwtSignerResourceModel) ToSharedJwtSignerPlugin(ctx contex
 			channelTokenIntrospectionHint = nil
 		}
 		channelTokenIntrospectionIssuerClaim := make([]string, 0, len(r.Config.ChannelTokenIntrospectionIssuerClaim))
-		for _, channelTokenIntrospectionIssuerClaimItem := range r.Config.ChannelTokenIntrospectionIssuerClaim {
-			channelTokenIntrospectionIssuerClaim = append(channelTokenIntrospectionIssuerClaim, channelTokenIntrospectionIssuerClaimItem.ValueString())
+		for channelTokenIntrospectionIssuerClaimIndex := range r.Config.ChannelTokenIntrospectionIssuerClaim {
+			channelTokenIntrospectionIssuerClaim = append(channelTokenIntrospectionIssuerClaim, r.Config.ChannelTokenIntrospectionIssuerClaim[channelTokenIntrospectionIssuerClaimIndex].ValueString())
 		}
 		var channelTokenIntrospectionIssuersAllowed []string
 		if r.Config.ChannelTokenIntrospectionIssuersAllowed != nil {
 			channelTokenIntrospectionIssuersAllowed = make([]string, 0, len(r.Config.ChannelTokenIntrospectionIssuersAllowed))
-			for _, channelTokenIntrospectionIssuersAllowedItem := range r.Config.ChannelTokenIntrospectionIssuersAllowed {
-				channelTokenIntrospectionIssuersAllowed = append(channelTokenIntrospectionIssuersAllowed, channelTokenIntrospectionIssuersAllowedItem.ValueString())
+			for channelTokenIntrospectionIssuersAllowedIndex := range r.Config.ChannelTokenIntrospectionIssuersAllowed {
+				channelTokenIntrospectionIssuersAllowed = append(channelTokenIntrospectionIssuersAllowed, r.Config.ChannelTokenIntrospectionIssuersAllowed[channelTokenIntrospectionIssuersAllowedIndex].ValueString())
 			}
 		}
 		var channelTokenIntrospectionJwtClaim []string
 		if r.Config.ChannelTokenIntrospectionJwtClaim != nil {
 			channelTokenIntrospectionJwtClaim = make([]string, 0, len(r.Config.ChannelTokenIntrospectionJwtClaim))
-			for _, channelTokenIntrospectionJwtClaimItem := range r.Config.ChannelTokenIntrospectionJwtClaim {
-				channelTokenIntrospectionJwtClaim = append(channelTokenIntrospectionJwtClaim, channelTokenIntrospectionJwtClaimItem.ValueString())
+			for channelTokenIntrospectionJwtClaimIndex := range r.Config.ChannelTokenIntrospectionJwtClaim {
+				channelTokenIntrospectionJwtClaim = append(channelTokenIntrospectionJwtClaim, r.Config.ChannelTokenIntrospectionJwtClaim[channelTokenIntrospectionJwtClaimIndex].ValueString())
 			}
 		}
 		channelTokenIntrospectionLeeway := new(float64)
@@ -1231,16 +1231,16 @@ func (r *GatewayPluginJwtSignerResourceModel) ToSharedJwtSignerPlugin(ctx contex
 			channelTokenIntrospectionLeeway = nil
 		}
 		channelTokenIntrospectionNotbeforeClaim := make([]string, 0, len(r.Config.ChannelTokenIntrospectionNotbeforeClaim))
-		for _, channelTokenIntrospectionNotbeforeClaimItem := range r.Config.ChannelTokenIntrospectionNotbeforeClaim {
-			channelTokenIntrospectionNotbeforeClaim = append(channelTokenIntrospectionNotbeforeClaim, channelTokenIntrospectionNotbeforeClaimItem.ValueString())
+		for channelTokenIntrospectionNotbeforeClaimIndex := range r.Config.ChannelTokenIntrospectionNotbeforeClaim {
+			channelTokenIntrospectionNotbeforeClaim = append(channelTokenIntrospectionNotbeforeClaim, r.Config.ChannelTokenIntrospectionNotbeforeClaim[channelTokenIntrospectionNotbeforeClaimIndex].ValueString())
 		}
 		var channelTokenIntrospectionOptionalClaims [][]string
 		if r.Config.ChannelTokenIntrospectionOptionalClaims != nil {
 			channelTokenIntrospectionOptionalClaims = make([][]string, 0, len(r.Config.ChannelTokenIntrospectionOptionalClaims))
-			for _, channelTokenIntrospectionOptionalClaimsItem := range r.Config.ChannelTokenIntrospectionOptionalClaims {
-				channelTokenIntrospectionOptionalClaimsTmp := make([]string, 0, len(channelTokenIntrospectionOptionalClaimsItem))
-				for _, item4 := range channelTokenIntrospectionOptionalClaimsItem {
-					channelTokenIntrospectionOptionalClaimsTmp = append(channelTokenIntrospectionOptionalClaimsTmp, item4.ValueString())
+			for channelTokenIntrospectionOptionalClaimsIndex := range r.Config.ChannelTokenIntrospectionOptionalClaims {
+				channelTokenIntrospectionOptionalClaimsTmp := make([]string, 0, len(r.Config.ChannelTokenIntrospectionOptionalClaims[channelTokenIntrospectionOptionalClaimsIndex]))
+				for index4 := range r.Config.ChannelTokenIntrospectionOptionalClaims[channelTokenIntrospectionOptionalClaimsIndex] {
+					channelTokenIntrospectionOptionalClaimsTmp = append(channelTokenIntrospectionOptionalClaimsTmp, r.Config.ChannelTokenIntrospectionOptionalClaims[channelTokenIntrospectionOptionalClaimsIndex][index4].ValueString())
 				}
 				channelTokenIntrospectionOptionalClaims = append(channelTokenIntrospectionOptionalClaims, channelTokenIntrospectionOptionalClaimsTmp)
 			}
@@ -1248,34 +1248,34 @@ func (r *GatewayPluginJwtSignerResourceModel) ToSharedJwtSignerPlugin(ctx contex
 		var channelTokenIntrospectionRequiredClaims [][]string
 		if r.Config.ChannelTokenIntrospectionRequiredClaims != nil {
 			channelTokenIntrospectionRequiredClaims = make([][]string, 0, len(r.Config.ChannelTokenIntrospectionRequiredClaims))
-			for _, channelTokenIntrospectionRequiredClaimsItem := range r.Config.ChannelTokenIntrospectionRequiredClaims {
-				channelTokenIntrospectionRequiredClaimsTmp := make([]string, 0, len(channelTokenIntrospectionRequiredClaimsItem))
-				for _, item5 := range channelTokenIntrospectionRequiredClaimsItem {
-					channelTokenIntrospectionRequiredClaimsTmp = append(channelTokenIntrospectionRequiredClaimsTmp, item5.ValueString())
+			for channelTokenIntrospectionRequiredClaimsIndex := range r.Config.ChannelTokenIntrospectionRequiredClaims {
+				channelTokenIntrospectionRequiredClaimsTmp := make([]string, 0, len(r.Config.ChannelTokenIntrospectionRequiredClaims[channelTokenIntrospectionRequiredClaimsIndex]))
+				for index5 := range r.Config.ChannelTokenIntrospectionRequiredClaims[channelTokenIntrospectionRequiredClaimsIndex] {
+					channelTokenIntrospectionRequiredClaimsTmp = append(channelTokenIntrospectionRequiredClaimsTmp, r.Config.ChannelTokenIntrospectionRequiredClaims[channelTokenIntrospectionRequiredClaimsIndex][index5].ValueString())
 				}
 				channelTokenIntrospectionRequiredClaims = append(channelTokenIntrospectionRequiredClaims, channelTokenIntrospectionRequiredClaimsTmp)
 			}
 		}
 		channelTokenIntrospectionScopesClaim := make([]string, 0, len(r.Config.ChannelTokenIntrospectionScopesClaim))
-		for _, channelTokenIntrospectionScopesClaimItem := range r.Config.ChannelTokenIntrospectionScopesClaim {
-			channelTokenIntrospectionScopesClaim = append(channelTokenIntrospectionScopesClaim, channelTokenIntrospectionScopesClaimItem.ValueString())
+		for channelTokenIntrospectionScopesClaimIndex := range r.Config.ChannelTokenIntrospectionScopesClaim {
+			channelTokenIntrospectionScopesClaim = append(channelTokenIntrospectionScopesClaim, r.Config.ChannelTokenIntrospectionScopesClaim[channelTokenIntrospectionScopesClaimIndex].ValueString())
 		}
 		var channelTokenIntrospectionScopesRequired []string
 		if r.Config.ChannelTokenIntrospectionScopesRequired != nil {
 			channelTokenIntrospectionScopesRequired = make([]string, 0, len(r.Config.ChannelTokenIntrospectionScopesRequired))
-			for _, channelTokenIntrospectionScopesRequiredItem := range r.Config.ChannelTokenIntrospectionScopesRequired {
-				channelTokenIntrospectionScopesRequired = append(channelTokenIntrospectionScopesRequired, channelTokenIntrospectionScopesRequiredItem.ValueString())
+			for channelTokenIntrospectionScopesRequiredIndex := range r.Config.ChannelTokenIntrospectionScopesRequired {
+				channelTokenIntrospectionScopesRequired = append(channelTokenIntrospectionScopesRequired, r.Config.ChannelTokenIntrospectionScopesRequired[channelTokenIntrospectionScopesRequiredIndex].ValueString())
 			}
 		}
 		channelTokenIntrospectionSubjectClaim := make([]string, 0, len(r.Config.ChannelTokenIntrospectionSubjectClaim))
-		for _, channelTokenIntrospectionSubjectClaimItem := range r.Config.ChannelTokenIntrospectionSubjectClaim {
-			channelTokenIntrospectionSubjectClaim = append(channelTokenIntrospectionSubjectClaim, channelTokenIntrospectionSubjectClaimItem.ValueString())
+		for channelTokenIntrospectionSubjectClaimIndex := range r.Config.ChannelTokenIntrospectionSubjectClaim {
+			channelTokenIntrospectionSubjectClaim = append(channelTokenIntrospectionSubjectClaim, r.Config.ChannelTokenIntrospectionSubjectClaim[channelTokenIntrospectionSubjectClaimIndex].ValueString())
 		}
 		var channelTokenIntrospectionSubjectsAllowed []string
 		if r.Config.ChannelTokenIntrospectionSubjectsAllowed != nil {
 			channelTokenIntrospectionSubjectsAllowed = make([]string, 0, len(r.Config.ChannelTokenIntrospectionSubjectsAllowed))
-			for _, channelTokenIntrospectionSubjectsAllowedItem := range r.Config.ChannelTokenIntrospectionSubjectsAllowed {
-				channelTokenIntrospectionSubjectsAllowed = append(channelTokenIntrospectionSubjectsAllowed, channelTokenIntrospectionSubjectsAllowedItem.ValueString())
+			for channelTokenIntrospectionSubjectsAllowedIndex := range r.Config.ChannelTokenIntrospectionSubjectsAllowed {
+				channelTokenIntrospectionSubjectsAllowed = append(channelTokenIntrospectionSubjectsAllowed, r.Config.ChannelTokenIntrospectionSubjectsAllowed[channelTokenIntrospectionSubjectsAllowedIndex].ValueString())
 			}
 		}
 		channelTokenIntrospectionTimeout := new(float64)
@@ -1291,14 +1291,14 @@ func (r *GatewayPluginJwtSignerResourceModel) ToSharedJwtSignerPlugin(ctx contex
 			channelTokenIssuer = nil
 		}
 		channelTokenIssuerClaim := make([]string, 0, len(r.Config.ChannelTokenIssuerClaim))
-		for _, channelTokenIssuerClaimItem := range r.Config.ChannelTokenIssuerClaim {
-			channelTokenIssuerClaim = append(channelTokenIssuerClaim, channelTokenIssuerClaimItem.ValueString())
+		for channelTokenIssuerClaimIndex := range r.Config.ChannelTokenIssuerClaim {
+			channelTokenIssuerClaim = append(channelTokenIssuerClaim, r.Config.ChannelTokenIssuerClaim[channelTokenIssuerClaimIndex].ValueString())
 		}
 		var channelTokenIssuersAllowed []string
 		if r.Config.ChannelTokenIssuersAllowed != nil {
 			channelTokenIssuersAllowed = make([]string, 0, len(r.Config.ChannelTokenIssuersAllowed))
-			for _, channelTokenIssuersAllowedItem := range r.Config.ChannelTokenIssuersAllowed {
-				channelTokenIssuersAllowed = append(channelTokenIssuersAllowed, channelTokenIssuersAllowedItem.ValueString())
+			for channelTokenIssuersAllowedIndex := range r.Config.ChannelTokenIssuersAllowed {
+				channelTokenIssuersAllowed = append(channelTokenIssuersAllowed, r.Config.ChannelTokenIssuersAllowed[channelTokenIssuersAllowedIndex].ValueString())
 			}
 		}
 		channelTokenJwksURI := new(string)
@@ -1380,8 +1380,8 @@ func (r *GatewayPluginJwtSignerResourceModel) ToSharedJwtSignerPlugin(ctx contex
 			channelTokenLeeway = nil
 		}
 		channelTokenNotbeforeClaim := make([]string, 0, len(r.Config.ChannelTokenNotbeforeClaim))
-		for _, channelTokenNotbeforeClaimItem := range r.Config.ChannelTokenNotbeforeClaim {
-			channelTokenNotbeforeClaim = append(channelTokenNotbeforeClaim, channelTokenNotbeforeClaimItem.ValueString())
+		for channelTokenNotbeforeClaimIndex := range r.Config.ChannelTokenNotbeforeClaim {
+			channelTokenNotbeforeClaim = append(channelTokenNotbeforeClaim, r.Config.ChannelTokenNotbeforeClaim[channelTokenNotbeforeClaimIndex].ValueString())
 		}
 		channelTokenOptional := new(bool)
 		if !r.Config.ChannelTokenOptional.IsUnknown() && !r.Config.ChannelTokenOptional.IsNull() {
@@ -1392,10 +1392,10 @@ func (r *GatewayPluginJwtSignerResourceModel) ToSharedJwtSignerPlugin(ctx contex
 		var channelTokenOptionalClaims [][]string
 		if r.Config.ChannelTokenOptionalClaims != nil {
 			channelTokenOptionalClaims = make([][]string, 0, len(r.Config.ChannelTokenOptionalClaims))
-			for _, channelTokenOptionalClaimsItem := range r.Config.ChannelTokenOptionalClaims {
-				channelTokenOptionalClaimsTmp := make([]string, 0, len(channelTokenOptionalClaimsItem))
-				for _, item6 := range channelTokenOptionalClaimsItem {
-					channelTokenOptionalClaimsTmp = append(channelTokenOptionalClaimsTmp, item6.ValueString())
+			for channelTokenOptionalClaimsIndex := range r.Config.ChannelTokenOptionalClaims {
+				channelTokenOptionalClaimsTmp := make([]string, 0, len(r.Config.ChannelTokenOptionalClaims[channelTokenOptionalClaimsIndex]))
+				for index6 := range r.Config.ChannelTokenOptionalClaims[channelTokenOptionalClaimsIndex] {
+					channelTokenOptionalClaimsTmp = append(channelTokenOptionalClaimsTmp, r.Config.ChannelTokenOptionalClaims[channelTokenOptionalClaimsIndex][index6].ValueString())
 				}
 				channelTokenOptionalClaims = append(channelTokenOptionalClaims, channelTokenOptionalClaimsTmp)
 			}
@@ -1409,23 +1409,23 @@ func (r *GatewayPluginJwtSignerResourceModel) ToSharedJwtSignerPlugin(ctx contex
 		var channelTokenRequiredClaims [][]string
 		if r.Config.ChannelTokenRequiredClaims != nil {
 			channelTokenRequiredClaims = make([][]string, 0, len(r.Config.ChannelTokenRequiredClaims))
-			for _, channelTokenRequiredClaimsItem := range r.Config.ChannelTokenRequiredClaims {
-				channelTokenRequiredClaimsTmp := make([]string, 0, len(channelTokenRequiredClaimsItem))
-				for _, item7 := range channelTokenRequiredClaimsItem {
-					channelTokenRequiredClaimsTmp = append(channelTokenRequiredClaimsTmp, item7.ValueString())
+			for channelTokenRequiredClaimsIndex := range r.Config.ChannelTokenRequiredClaims {
+				channelTokenRequiredClaimsTmp := make([]string, 0, len(r.Config.ChannelTokenRequiredClaims[channelTokenRequiredClaimsIndex]))
+				for index7 := range r.Config.ChannelTokenRequiredClaims[channelTokenRequiredClaimsIndex] {
+					channelTokenRequiredClaimsTmp = append(channelTokenRequiredClaimsTmp, r.Config.ChannelTokenRequiredClaims[channelTokenRequiredClaimsIndex][index7].ValueString())
 				}
 				channelTokenRequiredClaims = append(channelTokenRequiredClaims, channelTokenRequiredClaimsTmp)
 			}
 		}
 		channelTokenScopesClaim := make([]string, 0, len(r.Config.ChannelTokenScopesClaim))
-		for _, channelTokenScopesClaimItem := range r.Config.ChannelTokenScopesClaim {
-			channelTokenScopesClaim = append(channelTokenScopesClaim, channelTokenScopesClaimItem.ValueString())
+		for channelTokenScopesClaimIndex := range r.Config.ChannelTokenScopesClaim {
+			channelTokenScopesClaim = append(channelTokenScopesClaim, r.Config.ChannelTokenScopesClaim[channelTokenScopesClaimIndex].ValueString())
 		}
 		var channelTokenScopesRequired []string
 		if r.Config.ChannelTokenScopesRequired != nil {
 			channelTokenScopesRequired = make([]string, 0, len(r.Config.ChannelTokenScopesRequired))
-			for _, channelTokenScopesRequiredItem := range r.Config.ChannelTokenScopesRequired {
-				channelTokenScopesRequired = append(channelTokenScopesRequired, channelTokenScopesRequiredItem.ValueString())
+			for channelTokenScopesRequiredIndex := range r.Config.ChannelTokenScopesRequired {
+				channelTokenScopesRequired = append(channelTokenScopesRequired, r.Config.ChannelTokenScopesRequired[channelTokenScopesRequiredIndex].ValueString())
 			}
 		}
 		channelTokenSigning := new(bool)
@@ -1441,14 +1441,14 @@ func (r *GatewayPluginJwtSignerResourceModel) ToSharedJwtSignerPlugin(ctx contex
 			channelTokenSigningAlgorithm = nil
 		}
 		channelTokenSubjectClaim := make([]string, 0, len(r.Config.ChannelTokenSubjectClaim))
-		for _, channelTokenSubjectClaimItem := range r.Config.ChannelTokenSubjectClaim {
-			channelTokenSubjectClaim = append(channelTokenSubjectClaim, channelTokenSubjectClaimItem.ValueString())
+		for channelTokenSubjectClaimIndex := range r.Config.ChannelTokenSubjectClaim {
+			channelTokenSubjectClaim = append(channelTokenSubjectClaim, r.Config.ChannelTokenSubjectClaim[channelTokenSubjectClaimIndex].ValueString())
 		}
 		var channelTokenSubjectsAllowed []string
 		if r.Config.ChannelTokenSubjectsAllowed != nil {
 			channelTokenSubjectsAllowed = make([]string, 0, len(r.Config.ChannelTokenSubjectsAllowed))
-			for _, channelTokenSubjectsAllowedItem := range r.Config.ChannelTokenSubjectsAllowed {
-				channelTokenSubjectsAllowed = append(channelTokenSubjectsAllowed, channelTokenSubjectsAllowedItem.ValueString())
+			for channelTokenSubjectsAllowedIndex := range r.Config.ChannelTokenSubjectsAllowed {
+				channelTokenSubjectsAllowed = append(channelTokenSubjectsAllowed, r.Config.ChannelTokenSubjectsAllowed[channelTokenSubjectsAllowedIndex].ValueString())
 			}
 		}
 		channelTokenUpstreamHeader := new(string)
@@ -1506,19 +1506,19 @@ func (r *GatewayPluginJwtSignerResourceModel) ToSharedJwtSignerPlugin(ctx contex
 			realm = nil
 		}
 		removeAccessTokenClaims := make([]string, 0, len(r.Config.RemoveAccessTokenClaims))
-		for _, removeAccessTokenClaimsItem := range r.Config.RemoveAccessTokenClaims {
-			removeAccessTokenClaims = append(removeAccessTokenClaims, removeAccessTokenClaimsItem.ValueString())
+		for removeAccessTokenClaimsIndex := range r.Config.RemoveAccessTokenClaims {
+			removeAccessTokenClaims = append(removeAccessTokenClaims, r.Config.RemoveAccessTokenClaims[removeAccessTokenClaimsIndex].ValueString())
 		}
 		removeChannelTokenClaims := make([]string, 0, len(r.Config.RemoveChannelTokenClaims))
-		for _, removeChannelTokenClaimsItem := range r.Config.RemoveChannelTokenClaims {
-			removeChannelTokenClaims = append(removeChannelTokenClaims, removeChannelTokenClaimsItem.ValueString())
+		for removeChannelTokenClaimsIndex := range r.Config.RemoveChannelTokenClaims {
+			removeChannelTokenClaims = append(removeChannelTokenClaims, r.Config.RemoveChannelTokenClaims[removeChannelTokenClaimsIndex].ValueString())
 		}
 		var setAccessTokenClaims map[string]string
 		if r.Config.SetAccessTokenClaims != nil {
 			setAccessTokenClaims = make(map[string]string)
-			for setAccessTokenClaimsKey, setAccessTokenClaimsValue := range r.Config.SetAccessTokenClaims {
+			for setAccessTokenClaimsKey := range r.Config.SetAccessTokenClaims {
 				var setAccessTokenClaimsInst string
-				setAccessTokenClaimsInst = setAccessTokenClaimsValue.ValueString()
+				setAccessTokenClaimsInst = r.Config.SetAccessTokenClaims[setAccessTokenClaimsKey].ValueString()
 
 				setAccessTokenClaims[setAccessTokenClaimsKey] = setAccessTokenClaimsInst
 			}
@@ -1526,9 +1526,9 @@ func (r *GatewayPluginJwtSignerResourceModel) ToSharedJwtSignerPlugin(ctx contex
 		var setChannelTokenClaims map[string]string
 		if r.Config.SetChannelTokenClaims != nil {
 			setChannelTokenClaims = make(map[string]string)
-			for setChannelTokenClaimsKey, setChannelTokenClaimsValue := range r.Config.SetChannelTokenClaims {
+			for setChannelTokenClaimsKey := range r.Config.SetChannelTokenClaims {
 				var setChannelTokenClaimsInst string
-				setChannelTokenClaimsInst = setChannelTokenClaimsValue.ValueString()
+				setChannelTokenClaimsInst = r.Config.SetChannelTokenClaims[setChannelTokenClaimsKey].ValueString()
 
 				setChannelTokenClaims[setChannelTokenClaimsKey] = setChannelTokenClaimsInst
 			}
@@ -1536,9 +1536,9 @@ func (r *GatewayPluginJwtSignerResourceModel) ToSharedJwtSignerPlugin(ctx contex
 		var setClaims map[string]string
 		if r.Config.SetClaims != nil {
 			setClaims = make(map[string]string)
-			for setClaimsKey, setClaimsValue := range r.Config.SetClaims {
+			for setClaimsKey := range r.Config.SetClaims {
 				var setClaimsInst string
-				setClaimsInst = setClaimsValue.ValueString()
+				setClaimsInst = r.Config.SetClaims[setClaimsKey].ValueString()
 
 				setClaims[setClaimsKey] = setClaimsInst
 			}

--- a/internal/provider/gatewaypluginkafkaconsume_resource.go
+++ b/internal/provider/gatewaypluginkafkaconsume_resource.go
@@ -1331,7 +1331,10 @@ func (r *GatewayPluginKafkaConsumeResource) Delete(ctx context.Context, req reso
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginkafkaconsume_resource_sdk.go
+++ b/internal/provider/gatewaypluginkafkaconsume_resource_sdk.go
@@ -446,8 +446,8 @@ func (r *GatewayPluginKafkaConsumeResourceModel) ToSharedKafkaConsumePlugin(ctx 
 		var after *shared.KafkaConsumePluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.KafkaConsumePluginAfter{
 				Access: access,
@@ -456,8 +456,8 @@ func (r *GatewayPluginKafkaConsumeResourceModel) ToSharedKafkaConsumePlugin(ctx 
 		var before *shared.KafkaConsumePluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.KafkaConsumePluginBefore{
 				Access: access1,
@@ -471,22 +471,22 @@ func (r *GatewayPluginKafkaConsumeResourceModel) ToSharedKafkaConsumePlugin(ctx 
 	var partials []shared.KafkaConsumePluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.KafkaConsumePluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -500,8 +500,8 @@ func (r *GatewayPluginKafkaConsumeResourceModel) ToSharedKafkaConsumePlugin(ctx 
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -557,12 +557,12 @@ func (r *GatewayPluginKafkaConsumeResourceModel) ToSharedKafkaConsumePlugin(ctx 
 		autoOffsetReset = nil
 	}
 	bootstrapServers := make([]shared.KafkaConsumePluginBootstrapServers, 0, len(r.Config.BootstrapServers))
-	for _, bootstrapServersItem := range r.Config.BootstrapServers {
+	for bootstrapServersIndex := range r.Config.BootstrapServers {
 		var host string
-		host = bootstrapServersItem.Host.ValueString()
+		host = r.Config.BootstrapServers[bootstrapServersIndex].Host.ValueString()
 
 		var port int64
-		port = bootstrapServersItem.Port.ValueInt64()
+		port = r.Config.BootstrapServers[bootstrapServersIndex].Port.ValueInt64()
 
 		bootstrapServers = append(bootstrapServers, shared.KafkaConsumePluginBootstrapServers{
 			Host: host,
@@ -596,8 +596,8 @@ func (r *GatewayPluginKafkaConsumeResourceModel) ToSharedKafkaConsumePlugin(ctx 
 	var messageByLuaFunctions []string
 	if r.Config.MessageByLuaFunctions != nil {
 		messageByLuaFunctions = make([]string, 0, len(r.Config.MessageByLuaFunctions))
-		for _, messageByLuaFunctionsItem := range r.Config.MessageByLuaFunctions {
-			messageByLuaFunctions = append(messageByLuaFunctions, messageByLuaFunctionsItem.ValueString())
+		for messageByLuaFunctionsIndex := range r.Config.MessageByLuaFunctions {
+			messageByLuaFunctions = append(messageByLuaFunctions, r.Config.MessageByLuaFunctions[messageByLuaFunctionsIndex].ValueString())
 		}
 	}
 	messageDeserializer := new(shared.KafkaConsumePluginMessageDeserializer)
@@ -640,8 +640,8 @@ func (r *GatewayPluginKafkaConsumeResourceModel) ToSharedKafkaConsumePlugin(ctx 
 				var oauth2 *shared.KafkaConsumePluginOauth2
 				if r.Config.SchemaRegistry.Confluent.Authentication.Oauth2 != nil {
 					audience := make([]string, 0, len(r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.Audience))
-					for _, audienceItem := range r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.Audience {
-						audience = append(audience, audienceItem.ValueString())
+					for audienceIndex := range r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.Audience {
+						audience = append(audience, r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.Audience[audienceIndex].ValueString())
 					}
 					clientID := new(string)
 					if !r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.ClientID.IsUnknown() && !r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.ClientID.IsNull() {
@@ -668,8 +668,8 @@ func (r *GatewayPluginKafkaConsumeResourceModel) ToSharedKafkaConsumePlugin(ctx 
 						password2 = nil
 					}
 					scopes := make([]string, 0, len(r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.Scopes))
-					for _, scopesItem := range r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.Scopes {
-						scopes = append(scopes, scopesItem.ValueString())
+					for scopesIndex := range r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.Scopes {
+						scopes = append(scopes, r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.Scopes[scopesIndex].ValueString())
 					}
 					var tokenEndpoint string
 					tokenEndpoint = r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.TokenEndpoint.ValueString()
@@ -677,9 +677,9 @@ func (r *GatewayPluginKafkaConsumeResourceModel) ToSharedKafkaConsumePlugin(ctx 
 					var tokenHeaders map[string]string
 					if r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.TokenHeaders != nil {
 						tokenHeaders = make(map[string]string)
-						for tokenHeadersKey, tokenHeadersValue := range r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.TokenHeaders {
+						for tokenHeadersKey := range r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.TokenHeaders {
 							var tokenHeadersInst string
-							tokenHeadersInst = tokenHeadersValue.ValueString()
+							tokenHeadersInst = r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.TokenHeaders[tokenHeadersKey].ValueString()
 
 							tokenHeaders[tokenHeadersKey] = tokenHeadersInst
 						}
@@ -687,9 +687,9 @@ func (r *GatewayPluginKafkaConsumeResourceModel) ToSharedKafkaConsumePlugin(ctx 
 					var tokenPostArgs map[string]string
 					if r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.TokenPostArgs != nil {
 						tokenPostArgs = make(map[string]string)
-						for tokenPostArgsKey, tokenPostArgsValue := range r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.TokenPostArgs {
+						for tokenPostArgsKey := range r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.TokenPostArgs {
 							var tokenPostArgsInst string
-							tokenPostArgsInst = tokenPostArgsValue.ValueString()
+							tokenPostArgsInst = r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.TokenPostArgs[tokenPostArgsKey].ValueString()
 
 							tokenPostArgs[tokenPostArgsKey] = tokenPostArgsInst
 						}
@@ -851,23 +851,23 @@ func (r *GatewayPluginKafkaConsumeResourceModel) ToSharedKafkaConsumePlugin(ctx 
 		}
 	}
 	topics := make([]shared.KafkaConsumePluginTopics, 0, len(r.Config.Topics))
-	for _, topicsItem := range r.Config.Topics {
+	for topicsIndex := range r.Config.Topics {
 		var name1 string
-		name1 = topicsItem.Name.ValueString()
+		name1 = r.Config.Topics[topicsIndex].Name.ValueString()
 
 		var schemaRegistry1 *shared.KafkaConsumePluginConfigSchemaRegistry
-		if topicsItem.SchemaRegistry != nil {
+		if r.Config.Topics[topicsIndex].SchemaRegistry != nil {
 			var confluent1 *shared.KafkaConsumePluginConfigConfluent
-			if topicsItem.SchemaRegistry.Confluent != nil {
+			if r.Config.Topics[topicsIndex].SchemaRegistry.Confluent != nil {
 				var authentication2 *shared.KafkaConsumePluginConfigAuthentication
-				if topicsItem.SchemaRegistry.Confluent.Authentication != nil {
+				if r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication != nil {
 					var basic1 *shared.KafkaConsumePluginConfigBasic
-					if topicsItem.SchemaRegistry.Confluent.Authentication.Basic != nil {
+					if r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Basic != nil {
 						var password3 string
-						password3 = topicsItem.SchemaRegistry.Confluent.Authentication.Basic.Password.ValueString()
+						password3 = r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Basic.Password.ValueString()
 
 						var username2 string
-						username2 = topicsItem.SchemaRegistry.Confluent.Authentication.Basic.Username.ValueString()
+						username2 = r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Basic.Username.ValueString()
 
 						basic1 = &shared.KafkaConsumePluginConfigBasic{
 							Password: password3,
@@ -875,71 +875,71 @@ func (r *GatewayPluginKafkaConsumeResourceModel) ToSharedKafkaConsumePlugin(ctx 
 						}
 					}
 					mode2 := new(shared.KafkaConsumePluginConfigTopicsMode)
-					if !topicsItem.SchemaRegistry.Confluent.Authentication.Mode.IsUnknown() && !topicsItem.SchemaRegistry.Confluent.Authentication.Mode.IsNull() {
-						*mode2 = shared.KafkaConsumePluginConfigTopicsMode(topicsItem.SchemaRegistry.Confluent.Authentication.Mode.ValueString())
+					if !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Mode.IsUnknown() && !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Mode.IsNull() {
+						*mode2 = shared.KafkaConsumePluginConfigTopicsMode(r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Mode.ValueString())
 					} else {
 						mode2 = nil
 					}
 					var oauth21 *shared.KafkaConsumePluginConfigOauth2
-					if topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2 != nil {
-						audience1 := make([]string, 0, len(topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2.Audience))
-						for _, audienceItem1 := range topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2.Audience {
-							audience1 = append(audience1, audienceItem1.ValueString())
+					if r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2 != nil {
+						audience1 := make([]string, 0, len(r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.Audience))
+						for audienceIndex1 := range r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.Audience {
+							audience1 = append(audience1, r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.Audience[audienceIndex1].ValueString())
 						}
 						clientId1 := new(string)
-						if !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2.ClientID.IsUnknown() && !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2.ClientID.IsNull() {
-							*clientId1 = topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2.ClientID.ValueString()
+						if !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.ClientID.IsUnknown() && !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.ClientID.IsNull() {
+							*clientId1 = r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.ClientID.ValueString()
 						} else {
 							clientId1 = nil
 						}
 						clientSecret1 := new(string)
-						if !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2.ClientSecret.IsUnknown() && !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2.ClientSecret.IsNull() {
-							*clientSecret1 = topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2.ClientSecret.ValueString()
+						if !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.ClientSecret.IsUnknown() && !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.ClientSecret.IsNull() {
+							*clientSecret1 = r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.ClientSecret.ValueString()
 						} else {
 							clientSecret1 = nil
 						}
 						grantType1 := new(shared.KafkaConsumePluginConfigGrantType)
-						if !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2.GrantType.IsUnknown() && !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2.GrantType.IsNull() {
-							*grantType1 = shared.KafkaConsumePluginConfigGrantType(topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2.GrantType.ValueString())
+						if !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.GrantType.IsUnknown() && !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.GrantType.IsNull() {
+							*grantType1 = shared.KafkaConsumePluginConfigGrantType(r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.GrantType.ValueString())
 						} else {
 							grantType1 = nil
 						}
 						password4 := new(string)
-						if !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2.Password.IsUnknown() && !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2.Password.IsNull() {
-							*password4 = topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2.Password.ValueString()
+						if !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.Password.IsUnknown() && !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.Password.IsNull() {
+							*password4 = r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.Password.ValueString()
 						} else {
 							password4 = nil
 						}
-						scopes1 := make([]string, 0, len(topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2.Scopes))
-						for _, scopesItem1 := range topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2.Scopes {
-							scopes1 = append(scopes1, scopesItem1.ValueString())
+						scopes1 := make([]string, 0, len(r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.Scopes))
+						for scopesIndex1 := range r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.Scopes {
+							scopes1 = append(scopes1, r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.Scopes[scopesIndex1].ValueString())
 						}
 						var tokenEndpoint1 string
-						tokenEndpoint1 = topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2.TokenEndpoint.ValueString()
+						tokenEndpoint1 = r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.TokenEndpoint.ValueString()
 
 						var tokenHeaders1 map[string]string
-						if topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2.TokenHeaders != nil {
+						if r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.TokenHeaders != nil {
 							tokenHeaders1 = make(map[string]string)
-							for tokenHeadersKey1, tokenHeadersValue1 := range topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2.TokenHeaders {
+							for tokenHeadersKey1 := range r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.TokenHeaders {
 								var tokenHeadersInst1 string
-								tokenHeadersInst1 = tokenHeadersValue1.ValueString()
+								tokenHeadersInst1 = r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.TokenHeaders[tokenHeadersKey1].ValueString()
 
 								tokenHeaders1[tokenHeadersKey1] = tokenHeadersInst1
 							}
 						}
 						var tokenPostArgs1 map[string]string
-						if topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2.TokenPostArgs != nil {
+						if r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.TokenPostArgs != nil {
 							tokenPostArgs1 = make(map[string]string)
-							for tokenPostArgsKey1, tokenPostArgsValue1 := range topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2.TokenPostArgs {
+							for tokenPostArgsKey1 := range r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.TokenPostArgs {
 								var tokenPostArgsInst1 string
-								tokenPostArgsInst1 = tokenPostArgsValue1.ValueString()
+								tokenPostArgsInst1 = r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.TokenPostArgs[tokenPostArgsKey1].ValueString()
 
 								tokenPostArgs1[tokenPostArgsKey1] = tokenPostArgsInst1
 							}
 						}
 						username3 := new(string)
-						if !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2.Username.IsUnknown() && !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2.Username.IsNull() {
-							*username3 = topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2.Username.ValueString()
+						if !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.Username.IsUnknown() && !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.Username.IsNull() {
+							*username3 = r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2.Username.ValueString()
 						} else {
 							username3 = nil
 						}
@@ -957,70 +957,70 @@ func (r *GatewayPluginKafkaConsumeResourceModel) ToSharedKafkaConsumePlugin(ctx 
 						}
 					}
 					var oauth2Client1 *shared.KafkaConsumePluginConfigOauth2Client
-					if topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client != nil {
+					if r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client != nil {
 						authMethod1 := new(shared.KafkaConsumePluginConfigAuthMethod)
-						if !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.AuthMethod.IsUnknown() && !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.AuthMethod.IsNull() {
-							*authMethod1 = shared.KafkaConsumePluginConfigAuthMethod(topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.AuthMethod.ValueString())
+						if !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.AuthMethod.IsUnknown() && !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.AuthMethod.IsNull() {
+							*authMethod1 = shared.KafkaConsumePluginConfigAuthMethod(r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.AuthMethod.ValueString())
 						} else {
 							authMethod1 = nil
 						}
 						clientSecretJwtAlg1 := new(shared.KafkaConsumePluginConfigClientSecretJwtAlg)
-						if !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.ClientSecretJwtAlg.IsUnknown() && !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.ClientSecretJwtAlg.IsNull() {
-							*clientSecretJwtAlg1 = shared.KafkaConsumePluginConfigClientSecretJwtAlg(topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.ClientSecretJwtAlg.ValueString())
+						if !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.ClientSecretJwtAlg.IsUnknown() && !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.ClientSecretJwtAlg.IsNull() {
+							*clientSecretJwtAlg1 = shared.KafkaConsumePluginConfigClientSecretJwtAlg(r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.ClientSecretJwtAlg.ValueString())
 						} else {
 							clientSecretJwtAlg1 = nil
 						}
 						httpProxy1 := new(string)
-						if !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPProxy.IsUnknown() && !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPProxy.IsNull() {
-							*httpProxy1 = topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPProxy.ValueString()
+						if !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPProxy.IsUnknown() && !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPProxy.IsNull() {
+							*httpProxy1 = r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPProxy.ValueString()
 						} else {
 							httpProxy1 = nil
 						}
 						httpProxyAuthorization1 := new(string)
-						if !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPProxyAuthorization.IsUnknown() && !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPProxyAuthorization.IsNull() {
-							*httpProxyAuthorization1 = topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPProxyAuthorization.ValueString()
+						if !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPProxyAuthorization.IsUnknown() && !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPProxyAuthorization.IsNull() {
+							*httpProxyAuthorization1 = r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPProxyAuthorization.ValueString()
 						} else {
 							httpProxyAuthorization1 = nil
 						}
 						httpVersion1 := new(float64)
-						if !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPVersion.IsUnknown() && !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPVersion.IsNull() {
-							*httpVersion1 = topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPVersion.ValueFloat64()
+						if !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPVersion.IsUnknown() && !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPVersion.IsNull() {
+							*httpVersion1 = r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPVersion.ValueFloat64()
 						} else {
 							httpVersion1 = nil
 						}
 						httpsProxy1 := new(string)
-						if !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPSProxy.IsUnknown() && !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPSProxy.IsNull() {
-							*httpsProxy1 = topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPSProxy.ValueString()
+						if !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPSProxy.IsUnknown() && !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPSProxy.IsNull() {
+							*httpsProxy1 = r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPSProxy.ValueString()
 						} else {
 							httpsProxy1 = nil
 						}
 						httpsProxyAuthorization1 := new(string)
-						if !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPSProxyAuthorization.IsUnknown() && !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPSProxyAuthorization.IsNull() {
-							*httpsProxyAuthorization1 = topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPSProxyAuthorization.ValueString()
+						if !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPSProxyAuthorization.IsUnknown() && !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPSProxyAuthorization.IsNull() {
+							*httpsProxyAuthorization1 = r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.HTTPSProxyAuthorization.ValueString()
 						} else {
 							httpsProxyAuthorization1 = nil
 						}
 						keepAlive1 := new(bool)
-						if !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.KeepAlive.IsUnknown() && !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.KeepAlive.IsNull() {
-							*keepAlive1 = topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.KeepAlive.ValueBool()
+						if !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.KeepAlive.IsUnknown() && !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.KeepAlive.IsNull() {
+							*keepAlive1 = r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.KeepAlive.ValueBool()
 						} else {
 							keepAlive1 = nil
 						}
 						noProxy1 := new(string)
-						if !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.NoProxy.IsUnknown() && !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.NoProxy.IsNull() {
-							*noProxy1 = topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.NoProxy.ValueString()
+						if !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.NoProxy.IsUnknown() && !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.NoProxy.IsNull() {
+							*noProxy1 = r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.NoProxy.ValueString()
 						} else {
 							noProxy1 = nil
 						}
 						sslVerify2 := new(bool)
-						if !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.SslVerify.IsUnknown() && !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.SslVerify.IsNull() {
-							*sslVerify2 = topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.SslVerify.ValueBool()
+						if !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.SslVerify.IsUnknown() && !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.SslVerify.IsNull() {
+							*sslVerify2 = r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.SslVerify.ValueBool()
 						} else {
 							sslVerify2 = nil
 						}
 						timeout1 := new(int64)
-						if !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.Timeout.IsUnknown() && !topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.Timeout.IsNull() {
-							*timeout1 = topicsItem.SchemaRegistry.Confluent.Authentication.Oauth2Client.Timeout.ValueInt64()
+						if !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.Timeout.IsUnknown() && !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.Timeout.IsNull() {
+							*timeout1 = r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.Authentication.Oauth2Client.Timeout.ValueInt64()
 						} else {
 							timeout1 = nil
 						}
@@ -1046,20 +1046,20 @@ func (r *GatewayPluginKafkaConsumeResourceModel) ToSharedKafkaConsumePlugin(ctx 
 					}
 				}
 				sslVerify3 := new(bool)
-				if !topicsItem.SchemaRegistry.Confluent.SslVerify.IsUnknown() && !topicsItem.SchemaRegistry.Confluent.SslVerify.IsNull() {
-					*sslVerify3 = topicsItem.SchemaRegistry.Confluent.SslVerify.ValueBool()
+				if !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.SslVerify.IsUnknown() && !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.SslVerify.IsNull() {
+					*sslVerify3 = r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.SslVerify.ValueBool()
 				} else {
 					sslVerify3 = nil
 				}
 				ttl1 := new(float64)
-				if !topicsItem.SchemaRegistry.Confluent.TTL.IsUnknown() && !topicsItem.SchemaRegistry.Confluent.TTL.IsNull() {
-					*ttl1 = topicsItem.SchemaRegistry.Confluent.TTL.ValueFloat64()
+				if !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.TTL.IsUnknown() && !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.TTL.IsNull() {
+					*ttl1 = r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.TTL.ValueFloat64()
 				} else {
 					ttl1 = nil
 				}
 				url1 := new(string)
-				if !topicsItem.SchemaRegistry.Confluent.URL.IsUnknown() && !topicsItem.SchemaRegistry.Confluent.URL.IsNull() {
-					*url1 = topicsItem.SchemaRegistry.Confluent.URL.ValueString()
+				if !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.URL.IsUnknown() && !r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.URL.IsNull() {
+					*url1 = r.Config.Topics[topicsIndex].SchemaRegistry.Confluent.URL.ValueString()
 				} else {
 					url1 = nil
 				}

--- a/internal/provider/gatewaypluginkafkalog_resource.go
+++ b/internal/provider/gatewaypluginkafkalog_resource.go
@@ -1116,7 +1116,10 @@ func (r *GatewayPluginKafkaLogResource) Delete(ctx context.Context, req resource
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginkafkalog_resource_sdk.go
+++ b/internal/provider/gatewaypluginkafkalog_resource_sdk.go
@@ -366,8 +366,8 @@ func (r *GatewayPluginKafkaLogResourceModel) ToSharedKafkaLogPlugin(ctx context.
 		var after *shared.KafkaLogPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.KafkaLogPluginAfter{
 				Access: access,
@@ -376,8 +376,8 @@ func (r *GatewayPluginKafkaLogResourceModel) ToSharedKafkaLogPlugin(ctx context.
 		var before *shared.KafkaLogPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.KafkaLogPluginBefore{
 				Access: access1,
@@ -391,22 +391,22 @@ func (r *GatewayPluginKafkaLogResourceModel) ToSharedKafkaLogPlugin(ctx context.
 	var partials []shared.KafkaLogPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.KafkaLogPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -420,8 +420,8 @@ func (r *GatewayPluginKafkaLogResourceModel) ToSharedKafkaLogPlugin(ctx context.
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -473,12 +473,12 @@ func (r *GatewayPluginKafkaLogResourceModel) ToSharedKafkaLogPlugin(ctx context.
 	var bootstrapServers []shared.KafkaLogPluginBootstrapServers
 	if r.Config.BootstrapServers != nil {
 		bootstrapServers = make([]shared.KafkaLogPluginBootstrapServers, 0, len(r.Config.BootstrapServers))
-		for _, bootstrapServersItem := range r.Config.BootstrapServers {
+		for bootstrapServersIndex := range r.Config.BootstrapServers {
 			var host string
-			host = bootstrapServersItem.Host.ValueString()
+			host = r.Config.BootstrapServers[bootstrapServersIndex].Host.ValueString()
 
 			var port int64
-			port = bootstrapServersItem.Port.ValueInt64()
+			port = r.Config.BootstrapServers[bootstrapServersIndex].Port.ValueInt64()
 
 			bootstrapServers = append(bootstrapServers, shared.KafkaLogPluginBootstrapServers{
 				Host: host,
@@ -495,9 +495,9 @@ func (r *GatewayPluginKafkaLogResourceModel) ToSharedKafkaLogPlugin(ctx context.
 	var customFieldsByLua map[string]string
 	if r.Config.CustomFieldsByLua != nil {
 		customFieldsByLua = make(map[string]string)
-		for customFieldsByLuaKey, customFieldsByLuaValue := range r.Config.CustomFieldsByLua {
+		for customFieldsByLuaKey := range r.Config.CustomFieldsByLua {
 			var customFieldsByLuaInst string
-			customFieldsByLuaInst = customFieldsByLuaValue.ValueString()
+			customFieldsByLuaInst = r.Config.CustomFieldsByLua[customFieldsByLuaKey].ValueString()
 
 			customFieldsByLua[customFieldsByLuaKey] = customFieldsByLuaInst
 		}
@@ -602,8 +602,8 @@ func (r *GatewayPluginKafkaLogResourceModel) ToSharedKafkaLogPlugin(ctx context.
 				var oauth2 *shared.KafkaLogPluginOauth2
 				if r.Config.SchemaRegistry.Confluent.Authentication.Oauth2 != nil {
 					audience := make([]string, 0, len(r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.Audience))
-					for _, audienceItem := range r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.Audience {
-						audience = append(audience, audienceItem.ValueString())
+					for audienceIndex := range r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.Audience {
+						audience = append(audience, r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.Audience[audienceIndex].ValueString())
 					}
 					clientID := new(string)
 					if !r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.ClientID.IsUnknown() && !r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.ClientID.IsNull() {
@@ -630,8 +630,8 @@ func (r *GatewayPluginKafkaLogResourceModel) ToSharedKafkaLogPlugin(ctx context.
 						password2 = nil
 					}
 					scopes := make([]string, 0, len(r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.Scopes))
-					for _, scopesItem := range r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.Scopes {
-						scopes = append(scopes, scopesItem.ValueString())
+					for scopesIndex := range r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.Scopes {
+						scopes = append(scopes, r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.Scopes[scopesIndex].ValueString())
 					}
 					var tokenEndpoint string
 					tokenEndpoint = r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.TokenEndpoint.ValueString()
@@ -639,9 +639,9 @@ func (r *GatewayPluginKafkaLogResourceModel) ToSharedKafkaLogPlugin(ctx context.
 					var tokenHeaders map[string]string
 					if r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.TokenHeaders != nil {
 						tokenHeaders = make(map[string]string)
-						for tokenHeadersKey, tokenHeadersValue := range r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.TokenHeaders {
+						for tokenHeadersKey := range r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.TokenHeaders {
 							var tokenHeadersInst string
-							tokenHeadersInst = tokenHeadersValue.ValueString()
+							tokenHeadersInst = r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.TokenHeaders[tokenHeadersKey].ValueString()
 
 							tokenHeaders[tokenHeadersKey] = tokenHeadersInst
 						}
@@ -649,9 +649,9 @@ func (r *GatewayPluginKafkaLogResourceModel) ToSharedKafkaLogPlugin(ctx context.
 					var tokenPostArgs map[string]string
 					if r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.TokenPostArgs != nil {
 						tokenPostArgs = make(map[string]string)
-						for tokenPostArgsKey, tokenPostArgsValue := range r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.TokenPostArgs {
+						for tokenPostArgsKey := range r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.TokenPostArgs {
 							var tokenPostArgsInst string
-							tokenPostArgsInst = tokenPostArgsValue.ValueString()
+							tokenPostArgsInst = r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.TokenPostArgs[tokenPostArgsKey].ValueString()
 
 							tokenPostArgs[tokenPostArgsKey] = tokenPostArgsInst
 						}

--- a/internal/provider/gatewaypluginkafkaupstream_resource.go
+++ b/internal/provider/gatewaypluginkafkaupstream_resource.go
@@ -1147,7 +1147,10 @@ func (r *GatewayPluginKafkaUpstreamResource) Delete(ctx context.Context, req res
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginkafkaupstream_resource_sdk.go
+++ b/internal/provider/gatewaypluginkafkaupstream_resource_sdk.go
@@ -377,8 +377,8 @@ func (r *GatewayPluginKafkaUpstreamResourceModel) ToSharedKafkaUpstreamPlugin(ct
 		var after *shared.KafkaUpstreamPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.KafkaUpstreamPluginAfter{
 				Access: access,
@@ -387,8 +387,8 @@ func (r *GatewayPluginKafkaUpstreamResourceModel) ToSharedKafkaUpstreamPlugin(ct
 		var before *shared.KafkaUpstreamPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.KafkaUpstreamPluginBefore{
 				Access: access1,
@@ -402,22 +402,22 @@ func (r *GatewayPluginKafkaUpstreamResourceModel) ToSharedKafkaUpstreamPlugin(ct
 	var partials []shared.KafkaUpstreamPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.KafkaUpstreamPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -431,8 +431,8 @@ func (r *GatewayPluginKafkaUpstreamResourceModel) ToSharedKafkaUpstreamPlugin(ct
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -444,8 +444,8 @@ func (r *GatewayPluginKafkaUpstreamResourceModel) ToSharedKafkaUpstreamPlugin(ct
 	var allowedTopics []string
 	if r.Config.AllowedTopics != nil {
 		allowedTopics = make([]string, 0, len(r.Config.AllowedTopics))
-		for _, allowedTopicsItem := range r.Config.AllowedTopics {
-			allowedTopics = append(allowedTopics, allowedTopicsItem.ValueString())
+		for allowedTopicsIndex := range r.Config.AllowedTopics {
+			allowedTopics = append(allowedTopics, r.Config.AllowedTopics[allowedTopicsIndex].ValueString())
 		}
 	}
 	var authentication *shared.KafkaUpstreamPluginAuthentication
@@ -491,12 +491,12 @@ func (r *GatewayPluginKafkaUpstreamResourceModel) ToSharedKafkaUpstreamPlugin(ct
 	var bootstrapServers []shared.KafkaUpstreamPluginBootstrapServers
 	if r.Config.BootstrapServers != nil {
 		bootstrapServers = make([]shared.KafkaUpstreamPluginBootstrapServers, 0, len(r.Config.BootstrapServers))
-		for _, bootstrapServersItem := range r.Config.BootstrapServers {
+		for bootstrapServersIndex := range r.Config.BootstrapServers {
 			var host string
-			host = bootstrapServersItem.Host.ValueString()
+			host = r.Config.BootstrapServers[bootstrapServersIndex].Host.ValueString()
 
 			var port int64
-			port = bootstrapServersItem.Port.ValueInt64()
+			port = r.Config.BootstrapServers[bootstrapServersIndex].Port.ValueInt64()
 
 			bootstrapServers = append(bootstrapServers, shared.KafkaUpstreamPluginBootstrapServers{
 				Host: host,
@@ -555,8 +555,8 @@ func (r *GatewayPluginKafkaUpstreamResourceModel) ToSharedKafkaUpstreamPlugin(ct
 	var messageByLuaFunctions []string
 	if r.Config.MessageByLuaFunctions != nil {
 		messageByLuaFunctions = make([]string, 0, len(r.Config.MessageByLuaFunctions))
-		for _, messageByLuaFunctionsItem := range r.Config.MessageByLuaFunctions {
-			messageByLuaFunctions = append(messageByLuaFunctions, messageByLuaFunctionsItem.ValueString())
+		for messageByLuaFunctionsIndex := range r.Config.MessageByLuaFunctions {
+			messageByLuaFunctions = append(messageByLuaFunctions, r.Config.MessageByLuaFunctions[messageByLuaFunctionsIndex].ValueString())
 		}
 	}
 	producerAsync := new(bool)
@@ -641,8 +641,8 @@ func (r *GatewayPluginKafkaUpstreamResourceModel) ToSharedKafkaUpstreamPlugin(ct
 				var oauth2 *shared.KafkaUpstreamPluginOauth2
 				if r.Config.SchemaRegistry.Confluent.Authentication.Oauth2 != nil {
 					audience := make([]string, 0, len(r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.Audience))
-					for _, audienceItem := range r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.Audience {
-						audience = append(audience, audienceItem.ValueString())
+					for audienceIndex := range r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.Audience {
+						audience = append(audience, r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.Audience[audienceIndex].ValueString())
 					}
 					clientID := new(string)
 					if !r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.ClientID.IsUnknown() && !r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.ClientID.IsNull() {
@@ -669,8 +669,8 @@ func (r *GatewayPluginKafkaUpstreamResourceModel) ToSharedKafkaUpstreamPlugin(ct
 						password2 = nil
 					}
 					scopes := make([]string, 0, len(r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.Scopes))
-					for _, scopesItem := range r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.Scopes {
-						scopes = append(scopes, scopesItem.ValueString())
+					for scopesIndex := range r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.Scopes {
+						scopes = append(scopes, r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.Scopes[scopesIndex].ValueString())
 					}
 					var tokenEndpoint string
 					tokenEndpoint = r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.TokenEndpoint.ValueString()
@@ -678,9 +678,9 @@ func (r *GatewayPluginKafkaUpstreamResourceModel) ToSharedKafkaUpstreamPlugin(ct
 					var tokenHeaders map[string]string
 					if r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.TokenHeaders != nil {
 						tokenHeaders = make(map[string]string)
-						for tokenHeadersKey, tokenHeadersValue := range r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.TokenHeaders {
+						for tokenHeadersKey := range r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.TokenHeaders {
 							var tokenHeadersInst string
-							tokenHeadersInst = tokenHeadersValue.ValueString()
+							tokenHeadersInst = r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.TokenHeaders[tokenHeadersKey].ValueString()
 
 							tokenHeaders[tokenHeadersKey] = tokenHeadersInst
 						}
@@ -688,9 +688,9 @@ func (r *GatewayPluginKafkaUpstreamResourceModel) ToSharedKafkaUpstreamPlugin(ct
 					var tokenPostArgs map[string]string
 					if r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.TokenPostArgs != nil {
 						tokenPostArgs = make(map[string]string)
-						for tokenPostArgsKey, tokenPostArgsValue := range r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.TokenPostArgs {
+						for tokenPostArgsKey := range r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.TokenPostArgs {
 							var tokenPostArgsInst string
-							tokenPostArgsInst = tokenPostArgsValue.ValueString()
+							tokenPostArgsInst = r.Config.SchemaRegistry.Confluent.Authentication.Oauth2.TokenPostArgs[tokenPostArgsKey].ValueString()
 
 							tokenPostArgs[tokenPostArgsKey] = tokenPostArgsInst
 						}

--- a/internal/provider/gatewaypluginkeyauth_resource.go
+++ b/internal/provider/gatewaypluginkeyauth_resource.go
@@ -556,7 +556,10 @@ func (r *GatewayPluginKeyAuthResource) Delete(ctx context.Context, req resource.
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginkeyauth_resource_sdk.go
+++ b/internal/provider/gatewaypluginkeyauth_resource_sdk.go
@@ -226,8 +226,8 @@ func (r *GatewayPluginKeyAuthResourceModel) ToSharedKeyAuthPlugin(ctx context.Co
 		var after *shared.KeyAuthPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.KeyAuthPluginAfter{
 				Access: access,
@@ -236,8 +236,8 @@ func (r *GatewayPluginKeyAuthResourceModel) ToSharedKeyAuthPlugin(ctx context.Co
 		var before *shared.KeyAuthPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.KeyAuthPluginBefore{
 				Access: access1,
@@ -251,22 +251,22 @@ func (r *GatewayPluginKeyAuthResourceModel) ToSharedKeyAuthPlugin(ctx context.Co
 	var partials []shared.KeyAuthPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.KeyAuthPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -280,8 +280,8 @@ func (r *GatewayPluginKeyAuthResourceModel) ToSharedKeyAuthPlugin(ctx context.Co
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -305,22 +305,22 @@ func (r *GatewayPluginKeyAuthResourceModel) ToSharedKeyAuthPlugin(ctx context.Co
 			hideCredentials = nil
 		}
 		identityRealms := make([]shared.IdentityRealms, 0, len(r.Config.IdentityRealms))
-		for _, identityRealmsItem := range r.Config.IdentityRealms {
+		for identityRealmsIndex := range r.Config.IdentityRealms {
 			id2 := new(string)
-			if !identityRealmsItem.ID.IsUnknown() && !identityRealmsItem.ID.IsNull() {
-				*id2 = identityRealmsItem.ID.ValueString()
+			if !r.Config.IdentityRealms[identityRealmsIndex].ID.IsUnknown() && !r.Config.IdentityRealms[identityRealmsIndex].ID.IsNull() {
+				*id2 = r.Config.IdentityRealms[identityRealmsIndex].ID.ValueString()
 			} else {
 				id2 = nil
 			}
 			region := new(string)
-			if !identityRealmsItem.Region.IsUnknown() && !identityRealmsItem.Region.IsNull() {
-				*region = identityRealmsItem.Region.ValueString()
+			if !r.Config.IdentityRealms[identityRealmsIndex].Region.IsUnknown() && !r.Config.IdentityRealms[identityRealmsIndex].Region.IsNull() {
+				*region = r.Config.IdentityRealms[identityRealmsIndex].Region.ValueString()
 			} else {
 				region = nil
 			}
 			scope := new(shared.Scope)
-			if !identityRealmsItem.Scope.IsUnknown() && !identityRealmsItem.Scope.IsNull() {
-				*scope = shared.Scope(identityRealmsItem.Scope.ValueString())
+			if !r.Config.IdentityRealms[identityRealmsIndex].Scope.IsUnknown() && !r.Config.IdentityRealms[identityRealmsIndex].Scope.IsNull() {
+				*scope = shared.Scope(r.Config.IdentityRealms[identityRealmsIndex].Scope.ValueString())
 			} else {
 				scope = nil
 			}
@@ -349,8 +349,8 @@ func (r *GatewayPluginKeyAuthResourceModel) ToSharedKeyAuthPlugin(ctx context.Co
 			keyInQuery = nil
 		}
 		keyNames := make([]string, 0, len(r.Config.KeyNames))
-		for _, keyNamesItem := range r.Config.KeyNames {
-			keyNames = append(keyNames, keyNamesItem.ValueString())
+		for keyNamesIndex := range r.Config.KeyNames {
+			keyNames = append(keyNames, r.Config.KeyNames[keyNamesIndex].ValueString())
 		}
 		realm := new(string)
 		if !r.Config.Realm.IsUnknown() && !r.Config.Realm.IsNull() {

--- a/internal/provider/gatewaypluginldapauth_resource.go
+++ b/internal/provider/gatewaypluginldapauth_resource.go
@@ -538,7 +538,10 @@ func (r *GatewayPluginLdapAuthResource) Delete(ctx context.Context, req resource
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginldapauth_resource_sdk.go
+++ b/internal/provider/gatewaypluginldapauth_resource_sdk.go
@@ -209,8 +209,8 @@ func (r *GatewayPluginLdapAuthResourceModel) ToSharedLdapAuthPlugin(ctx context.
 		var after *shared.LdapAuthPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.LdapAuthPluginAfter{
 				Access: access,
@@ -219,8 +219,8 @@ func (r *GatewayPluginLdapAuthResourceModel) ToSharedLdapAuthPlugin(ctx context.
 		var before *shared.LdapAuthPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.LdapAuthPluginBefore{
 				Access: access1,
@@ -234,22 +234,22 @@ func (r *GatewayPluginLdapAuthResourceModel) ToSharedLdapAuthPlugin(ctx context.
 	var partials []shared.LdapAuthPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.LdapAuthPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -263,8 +263,8 @@ func (r *GatewayPluginLdapAuthResourceModel) ToSharedLdapAuthPlugin(ctx context.
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)

--- a/internal/provider/gatewaypluginldapauthadvanced_resource.go
+++ b/internal/provider/gatewaypluginldapauthadvanced_resource.go
@@ -585,7 +585,10 @@ func (r *GatewayPluginLdapAuthAdvancedResource) Delete(ctx context.Context, req 
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginldapauthadvanced_resource_sdk.go
+++ b/internal/provider/gatewaypluginldapauthadvanced_resource_sdk.go
@@ -226,8 +226,8 @@ func (r *GatewayPluginLdapAuthAdvancedResourceModel) ToSharedLdapAuthAdvancedPlu
 		var after *shared.LdapAuthAdvancedPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.LdapAuthAdvancedPluginAfter{
 				Access: access,
@@ -236,8 +236,8 @@ func (r *GatewayPluginLdapAuthAdvancedResourceModel) ToSharedLdapAuthAdvancedPlu
 		var before *shared.LdapAuthAdvancedPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.LdapAuthAdvancedPluginBefore{
 				Access: access1,
@@ -251,22 +251,22 @@ func (r *GatewayPluginLdapAuthAdvancedResourceModel) ToSharedLdapAuthAdvancedPlu
 	var partials []shared.LdapAuthAdvancedPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.LdapAuthAdvancedPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -280,8 +280,8 @@ func (r *GatewayPluginLdapAuthAdvancedResourceModel) ToSharedLdapAuthAdvancedPlu
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -345,8 +345,8 @@ func (r *GatewayPluginLdapAuthAdvancedResourceModel) ToSharedLdapAuthAdvancedPlu
 	var groupsRequired []string
 	if r.Config.GroupsRequired != nil {
 		groupsRequired = make([]string, 0, len(r.Config.GroupsRequired))
-		for _, groupsRequiredItem := range r.Config.GroupsRequired {
-			groupsRequired = append(groupsRequired, groupsRequiredItem.ValueString())
+		for groupsRequiredIndex := range r.Config.GroupsRequired {
+			groupsRequired = append(groupsRequired, r.Config.GroupsRequired[groupsRequiredIndex].ValueString())
 		}
 	}
 	headerType := new(string)

--- a/internal/provider/gatewaypluginloggly_resource.go
+++ b/internal/provider/gatewaypluginloggly_resource.go
@@ -583,7 +583,10 @@ func (r *GatewayPluginLogglyResource) Delete(ctx context.Context, req resource.D
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginloggly_resource_sdk.go
+++ b/internal/provider/gatewaypluginloggly_resource_sdk.go
@@ -235,8 +235,8 @@ func (r *GatewayPluginLogglyResourceModel) ToSharedLogglyPlugin(ctx context.Cont
 		var after *shared.LogglyPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.LogglyPluginAfter{
 				Access: access,
@@ -245,8 +245,8 @@ func (r *GatewayPluginLogglyResourceModel) ToSharedLogglyPlugin(ctx context.Cont
 		var before *shared.LogglyPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.LogglyPluginBefore{
 				Access: access1,
@@ -260,22 +260,22 @@ func (r *GatewayPluginLogglyResourceModel) ToSharedLogglyPlugin(ctx context.Cont
 	var partials []shared.LogglyPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.LogglyPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -289,8 +289,8 @@ func (r *GatewayPluginLogglyResourceModel) ToSharedLogglyPlugin(ctx context.Cont
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -308,9 +308,9 @@ func (r *GatewayPluginLogglyResourceModel) ToSharedLogglyPlugin(ctx context.Cont
 	var customFieldsByLua map[string]string
 	if r.Config.CustomFieldsByLua != nil {
 		customFieldsByLua = make(map[string]string)
-		for customFieldsByLuaKey, customFieldsByLuaValue := range r.Config.CustomFieldsByLua {
+		for customFieldsByLuaKey := range r.Config.CustomFieldsByLua {
 			var customFieldsByLuaInst string
-			customFieldsByLuaInst = customFieldsByLuaValue.ValueString()
+			customFieldsByLuaInst = r.Config.CustomFieldsByLua[customFieldsByLuaKey].ValueString()
 
 			customFieldsByLua[customFieldsByLuaKey] = customFieldsByLuaInst
 		}
@@ -349,8 +349,8 @@ func (r *GatewayPluginLogglyResourceModel) ToSharedLogglyPlugin(ctx context.Cont
 		successfulSeverity = nil
 	}
 	tags1 := make([]string, 0, len(r.Config.Tags))
-	for _, tagsItem1 := range r.Config.Tags {
-		tags1 = append(tags1, tagsItem1.ValueString())
+	for tagsIndex1 := range r.Config.Tags {
+		tags1 = append(tags1, r.Config.Tags[tagsIndex1].ValueString())
 	}
 	timeout := new(float64)
 	if !r.Config.Timeout.IsUnknown() && !r.Config.Timeout.IsNull() {

--- a/internal/provider/gatewaypluginmocking_resource.go
+++ b/internal/provider/gatewaypluginmocking_resource.go
@@ -538,7 +538,10 @@ func (r *GatewayPluginMockingResource) Delete(ctx context.Context, req resource.
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginmocking_resource_sdk.go
+++ b/internal/provider/gatewaypluginmocking_resource_sdk.go
@@ -221,8 +221,8 @@ func (r *GatewayPluginMockingResourceModel) ToSharedMockingPlugin(ctx context.Co
 		var after *shared.MockingPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.MockingPluginAfter{
 				Access: access,
@@ -231,8 +231,8 @@ func (r *GatewayPluginMockingResourceModel) ToSharedMockingPlugin(ctx context.Co
 		var before *shared.MockingPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.MockingPluginBefore{
 				Access: access1,
@@ -246,22 +246,22 @@ func (r *GatewayPluginMockingResourceModel) ToSharedMockingPlugin(ctx context.Co
 	var partials []shared.MockingPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.MockingPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -275,8 +275,8 @@ func (r *GatewayPluginMockingResourceModel) ToSharedMockingPlugin(ctx context.Co
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -314,8 +314,8 @@ func (r *GatewayPluginMockingResourceModel) ToSharedMockingPlugin(ctx context.Co
 		var includedStatusCodes []int64
 		if r.Config.IncludedStatusCodes != nil {
 			includedStatusCodes = make([]int64, 0, len(r.Config.IncludedStatusCodes))
-			for _, includedStatusCodesItem := range r.Config.IncludedStatusCodes {
-				includedStatusCodes = append(includedStatusCodes, includedStatusCodesItem.ValueInt64())
+			for includedStatusCodesIndex := range r.Config.IncludedStatusCodes {
+				includedStatusCodes = append(includedStatusCodes, r.Config.IncludedStatusCodes[includedStatusCodesIndex].ValueInt64())
 			}
 		}
 		maxDelayTime := new(float64)

--- a/internal/provider/gatewaypluginmtlsauth_resource.go
+++ b/internal/provider/gatewaypluginmtlsauth_resource.go
@@ -562,7 +562,10 @@ func (r *GatewayPluginMtlsAuthResource) Delete(ctx context.Context, req resource
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginmtlsauth_resource_sdk.go
+++ b/internal/provider/gatewaypluginmtlsauth_resource_sdk.go
@@ -225,8 +225,8 @@ func (r *GatewayPluginMtlsAuthResourceModel) ToSharedMtlsAuthPlugin(ctx context.
 		var after *shared.MtlsAuthPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.MtlsAuthPluginAfter{
 				Access: access,
@@ -235,8 +235,8 @@ func (r *GatewayPluginMtlsAuthResourceModel) ToSharedMtlsAuthPlugin(ctx context.
 		var before *shared.MtlsAuthPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.MtlsAuthPluginBefore{
 				Access: access1,
@@ -250,22 +250,22 @@ func (r *GatewayPluginMtlsAuthResourceModel) ToSharedMtlsAuthPlugin(ctx context.
 	var partials []shared.MtlsAuthPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.MtlsAuthPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -279,8 +279,8 @@ func (r *GatewayPluginMtlsAuthResourceModel) ToSharedMtlsAuthPlugin(ctx context.
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -308,8 +308,8 @@ func (r *GatewayPluginMtlsAuthResourceModel) ToSharedMtlsAuthPlugin(ctx context.
 		authenticatedGroupBy = nil
 	}
 	caCertificates := make([]string, 0, len(r.Config.CaCertificates))
-	for _, caCertificatesItem := range r.Config.CaCertificates {
-		caCertificates = append(caCertificates, caCertificatesItem.ValueString())
+	for caCertificatesIndex := range r.Config.CaCertificates {
+		caCertificates = append(caCertificates, r.Config.CaCertificates[caCertificatesIndex].ValueString())
 	}
 	cacheTTL := new(float64)
 	if !r.Config.CacheTTL.IsUnknown() && !r.Config.CacheTTL.IsNull() {

--- a/internal/provider/gatewaypluginoasvalidation_resource.go
+++ b/internal/provider/gatewaypluginoasvalidation_resource.go
@@ -557,7 +557,10 @@ func (r *GatewayPluginOasValidationResource) Delete(ctx context.Context, req res
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginoasvalidation_resource_sdk.go
+++ b/internal/provider/gatewaypluginoasvalidation_resource_sdk.go
@@ -216,8 +216,8 @@ func (r *GatewayPluginOasValidationResourceModel) ToSharedOasValidationPlugin(ct
 		var after *shared.OasValidationPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.OasValidationPluginAfter{
 				Access: access,
@@ -226,8 +226,8 @@ func (r *GatewayPluginOasValidationResourceModel) ToSharedOasValidationPlugin(ct
 		var before *shared.OasValidationPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.OasValidationPluginBefore{
 				Access: access1,
@@ -241,22 +241,22 @@ func (r *GatewayPluginOasValidationResourceModel) ToSharedOasValidationPlugin(ct
 	var partials []shared.OasValidationPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.OasValidationPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -270,8 +270,8 @@ func (r *GatewayPluginOasValidationResourceModel) ToSharedOasValidationPlugin(ct
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)

--- a/internal/provider/gatewaypluginoauth2introspection_resource.go
+++ b/internal/provider/gatewaypluginoauth2introspection_resource.go
@@ -537,7 +537,10 @@ func (r *GatewayPluginOauth2IntrospectionResource) Delete(ctx context.Context, r
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginoauth2introspection_resource_sdk.go
+++ b/internal/provider/gatewaypluginoauth2introspection_resource_sdk.go
@@ -220,8 +220,8 @@ func (r *GatewayPluginOauth2IntrospectionResourceModel) ToSharedOauth2Introspect
 		var after *shared.Oauth2IntrospectionPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.Oauth2IntrospectionPluginAfter{
 				Access: access,
@@ -230,8 +230,8 @@ func (r *GatewayPluginOauth2IntrospectionResourceModel) ToSharedOauth2Introspect
 		var before *shared.Oauth2IntrospectionPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.Oauth2IntrospectionPluginBefore{
 				Access: access1,
@@ -245,22 +245,22 @@ func (r *GatewayPluginOauth2IntrospectionResourceModel) ToSharedOauth2Introspect
 	var partials []shared.Oauth2IntrospectionPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.Oauth2IntrospectionPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -274,8 +274,8 @@ func (r *GatewayPluginOauth2IntrospectionResourceModel) ToSharedOauth2Introspect
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -300,15 +300,15 @@ func (r *GatewayPluginOauth2IntrospectionResourceModel) ToSharedOauth2Introspect
 		consumerBy = nil
 	}
 	customClaimsForward := make([]string, 0, len(r.Config.CustomClaimsForward))
-	for _, customClaimsForwardItem := range r.Config.CustomClaimsForward {
-		customClaimsForward = append(customClaimsForward, customClaimsForwardItem.ValueString())
+	for customClaimsForwardIndex := range r.Config.CustomClaimsForward {
+		customClaimsForward = append(customClaimsForward, r.Config.CustomClaimsForward[customClaimsForwardIndex].ValueString())
 	}
 	var customIntrospectionHeaders map[string]string
 	if r.Config.CustomIntrospectionHeaders != nil {
 		customIntrospectionHeaders = make(map[string]string)
-		for customIntrospectionHeadersKey, customIntrospectionHeadersValue := range r.Config.CustomIntrospectionHeaders {
+		for customIntrospectionHeadersKey := range r.Config.CustomIntrospectionHeaders {
 			var customIntrospectionHeadersInst string
-			customIntrospectionHeadersInst = customIntrospectionHeadersValue.ValueString()
+			customIntrospectionHeadersInst = r.Config.CustomIntrospectionHeaders[customIntrospectionHeadersKey].ValueString()
 
 			customIntrospectionHeaders[customIntrospectionHeadersKey] = customIntrospectionHeadersInst
 		}

--- a/internal/provider/gatewaypluginopa_resource.go
+++ b/internal/provider/gatewaypluginopa_resource.go
@@ -531,7 +531,10 @@ func (r *GatewayPluginOpaResource) Delete(ctx context.Context, req resource.Dele
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginopa_resource_sdk.go
+++ b/internal/provider/gatewaypluginopa_resource_sdk.go
@@ -210,8 +210,8 @@ func (r *GatewayPluginOpaResourceModel) ToSharedOpaPlugin(ctx context.Context) (
 		var after *shared.OpaPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.OpaPluginAfter{
 				Access: access,
@@ -220,8 +220,8 @@ func (r *GatewayPluginOpaResourceModel) ToSharedOpaPlugin(ctx context.Context) (
 		var before *shared.OpaPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.OpaPluginBefore{
 				Access: access1,
@@ -235,22 +235,22 @@ func (r *GatewayPluginOpaResourceModel) ToSharedOpaPlugin(ctx context.Context) (
 	var partials []shared.OpaPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.OpaPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -264,8 +264,8 @@ func (r *GatewayPluginOpaResourceModel) ToSharedOpaPlugin(ctx context.Context) (
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)

--- a/internal/provider/gatewaypluginopenidconnect_resource.go
+++ b/internal/provider/gatewaypluginopenidconnect_resource.go
@@ -2247,7 +2247,10 @@ func (r *GatewayPluginOpenidConnectResource) Delete(ctx context.Context, req res
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginopenidconnect_resource_sdk.go
+++ b/internal/provider/gatewaypluginopenidconnect_resource_sdk.go
@@ -963,8 +963,8 @@ func (r *GatewayPluginOpenidConnectResourceModel) ToSharedOpenidConnectPlugin(ct
 		var after *shared.OpenidConnectPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.OpenidConnectPluginAfter{
 				Access: access,
@@ -973,8 +973,8 @@ func (r *GatewayPluginOpenidConnectResourceModel) ToSharedOpenidConnectPlugin(ct
 		var before *shared.OpenidConnectPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.OpenidConnectPluginBefore{
 				Access: access1,
@@ -988,22 +988,22 @@ func (r *GatewayPluginOpenidConnectResourceModel) ToSharedOpenidConnectPlugin(ct
 	var partials []shared.OpenidConnectPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.OpenidConnectPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -1017,8 +1017,8 @@ func (r *GatewayPluginOpenidConnectResourceModel) ToSharedOpenidConnectPlugin(ct
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -1036,19 +1036,19 @@ func (r *GatewayPluginOpenidConnectResourceModel) ToSharedOpenidConnectPlugin(ct
 	var audience []string
 	if r.Config.Audience != nil {
 		audience = make([]string, 0, len(r.Config.Audience))
-		for _, audienceItem := range r.Config.Audience {
-			audience = append(audience, audienceItem.ValueString())
+		for audienceIndex := range r.Config.Audience {
+			audience = append(audience, r.Config.Audience[audienceIndex].ValueString())
 		}
 	}
 	audienceClaim := make([]string, 0, len(r.Config.AudienceClaim))
-	for _, audienceClaimItem := range r.Config.AudienceClaim {
-		audienceClaim = append(audienceClaim, audienceClaimItem.ValueString())
+	for audienceClaimIndex := range r.Config.AudienceClaim {
+		audienceClaim = append(audienceClaim, r.Config.AudienceClaim[audienceClaimIndex].ValueString())
 	}
 	var audienceRequired []string
 	if r.Config.AudienceRequired != nil {
 		audienceRequired = make([]string, 0, len(r.Config.AudienceRequired))
-		for _, audienceRequiredItem := range r.Config.AudienceRequired {
-			audienceRequired = append(audienceRequired, audienceRequiredItem.ValueString())
+		for audienceRequiredIndex := range r.Config.AudienceRequired {
+			audienceRequired = append(audienceRequired, r.Config.AudienceRequired[audienceRequiredIndex].ValueString())
 		}
 	}
 	authMethods := make([]shared.AuthMethods, 0, len(r.Config.AuthMethods))
@@ -1058,8 +1058,8 @@ func (r *GatewayPluginOpenidConnectResourceModel) ToSharedOpenidConnectPlugin(ct
 	var authenticatedGroupsClaim []string
 	if r.Config.AuthenticatedGroupsClaim != nil {
 		authenticatedGroupsClaim = make([]string, 0, len(r.Config.AuthenticatedGroupsClaim))
-		for _, authenticatedGroupsClaimItem := range r.Config.AuthenticatedGroupsClaim {
-			authenticatedGroupsClaim = append(authenticatedGroupsClaim, authenticatedGroupsClaimItem.ValueString())
+		for authenticatedGroupsClaimIndex := range r.Config.AuthenticatedGroupsClaim {
+			authenticatedGroupsClaim = append(authenticatedGroupsClaim, r.Config.AuthenticatedGroupsClaim[authenticatedGroupsClaimIndex].ValueString())
 		}
 	}
 	authorizationCookieDomain := new(string)
@@ -1107,22 +1107,22 @@ func (r *GatewayPluginOpenidConnectResourceModel) ToSharedOpenidConnectPlugin(ct
 	var authorizationQueryArgsClient []string
 	if r.Config.AuthorizationQueryArgsClient != nil {
 		authorizationQueryArgsClient = make([]string, 0, len(r.Config.AuthorizationQueryArgsClient))
-		for _, authorizationQueryArgsClientItem := range r.Config.AuthorizationQueryArgsClient {
-			authorizationQueryArgsClient = append(authorizationQueryArgsClient, authorizationQueryArgsClientItem.ValueString())
+		for authorizationQueryArgsClientIndex := range r.Config.AuthorizationQueryArgsClient {
+			authorizationQueryArgsClient = append(authorizationQueryArgsClient, r.Config.AuthorizationQueryArgsClient[authorizationQueryArgsClientIndex].ValueString())
 		}
 	}
 	var authorizationQueryArgsNames []string
 	if r.Config.AuthorizationQueryArgsNames != nil {
 		authorizationQueryArgsNames = make([]string, 0, len(r.Config.AuthorizationQueryArgsNames))
-		for _, authorizationQueryArgsNamesItem := range r.Config.AuthorizationQueryArgsNames {
-			authorizationQueryArgsNames = append(authorizationQueryArgsNames, authorizationQueryArgsNamesItem.ValueString())
+		for authorizationQueryArgsNamesIndex := range r.Config.AuthorizationQueryArgsNames {
+			authorizationQueryArgsNames = append(authorizationQueryArgsNames, r.Config.AuthorizationQueryArgsNames[authorizationQueryArgsNamesIndex].ValueString())
 		}
 	}
 	var authorizationQueryArgsValues []string
 	if r.Config.AuthorizationQueryArgsValues != nil {
 		authorizationQueryArgsValues = make([]string, 0, len(r.Config.AuthorizationQueryArgsValues))
-		for _, authorizationQueryArgsValuesItem := range r.Config.AuthorizationQueryArgsValues {
-			authorizationQueryArgsValues = append(authorizationQueryArgsValues, authorizationQueryArgsValuesItem.ValueString())
+		for authorizationQueryArgsValuesIndex := range r.Config.AuthorizationQueryArgsValues {
+			authorizationQueryArgsValues = append(authorizationQueryArgsValues, r.Config.AuthorizationQueryArgsValues[authorizationQueryArgsValuesIndex].ValueString())
 		}
 	}
 	authorizationRollingTimeout := new(float64)
@@ -1210,8 +1210,8 @@ func (r *GatewayPluginOpenidConnectResourceModel) ToSharedOpenidConnectPlugin(ct
 	var claimsForbidden []string
 	if r.Config.ClaimsForbidden != nil {
 		claimsForbidden = make([]string, 0, len(r.Config.ClaimsForbidden))
-		for _, claimsForbiddenItem := range r.Config.ClaimsForbidden {
-			claimsForbidden = append(claimsForbidden, claimsForbiddenItem.ValueString())
+		for claimsForbiddenIndex := range r.Config.ClaimsForbidden {
+			claimsForbidden = append(claimsForbidden, r.Config.ClaimsForbidden[claimsForbiddenIndex].ValueString())
 		}
 	}
 	var clientAlg []shared.OpenidConnectPluginClientAlg
@@ -1241,163 +1241,163 @@ func (r *GatewayPluginOpenidConnectResourceModel) ToSharedOpenidConnectPlugin(ct
 	var clientID []string
 	if r.Config.ClientID != nil {
 		clientID = make([]string, 0, len(r.Config.ClientID))
-		for _, clientIDItem := range r.Config.ClientID {
-			clientID = append(clientID, clientIDItem.ValueString())
+		for clientIDIndex := range r.Config.ClientID {
+			clientID = append(clientID, r.Config.ClientID[clientIDIndex].ValueString())
 		}
 	}
 	var clientJwk []shared.ClientJwk
 	if r.Config.ClientJwk != nil {
 		clientJwk = make([]shared.ClientJwk, 0, len(r.Config.ClientJwk))
-		for _, clientJwkItem := range r.Config.ClientJwk {
+		for clientJwkIndex := range r.Config.ClientJwk {
 			alg := new(string)
-			if !clientJwkItem.Alg.IsUnknown() && !clientJwkItem.Alg.IsNull() {
-				*alg = clientJwkItem.Alg.ValueString()
+			if !r.Config.ClientJwk[clientJwkIndex].Alg.IsUnknown() && !r.Config.ClientJwk[clientJwkIndex].Alg.IsNull() {
+				*alg = r.Config.ClientJwk[clientJwkIndex].Alg.ValueString()
 			} else {
 				alg = nil
 			}
 			crv := new(string)
-			if !clientJwkItem.Crv.IsUnknown() && !clientJwkItem.Crv.IsNull() {
-				*crv = clientJwkItem.Crv.ValueString()
+			if !r.Config.ClientJwk[clientJwkIndex].Crv.IsUnknown() && !r.Config.ClientJwk[clientJwkIndex].Crv.IsNull() {
+				*crv = r.Config.ClientJwk[clientJwkIndex].Crv.ValueString()
 			} else {
 				crv = nil
 			}
 			d := new(string)
-			if !clientJwkItem.D.IsUnknown() && !clientJwkItem.D.IsNull() {
-				*d = clientJwkItem.D.ValueString()
+			if !r.Config.ClientJwk[clientJwkIndex].D.IsUnknown() && !r.Config.ClientJwk[clientJwkIndex].D.IsNull() {
+				*d = r.Config.ClientJwk[clientJwkIndex].D.ValueString()
 			} else {
 				d = nil
 			}
 			dp := new(string)
-			if !clientJwkItem.Dp.IsUnknown() && !clientJwkItem.Dp.IsNull() {
-				*dp = clientJwkItem.Dp.ValueString()
+			if !r.Config.ClientJwk[clientJwkIndex].Dp.IsUnknown() && !r.Config.ClientJwk[clientJwkIndex].Dp.IsNull() {
+				*dp = r.Config.ClientJwk[clientJwkIndex].Dp.ValueString()
 			} else {
 				dp = nil
 			}
 			dq := new(string)
-			if !clientJwkItem.Dq.IsUnknown() && !clientJwkItem.Dq.IsNull() {
-				*dq = clientJwkItem.Dq.ValueString()
+			if !r.Config.ClientJwk[clientJwkIndex].Dq.IsUnknown() && !r.Config.ClientJwk[clientJwkIndex].Dq.IsNull() {
+				*dq = r.Config.ClientJwk[clientJwkIndex].Dq.ValueString()
 			} else {
 				dq = nil
 			}
 			e := new(string)
-			if !clientJwkItem.E.IsUnknown() && !clientJwkItem.E.IsNull() {
-				*e = clientJwkItem.E.ValueString()
+			if !r.Config.ClientJwk[clientJwkIndex].E.IsUnknown() && !r.Config.ClientJwk[clientJwkIndex].E.IsNull() {
+				*e = r.Config.ClientJwk[clientJwkIndex].E.ValueString()
 			} else {
 				e = nil
 			}
 			issuer := new(string)
-			if !clientJwkItem.Issuer.IsUnknown() && !clientJwkItem.Issuer.IsNull() {
-				*issuer = clientJwkItem.Issuer.ValueString()
+			if !r.Config.ClientJwk[clientJwkIndex].Issuer.IsUnknown() && !r.Config.ClientJwk[clientJwkIndex].Issuer.IsNull() {
+				*issuer = r.Config.ClientJwk[clientJwkIndex].Issuer.ValueString()
 			} else {
 				issuer = nil
 			}
 			k := new(string)
-			if !clientJwkItem.K.IsUnknown() && !clientJwkItem.K.IsNull() {
-				*k = clientJwkItem.K.ValueString()
+			if !r.Config.ClientJwk[clientJwkIndex].K.IsUnknown() && !r.Config.ClientJwk[clientJwkIndex].K.IsNull() {
+				*k = r.Config.ClientJwk[clientJwkIndex].K.ValueString()
 			} else {
 				k = nil
 			}
 			var keyOps []string
-			if clientJwkItem.KeyOps != nil {
-				keyOps = make([]string, 0, len(clientJwkItem.KeyOps))
-				for _, keyOpsItem := range clientJwkItem.KeyOps {
-					keyOps = append(keyOps, keyOpsItem.ValueString())
+			if r.Config.ClientJwk[clientJwkIndex].KeyOps != nil {
+				keyOps = make([]string, 0, len(r.Config.ClientJwk[clientJwkIndex].KeyOps))
+				for keyOpsIndex := range r.Config.ClientJwk[clientJwkIndex].KeyOps {
+					keyOps = append(keyOps, r.Config.ClientJwk[clientJwkIndex].KeyOps[keyOpsIndex].ValueString())
 				}
 			}
 			kid := new(string)
-			if !clientJwkItem.Kid.IsUnknown() && !clientJwkItem.Kid.IsNull() {
-				*kid = clientJwkItem.Kid.ValueString()
+			if !r.Config.ClientJwk[clientJwkIndex].Kid.IsUnknown() && !r.Config.ClientJwk[clientJwkIndex].Kid.IsNull() {
+				*kid = r.Config.ClientJwk[clientJwkIndex].Kid.ValueString()
 			} else {
 				kid = nil
 			}
 			kty := new(string)
-			if !clientJwkItem.Kty.IsUnknown() && !clientJwkItem.Kty.IsNull() {
-				*kty = clientJwkItem.Kty.ValueString()
+			if !r.Config.ClientJwk[clientJwkIndex].Kty.IsUnknown() && !r.Config.ClientJwk[clientJwkIndex].Kty.IsNull() {
+				*kty = r.Config.ClientJwk[clientJwkIndex].Kty.ValueString()
 			} else {
 				kty = nil
 			}
 			n := new(string)
-			if !clientJwkItem.N.IsUnknown() && !clientJwkItem.N.IsNull() {
-				*n = clientJwkItem.N.ValueString()
+			if !r.Config.ClientJwk[clientJwkIndex].N.IsUnknown() && !r.Config.ClientJwk[clientJwkIndex].N.IsNull() {
+				*n = r.Config.ClientJwk[clientJwkIndex].N.ValueString()
 			} else {
 				n = nil
 			}
 			oth := new(string)
-			if !clientJwkItem.Oth.IsUnknown() && !clientJwkItem.Oth.IsNull() {
-				*oth = clientJwkItem.Oth.ValueString()
+			if !r.Config.ClientJwk[clientJwkIndex].Oth.IsUnknown() && !r.Config.ClientJwk[clientJwkIndex].Oth.IsNull() {
+				*oth = r.Config.ClientJwk[clientJwkIndex].Oth.ValueString()
 			} else {
 				oth = nil
 			}
 			p := new(string)
-			if !clientJwkItem.P.IsUnknown() && !clientJwkItem.P.IsNull() {
-				*p = clientJwkItem.P.ValueString()
+			if !r.Config.ClientJwk[clientJwkIndex].P.IsUnknown() && !r.Config.ClientJwk[clientJwkIndex].P.IsNull() {
+				*p = r.Config.ClientJwk[clientJwkIndex].P.ValueString()
 			} else {
 				p = nil
 			}
 			q := new(string)
-			if !clientJwkItem.Q.IsUnknown() && !clientJwkItem.Q.IsNull() {
-				*q = clientJwkItem.Q.ValueString()
+			if !r.Config.ClientJwk[clientJwkIndex].Q.IsUnknown() && !r.Config.ClientJwk[clientJwkIndex].Q.IsNull() {
+				*q = r.Config.ClientJwk[clientJwkIndex].Q.ValueString()
 			} else {
 				q = nil
 			}
 			qi := new(string)
-			if !clientJwkItem.Qi.IsUnknown() && !clientJwkItem.Qi.IsNull() {
-				*qi = clientJwkItem.Qi.ValueString()
+			if !r.Config.ClientJwk[clientJwkIndex].Qi.IsUnknown() && !r.Config.ClientJwk[clientJwkIndex].Qi.IsNull() {
+				*qi = r.Config.ClientJwk[clientJwkIndex].Qi.ValueString()
 			} else {
 				qi = nil
 			}
 			r1 := new(string)
-			if !clientJwkItem.R.IsUnknown() && !clientJwkItem.R.IsNull() {
-				*r1 = clientJwkItem.R.ValueString()
+			if !r.Config.ClientJwk[clientJwkIndex].R.IsUnknown() && !r.Config.ClientJwk[clientJwkIndex].R.IsNull() {
+				*r1 = r.Config.ClientJwk[clientJwkIndex].R.ValueString()
 			} else {
 				r1 = nil
 			}
 			t := new(string)
-			if !clientJwkItem.T.IsUnknown() && !clientJwkItem.T.IsNull() {
-				*t = clientJwkItem.T.ValueString()
+			if !r.Config.ClientJwk[clientJwkIndex].T.IsUnknown() && !r.Config.ClientJwk[clientJwkIndex].T.IsNull() {
+				*t = r.Config.ClientJwk[clientJwkIndex].T.ValueString()
 			} else {
 				t = nil
 			}
 			use := new(string)
-			if !clientJwkItem.Use.IsUnknown() && !clientJwkItem.Use.IsNull() {
-				*use = clientJwkItem.Use.ValueString()
+			if !r.Config.ClientJwk[clientJwkIndex].Use.IsUnknown() && !r.Config.ClientJwk[clientJwkIndex].Use.IsNull() {
+				*use = r.Config.ClientJwk[clientJwkIndex].Use.ValueString()
 			} else {
 				use = nil
 			}
 			x := new(string)
-			if !clientJwkItem.X.IsUnknown() && !clientJwkItem.X.IsNull() {
-				*x = clientJwkItem.X.ValueString()
+			if !r.Config.ClientJwk[clientJwkIndex].X.IsUnknown() && !r.Config.ClientJwk[clientJwkIndex].X.IsNull() {
+				*x = r.Config.ClientJwk[clientJwkIndex].X.ValueString()
 			} else {
 				x = nil
 			}
 			var x5c []string
-			if clientJwkItem.X5c != nil {
-				x5c = make([]string, 0, len(clientJwkItem.X5c))
-				for _, x5cItem := range clientJwkItem.X5c {
-					x5c = append(x5c, x5cItem.ValueString())
+			if r.Config.ClientJwk[clientJwkIndex].X5c != nil {
+				x5c = make([]string, 0, len(r.Config.ClientJwk[clientJwkIndex].X5c))
+				for x5cIndex := range r.Config.ClientJwk[clientJwkIndex].X5c {
+					x5c = append(x5c, r.Config.ClientJwk[clientJwkIndex].X5c[x5cIndex].ValueString())
 				}
 			}
 			x5t := new(string)
-			if !clientJwkItem.X5t.IsUnknown() && !clientJwkItem.X5t.IsNull() {
-				*x5t = clientJwkItem.X5t.ValueString()
+			if !r.Config.ClientJwk[clientJwkIndex].X5t.IsUnknown() && !r.Config.ClientJwk[clientJwkIndex].X5t.IsNull() {
+				*x5t = r.Config.ClientJwk[clientJwkIndex].X5t.ValueString()
 			} else {
 				x5t = nil
 			}
 			x5tNumberS256 := new(string)
-			if !clientJwkItem.X5tNumberS256.IsUnknown() && !clientJwkItem.X5tNumberS256.IsNull() {
-				*x5tNumberS256 = clientJwkItem.X5tNumberS256.ValueString()
+			if !r.Config.ClientJwk[clientJwkIndex].X5tNumberS256.IsUnknown() && !r.Config.ClientJwk[clientJwkIndex].X5tNumberS256.IsNull() {
+				*x5tNumberS256 = r.Config.ClientJwk[clientJwkIndex].X5tNumberS256.ValueString()
 			} else {
 				x5tNumberS256 = nil
 			}
 			x5u := new(string)
-			if !clientJwkItem.X5u.IsUnknown() && !clientJwkItem.X5u.IsNull() {
-				*x5u = clientJwkItem.X5u.ValueString()
+			if !r.Config.ClientJwk[clientJwkIndex].X5u.IsUnknown() && !r.Config.ClientJwk[clientJwkIndex].X5u.IsNull() {
+				*x5u = r.Config.ClientJwk[clientJwkIndex].X5u.ValueString()
 			} else {
 				x5u = nil
 			}
 			y := new(string)
-			if !clientJwkItem.Y.IsUnknown() && !clientJwkItem.Y.IsNull() {
-				*y = clientJwkItem.Y.ValueString()
+			if !r.Config.ClientJwk[clientJwkIndex].Y.IsUnknown() && !r.Config.ClientJwk[clientJwkIndex].Y.IsNull() {
+				*y = r.Config.ClientJwk[clientJwkIndex].Y.ValueString()
 			} else {
 				y = nil
 			}
@@ -1433,8 +1433,8 @@ func (r *GatewayPluginOpenidConnectResourceModel) ToSharedOpenidConnectPlugin(ct
 	var clientSecret []string
 	if r.Config.ClientSecret != nil {
 		clientSecret = make([]string, 0, len(r.Config.ClientSecret))
-		for _, clientSecretItem := range r.Config.ClientSecret {
-			clientSecret = append(clientSecret, clientSecretItem.ValueString())
+		for clientSecretIndex := range r.Config.ClientSecret {
+			clientSecret = append(clientSecret, r.Config.ClientSecret[clientSecretIndex].ValueString())
 		}
 	}
 	var clusterCacheRedis *shared.ClusterCacheRedis
@@ -1448,16 +1448,16 @@ func (r *GatewayPluginOpenidConnectResourceModel) ToSharedOpenidConnectPlugin(ct
 		var clusterNodes []shared.OpenidConnectPluginClusterNodes
 		if r.Config.ClusterCacheRedis.ClusterNodes != nil {
 			clusterNodes = make([]shared.OpenidConnectPluginClusterNodes, 0, len(r.Config.ClusterCacheRedis.ClusterNodes))
-			for _, clusterNodesItem := range r.Config.ClusterCacheRedis.ClusterNodes {
+			for clusterNodesIndex := range r.Config.ClusterCacheRedis.ClusterNodes {
 				ip := new(string)
-				if !clusterNodesItem.IP.IsUnknown() && !clusterNodesItem.IP.IsNull() {
-					*ip = clusterNodesItem.IP.ValueString()
+				if !r.Config.ClusterCacheRedis.ClusterNodes[clusterNodesIndex].IP.IsUnknown() && !r.Config.ClusterCacheRedis.ClusterNodes[clusterNodesIndex].IP.IsNull() {
+					*ip = r.Config.ClusterCacheRedis.ClusterNodes[clusterNodesIndex].IP.ValueString()
 				} else {
 					ip = nil
 				}
 				port := new(int64)
-				if !clusterNodesItem.Port.IsUnknown() && !clusterNodesItem.Port.IsNull() {
-					*port = clusterNodesItem.Port.ValueInt64()
+				if !r.Config.ClusterCacheRedis.ClusterNodes[clusterNodesIndex].Port.IsUnknown() && !r.Config.ClusterCacheRedis.ClusterNodes[clusterNodesIndex].Port.IsNull() {
+					*port = r.Config.ClusterCacheRedis.ClusterNodes[clusterNodesIndex].Port.ValueInt64()
 				} else {
 					port = nil
 				}
@@ -1536,16 +1536,16 @@ func (r *GatewayPluginOpenidConnectResourceModel) ToSharedOpenidConnectPlugin(ct
 		var sentinelNodes []shared.OpenidConnectPluginSentinelNodes
 		if r.Config.ClusterCacheRedis.SentinelNodes != nil {
 			sentinelNodes = make([]shared.OpenidConnectPluginSentinelNodes, 0, len(r.Config.ClusterCacheRedis.SentinelNodes))
-			for _, sentinelNodesItem := range r.Config.ClusterCacheRedis.SentinelNodes {
+			for sentinelNodesIndex := range r.Config.ClusterCacheRedis.SentinelNodes {
 				host1 := new(string)
-				if !sentinelNodesItem.Host.IsUnknown() && !sentinelNodesItem.Host.IsNull() {
-					*host1 = sentinelNodesItem.Host.ValueString()
+				if !r.Config.ClusterCacheRedis.SentinelNodes[sentinelNodesIndex].Host.IsUnknown() && !r.Config.ClusterCacheRedis.SentinelNodes[sentinelNodesIndex].Host.IsNull() {
+					*host1 = r.Config.ClusterCacheRedis.SentinelNodes[sentinelNodesIndex].Host.ValueString()
 				} else {
 					host1 = nil
 				}
 				port2 := new(int64)
-				if !sentinelNodesItem.Port.IsUnknown() && !sentinelNodesItem.Port.IsNull() {
-					*port2 = sentinelNodesItem.Port.ValueInt64()
+				if !r.Config.ClusterCacheRedis.SentinelNodes[sentinelNodesIndex].Port.IsUnknown() && !r.Config.ClusterCacheRedis.SentinelNodes[sentinelNodesIndex].Port.IsNull() {
+					*port2 = r.Config.ClusterCacheRedis.SentinelNodes[sentinelNodesIndex].Port.ValueInt64()
 				} else {
 					port2 = nil
 				}
@@ -1634,15 +1634,15 @@ func (r *GatewayPluginOpenidConnectResourceModel) ToSharedOpenidConnectPlugin(ct
 	var consumerClaim []string
 	if r.Config.ConsumerClaim != nil {
 		consumerClaim = make([]string, 0, len(r.Config.ConsumerClaim))
-		for _, consumerClaimItem := range r.Config.ConsumerClaim {
-			consumerClaim = append(consumerClaim, consumerClaimItem.ValueString())
+		for consumerClaimIndex := range r.Config.ConsumerClaim {
+			consumerClaim = append(consumerClaim, r.Config.ConsumerClaim[consumerClaimIndex].ValueString())
 		}
 	}
 	var consumerGroupsClaim []string
 	if r.Config.ConsumerGroupsClaim != nil {
 		consumerGroupsClaim = make([]string, 0, len(r.Config.ConsumerGroupsClaim))
-		for _, consumerGroupsClaimItem := range r.Config.ConsumerGroupsClaim {
-			consumerGroupsClaim = append(consumerGroupsClaim, consumerGroupsClaimItem.ValueString())
+		for consumerGroupsClaimIndex := range r.Config.ConsumerGroupsClaim {
+			consumerGroupsClaim = append(consumerGroupsClaim, r.Config.ConsumerGroupsClaim[consumerGroupsClaimIndex].ValueString())
 		}
 	}
 	consumerGroupsOptional := new(bool)
@@ -1658,8 +1658,8 @@ func (r *GatewayPluginOpenidConnectResourceModel) ToSharedOpenidConnectPlugin(ct
 		consumerOptional = nil
 	}
 	credentialClaim := make([]string, 0, len(r.Config.CredentialClaim))
-	for _, credentialClaimItem := range r.Config.CredentialClaim {
-		credentialClaim = append(credentialClaim, credentialClaimItem.ValueString())
+	for credentialClaimIndex := range r.Config.CredentialClaim {
+		credentialClaim = append(credentialClaim, r.Config.CredentialClaim[credentialClaimIndex].ValueString())
 	}
 	var disableSession []shared.DisableSession
 	if r.Config.DisableSession != nil {
@@ -1671,15 +1671,15 @@ func (r *GatewayPluginOpenidConnectResourceModel) ToSharedOpenidConnectPlugin(ct
 	var discoveryHeadersNames []string
 	if r.Config.DiscoveryHeadersNames != nil {
 		discoveryHeadersNames = make([]string, 0, len(r.Config.DiscoveryHeadersNames))
-		for _, discoveryHeadersNamesItem := range r.Config.DiscoveryHeadersNames {
-			discoveryHeadersNames = append(discoveryHeadersNames, discoveryHeadersNamesItem.ValueString())
+		for discoveryHeadersNamesIndex := range r.Config.DiscoveryHeadersNames {
+			discoveryHeadersNames = append(discoveryHeadersNames, r.Config.DiscoveryHeadersNames[discoveryHeadersNamesIndex].ValueString())
 		}
 	}
 	var discoveryHeadersValues []string
 	if r.Config.DiscoveryHeadersValues != nil {
 		discoveryHeadersValues = make([]string, 0, len(r.Config.DiscoveryHeadersValues))
-		for _, discoveryHeadersValuesItem := range r.Config.DiscoveryHeadersValues {
-			discoveryHeadersValues = append(discoveryHeadersValues, discoveryHeadersValuesItem.ValueString())
+		for discoveryHeadersValuesIndex := range r.Config.DiscoveryHeadersValues {
+			discoveryHeadersValues = append(discoveryHeadersValues, r.Config.DiscoveryHeadersValues[discoveryHeadersValuesIndex].ValueString())
 		}
 	}
 	displayErrors := new(bool)
@@ -1691,8 +1691,8 @@ func (r *GatewayPluginOpenidConnectResourceModel) ToSharedOpenidConnectPlugin(ct
 	var domains []string
 	if r.Config.Domains != nil {
 		domains = make([]string, 0, len(r.Config.Domains))
-		for _, domainsItem := range r.Config.Domains {
-			domains = append(domains, domainsItem.ValueString())
+		for domainsIndex := range r.Config.Domains {
+			domains = append(domains, r.Config.Domains[domainsIndex].ValueString())
 		}
 	}
 	downstreamAccessTokenHeader := new(string)
@@ -1710,15 +1710,15 @@ func (r *GatewayPluginOpenidConnectResourceModel) ToSharedOpenidConnectPlugin(ct
 	var downstreamHeadersClaims []string
 	if r.Config.DownstreamHeadersClaims != nil {
 		downstreamHeadersClaims = make([]string, 0, len(r.Config.DownstreamHeadersClaims))
-		for _, downstreamHeadersClaimsItem := range r.Config.DownstreamHeadersClaims {
-			downstreamHeadersClaims = append(downstreamHeadersClaims, downstreamHeadersClaimsItem.ValueString())
+		for downstreamHeadersClaimsIndex := range r.Config.DownstreamHeadersClaims {
+			downstreamHeadersClaims = append(downstreamHeadersClaims, r.Config.DownstreamHeadersClaims[downstreamHeadersClaimsIndex].ValueString())
 		}
 	}
 	var downstreamHeadersNames []string
 	if r.Config.DownstreamHeadersNames != nil {
 		downstreamHeadersNames = make([]string, 0, len(r.Config.DownstreamHeadersNames))
-		for _, downstreamHeadersNamesItem := range r.Config.DownstreamHeadersNames {
-			downstreamHeadersNames = append(downstreamHeadersNames, downstreamHeadersNamesItem.ValueString())
+		for downstreamHeadersNamesIndex := range r.Config.DownstreamHeadersNames {
+			downstreamHeadersNames = append(downstreamHeadersNames, r.Config.DownstreamHeadersNames[downstreamHeadersNamesIndex].ValueString())
 		}
 	}
 	downstreamIDTokenHeader := new(string)
@@ -1802,8 +1802,8 @@ func (r *GatewayPluginOpenidConnectResourceModel) ToSharedOpenidConnectPlugin(ct
 	var extraJwksUris []string
 	if r.Config.ExtraJwksUris != nil {
 		extraJwksUris = make([]string, 0, len(r.Config.ExtraJwksUris))
-		for _, extraJwksUrisItem := range r.Config.ExtraJwksUris {
-			extraJwksUris = append(extraJwksUris, extraJwksUrisItem.ValueString())
+		for extraJwksUrisIndex := range r.Config.ExtraJwksUris {
+			extraJwksUris = append(extraJwksUris, r.Config.ExtraJwksUris[extraJwksUrisIndex].ValueString())
 		}
 	}
 	forbiddenDestroySession := new(bool)
@@ -1821,19 +1821,19 @@ func (r *GatewayPluginOpenidConnectResourceModel) ToSharedOpenidConnectPlugin(ct
 	var forbiddenRedirectURI []string
 	if r.Config.ForbiddenRedirectURI != nil {
 		forbiddenRedirectURI = make([]string, 0, len(r.Config.ForbiddenRedirectURI))
-		for _, forbiddenRedirectURIItem := range r.Config.ForbiddenRedirectURI {
-			forbiddenRedirectURI = append(forbiddenRedirectURI, forbiddenRedirectURIItem.ValueString())
+		for forbiddenRedirectURIIndex := range r.Config.ForbiddenRedirectURI {
+			forbiddenRedirectURI = append(forbiddenRedirectURI, r.Config.ForbiddenRedirectURI[forbiddenRedirectURIIndex].ValueString())
 		}
 	}
 	groupsClaim := make([]string, 0, len(r.Config.GroupsClaim))
-	for _, groupsClaimItem := range r.Config.GroupsClaim {
-		groupsClaim = append(groupsClaim, groupsClaimItem.ValueString())
+	for groupsClaimIndex := range r.Config.GroupsClaim {
+		groupsClaim = append(groupsClaim, r.Config.GroupsClaim[groupsClaimIndex].ValueString())
 	}
 	var groupsRequired []string
 	if r.Config.GroupsRequired != nil {
 		groupsRequired = make([]string, 0, len(r.Config.GroupsRequired))
-		for _, groupsRequiredItem := range r.Config.GroupsRequired {
-			groupsRequired = append(groupsRequired, groupsRequiredItem.ValueString())
+		for groupsRequiredIndex := range r.Config.GroupsRequired {
+			groupsRequired = append(groupsRequired, r.Config.GroupsRequired[groupsRequiredIndex].ValueString())
 		}
 	}
 	hideCredentials := new(bool)
@@ -1919,22 +1919,22 @@ func (r *GatewayPluginOpenidConnectResourceModel) ToSharedOpenidConnectPlugin(ct
 	var introspectionHeadersClient []string
 	if r.Config.IntrospectionHeadersClient != nil {
 		introspectionHeadersClient = make([]string, 0, len(r.Config.IntrospectionHeadersClient))
-		for _, introspectionHeadersClientItem := range r.Config.IntrospectionHeadersClient {
-			introspectionHeadersClient = append(introspectionHeadersClient, introspectionHeadersClientItem.ValueString())
+		for introspectionHeadersClientIndex := range r.Config.IntrospectionHeadersClient {
+			introspectionHeadersClient = append(introspectionHeadersClient, r.Config.IntrospectionHeadersClient[introspectionHeadersClientIndex].ValueString())
 		}
 	}
 	var introspectionHeadersNames []string
 	if r.Config.IntrospectionHeadersNames != nil {
 		introspectionHeadersNames = make([]string, 0, len(r.Config.IntrospectionHeadersNames))
-		for _, introspectionHeadersNamesItem := range r.Config.IntrospectionHeadersNames {
-			introspectionHeadersNames = append(introspectionHeadersNames, introspectionHeadersNamesItem.ValueString())
+		for introspectionHeadersNamesIndex := range r.Config.IntrospectionHeadersNames {
+			introspectionHeadersNames = append(introspectionHeadersNames, r.Config.IntrospectionHeadersNames[introspectionHeadersNamesIndex].ValueString())
 		}
 	}
 	var introspectionHeadersValues []string
 	if r.Config.IntrospectionHeadersValues != nil {
 		introspectionHeadersValues = make([]string, 0, len(r.Config.IntrospectionHeadersValues))
-		for _, introspectionHeadersValuesItem := range r.Config.IntrospectionHeadersValues {
-			introspectionHeadersValues = append(introspectionHeadersValues, introspectionHeadersValuesItem.ValueString())
+		for introspectionHeadersValuesIndex := range r.Config.IntrospectionHeadersValues {
+			introspectionHeadersValues = append(introspectionHeadersValues, r.Config.IntrospectionHeadersValues[introspectionHeadersValuesIndex].ValueString())
 		}
 	}
 	introspectionHint := new(string)
@@ -1946,29 +1946,29 @@ func (r *GatewayPluginOpenidConnectResourceModel) ToSharedOpenidConnectPlugin(ct
 	var introspectionPostArgsClient []string
 	if r.Config.IntrospectionPostArgsClient != nil {
 		introspectionPostArgsClient = make([]string, 0, len(r.Config.IntrospectionPostArgsClient))
-		for _, introspectionPostArgsClientItem := range r.Config.IntrospectionPostArgsClient {
-			introspectionPostArgsClient = append(introspectionPostArgsClient, introspectionPostArgsClientItem.ValueString())
+		for introspectionPostArgsClientIndex := range r.Config.IntrospectionPostArgsClient {
+			introspectionPostArgsClient = append(introspectionPostArgsClient, r.Config.IntrospectionPostArgsClient[introspectionPostArgsClientIndex].ValueString())
 		}
 	}
 	var introspectionPostArgsClientHeaders []string
 	if r.Config.IntrospectionPostArgsClientHeaders != nil {
 		introspectionPostArgsClientHeaders = make([]string, 0, len(r.Config.IntrospectionPostArgsClientHeaders))
-		for _, introspectionPostArgsClientHeadersItem := range r.Config.IntrospectionPostArgsClientHeaders {
-			introspectionPostArgsClientHeaders = append(introspectionPostArgsClientHeaders, introspectionPostArgsClientHeadersItem.ValueString())
+		for introspectionPostArgsClientHeadersIndex := range r.Config.IntrospectionPostArgsClientHeaders {
+			introspectionPostArgsClientHeaders = append(introspectionPostArgsClientHeaders, r.Config.IntrospectionPostArgsClientHeaders[introspectionPostArgsClientHeadersIndex].ValueString())
 		}
 	}
 	var introspectionPostArgsNames []string
 	if r.Config.IntrospectionPostArgsNames != nil {
 		introspectionPostArgsNames = make([]string, 0, len(r.Config.IntrospectionPostArgsNames))
-		for _, introspectionPostArgsNamesItem := range r.Config.IntrospectionPostArgsNames {
-			introspectionPostArgsNames = append(introspectionPostArgsNames, introspectionPostArgsNamesItem.ValueString())
+		for introspectionPostArgsNamesIndex := range r.Config.IntrospectionPostArgsNames {
+			introspectionPostArgsNames = append(introspectionPostArgsNames, r.Config.IntrospectionPostArgsNames[introspectionPostArgsNamesIndex].ValueString())
 		}
 	}
 	var introspectionPostArgsValues []string
 	if r.Config.IntrospectionPostArgsValues != nil {
 		introspectionPostArgsValues = make([]string, 0, len(r.Config.IntrospectionPostArgsValues))
-		for _, introspectionPostArgsValuesItem := range r.Config.IntrospectionPostArgsValues {
-			introspectionPostArgsValues = append(introspectionPostArgsValues, introspectionPostArgsValuesItem.ValueString())
+		for introspectionPostArgsValuesIndex := range r.Config.IntrospectionPostArgsValues {
+			introspectionPostArgsValues = append(introspectionPostArgsValues, r.Config.IntrospectionPostArgsValues[introspectionPostArgsValuesIndex].ValueString())
 		}
 	}
 	introspectionTokenParamName := new(string)
@@ -1983,8 +1983,8 @@ func (r *GatewayPluginOpenidConnectResourceModel) ToSharedOpenidConnectPlugin(ct
 	var issuersAllowed []string
 	if r.Config.IssuersAllowed != nil {
 		issuersAllowed = make([]string, 0, len(r.Config.IssuersAllowed))
-		for _, issuersAllowedItem := range r.Config.IssuersAllowed {
-			issuersAllowed = append(issuersAllowed, issuersAllowedItem.ValueString())
+		for issuersAllowedIndex := range r.Config.IssuersAllowed {
+			issuersAllowed = append(issuersAllowed, r.Config.IssuersAllowed[issuersAllowedIndex].ValueString())
 		}
 	}
 	jwtSessionClaim := new(string)
@@ -2030,8 +2030,8 @@ func (r *GatewayPluginOpenidConnectResourceModel) ToSharedOpenidConnectPlugin(ct
 	var loginRedirectURI []string
 	if r.Config.LoginRedirectURI != nil {
 		loginRedirectURI = make([]string, 0, len(r.Config.LoginRedirectURI))
-		for _, loginRedirectURIItem := range r.Config.LoginRedirectURI {
-			loginRedirectURI = append(loginRedirectURI, loginRedirectURIItem.ValueString())
+		for loginRedirectURIIndex := range r.Config.LoginRedirectURI {
+			loginRedirectURI = append(loginRedirectURI, r.Config.LoginRedirectURI[loginRedirectURIIndex].ValueString())
 		}
 	}
 	loginTokens := make([]shared.LoginTokens, 0, len(r.Config.LoginTokens))
@@ -2057,8 +2057,8 @@ func (r *GatewayPluginOpenidConnectResourceModel) ToSharedOpenidConnectPlugin(ct
 	var logoutRedirectURI []string
 	if r.Config.LogoutRedirectURI != nil {
 		logoutRedirectURI = make([]string, 0, len(r.Config.LogoutRedirectURI))
-		for _, logoutRedirectURIItem := range r.Config.LogoutRedirectURI {
-			logoutRedirectURI = append(logoutRedirectURI, logoutRedirectURIItem.ValueString())
+		for logoutRedirectURIIndex := range r.Config.LogoutRedirectURI {
+			logoutRedirectURI = append(logoutRedirectURI, r.Config.LogoutRedirectURI[logoutRedirectURIIndex].ValueString())
 		}
 	}
 	logoutRevoke := new(bool)
@@ -2158,8 +2158,8 @@ func (r *GatewayPluginOpenidConnectResourceModel) ToSharedOpenidConnectPlugin(ct
 	var redirectURI []string
 	if r.Config.RedirectURI != nil {
 		redirectURI = make([]string, 0, len(r.Config.RedirectURI))
-		for _, redirectURIItem := range r.Config.RedirectURI {
-			redirectURI = append(redirectURI, redirectURIItem.ValueString())
+		for redirectURIIndex := range r.Config.RedirectURI {
+			redirectURI = append(redirectURI, r.Config.RedirectURI[redirectURIIndex].ValueString())
 		}
 	}
 	var redis *shared.OpenidConnectPluginRedis
@@ -2173,16 +2173,16 @@ func (r *GatewayPluginOpenidConnectResourceModel) ToSharedOpenidConnectPlugin(ct
 		var clusterNodes1 []shared.OpenidConnectPluginConfigClusterNodes
 		if r.Config.Redis.ClusterNodes != nil {
 			clusterNodes1 = make([]shared.OpenidConnectPluginConfigClusterNodes, 0, len(r.Config.Redis.ClusterNodes))
-			for _, clusterNodesItem1 := range r.Config.Redis.ClusterNodes {
+			for clusterNodesIndex1 := range r.Config.Redis.ClusterNodes {
 				ip1 := new(string)
-				if !clusterNodesItem1.IP.IsUnknown() && !clusterNodesItem1.IP.IsNull() {
-					*ip1 = clusterNodesItem1.IP.ValueString()
+				if !r.Config.Redis.ClusterNodes[clusterNodesIndex1].IP.IsUnknown() && !r.Config.Redis.ClusterNodes[clusterNodesIndex1].IP.IsNull() {
+					*ip1 = r.Config.Redis.ClusterNodes[clusterNodesIndex1].IP.ValueString()
 				} else {
 					ip1 = nil
 				}
 				port3 := new(int64)
-				if !clusterNodesItem1.Port.IsUnknown() && !clusterNodesItem1.Port.IsNull() {
-					*port3 = clusterNodesItem1.Port.ValueInt64()
+				if !r.Config.Redis.ClusterNodes[clusterNodesIndex1].Port.IsUnknown() && !r.Config.Redis.ClusterNodes[clusterNodesIndex1].Port.IsNull() {
+					*port3 = r.Config.Redis.ClusterNodes[clusterNodesIndex1].Port.ValueInt64()
 				} else {
 					port3 = nil
 				}
@@ -2267,16 +2267,16 @@ func (r *GatewayPluginOpenidConnectResourceModel) ToSharedOpenidConnectPlugin(ct
 		var sentinelNodes1 []shared.OpenidConnectPluginConfigSentinelNodes
 		if r.Config.Redis.SentinelNodes != nil {
 			sentinelNodes1 = make([]shared.OpenidConnectPluginConfigSentinelNodes, 0, len(r.Config.Redis.SentinelNodes))
-			for _, sentinelNodesItem1 := range r.Config.Redis.SentinelNodes {
+			for sentinelNodesIndex1 := range r.Config.Redis.SentinelNodes {
 				host3 := new(string)
-				if !sentinelNodesItem1.Host.IsUnknown() && !sentinelNodesItem1.Host.IsNull() {
-					*host3 = sentinelNodesItem1.Host.ValueString()
+				if !r.Config.Redis.SentinelNodes[sentinelNodesIndex1].Host.IsUnknown() && !r.Config.Redis.SentinelNodes[sentinelNodesIndex1].Host.IsNull() {
+					*host3 = r.Config.Redis.SentinelNodes[sentinelNodesIndex1].Host.ValueString()
 				} else {
 					host3 = nil
 				}
 				port5 := new(int64)
-				if !sentinelNodesItem1.Port.IsUnknown() && !sentinelNodesItem1.Port.IsNull() {
-					*port5 = sentinelNodesItem1.Port.ValueInt64()
+				if !r.Config.Redis.SentinelNodes[sentinelNodesIndex1].Port.IsUnknown() && !r.Config.Redis.SentinelNodes[sentinelNodesIndex1].Port.IsNull() {
+					*port5 = r.Config.Redis.SentinelNodes[sentinelNodesIndex1].Port.ValueInt64()
 				} else {
 					port5 = nil
 				}
@@ -2413,8 +2413,8 @@ func (r *GatewayPluginOpenidConnectResourceModel) ToSharedOpenidConnectPlugin(ct
 		responseMode = nil
 	}
 	responseType := make([]string, 0, len(r.Config.ResponseType))
-	for _, responseTypeItem := range r.Config.ResponseType {
-		responseType = append(responseType, responseTypeItem.ValueString())
+	for responseTypeIndex := range r.Config.ResponseType {
+		responseType = append(responseType, r.Config.ResponseType[responseTypeIndex].ValueString())
 	}
 	reverify := new(bool)
 	if !r.Config.Reverify.IsUnknown() && !r.Config.Reverify.IsNull() {
@@ -2441,14 +2441,14 @@ func (r *GatewayPluginOpenidConnectResourceModel) ToSharedOpenidConnectPlugin(ct
 		revocationTokenParamName = nil
 	}
 	rolesClaim := make([]string, 0, len(r.Config.RolesClaim))
-	for _, rolesClaimItem := range r.Config.RolesClaim {
-		rolesClaim = append(rolesClaim, rolesClaimItem.ValueString())
+	for rolesClaimIndex := range r.Config.RolesClaim {
+		rolesClaim = append(rolesClaim, r.Config.RolesClaim[rolesClaimIndex].ValueString())
 	}
 	var rolesRequired []string
 	if r.Config.RolesRequired != nil {
 		rolesRequired = make([]string, 0, len(r.Config.RolesRequired))
-		for _, rolesRequiredItem := range r.Config.RolesRequired {
-			rolesRequired = append(rolesRequired, rolesRequiredItem.ValueString())
+		for rolesRequiredIndex := range r.Config.RolesRequired {
+			rolesRequired = append(rolesRequired, r.Config.RolesRequired[rolesRequiredIndex].ValueString())
 		}
 	}
 	runOnPreflight := new(bool)
@@ -2460,19 +2460,19 @@ func (r *GatewayPluginOpenidConnectResourceModel) ToSharedOpenidConnectPlugin(ct
 	var scopes []string
 	if r.Config.Scopes != nil {
 		scopes = make([]string, 0, len(r.Config.Scopes))
-		for _, scopesItem := range r.Config.Scopes {
-			scopes = append(scopes, scopesItem.ValueString())
+		for scopesIndex := range r.Config.Scopes {
+			scopes = append(scopes, r.Config.Scopes[scopesIndex].ValueString())
 		}
 	}
 	scopesClaim := make([]string, 0, len(r.Config.ScopesClaim))
-	for _, scopesClaimItem := range r.Config.ScopesClaim {
-		scopesClaim = append(scopesClaim, scopesClaimItem.ValueString())
+	for scopesClaimIndex := range r.Config.ScopesClaim {
+		scopesClaim = append(scopesClaim, r.Config.ScopesClaim[scopesClaimIndex].ValueString())
 	}
 	var scopesRequired []string
 	if r.Config.ScopesRequired != nil {
 		scopesRequired = make([]string, 0, len(r.Config.ScopesRequired))
-		for _, scopesRequiredItem := range r.Config.ScopesRequired {
-			scopesRequired = append(scopesRequired, scopesRequiredItem.ValueString())
+		for scopesRequiredIndex := range r.Config.ScopesRequired {
+			scopesRequired = append(scopesRequired, r.Config.ScopesRequired[scopesRequiredIndex].ValueString())
 		}
 	}
 	searchUserInfo := new(bool)
@@ -2697,8 +2697,8 @@ func (r *GatewayPluginOpenidConnectResourceModel) ToSharedOpenidConnectPlugin(ct
 	var tokenHeadersClient []string
 	if r.Config.TokenHeadersClient != nil {
 		tokenHeadersClient = make([]string, 0, len(r.Config.TokenHeadersClient))
-		for _, tokenHeadersClientItem := range r.Config.TokenHeadersClient {
-			tokenHeadersClient = append(tokenHeadersClient, tokenHeadersClientItem.ValueString())
+		for tokenHeadersClientIndex := range r.Config.TokenHeadersClient {
+			tokenHeadersClient = append(tokenHeadersClient, r.Config.TokenHeadersClient[tokenHeadersClientIndex].ValueString())
 		}
 	}
 	var tokenHeadersGrants []shared.TokenHeadersGrants
@@ -2711,8 +2711,8 @@ func (r *GatewayPluginOpenidConnectResourceModel) ToSharedOpenidConnectPlugin(ct
 	var tokenHeadersNames []string
 	if r.Config.TokenHeadersNames != nil {
 		tokenHeadersNames = make([]string, 0, len(r.Config.TokenHeadersNames))
-		for _, tokenHeadersNamesItem := range r.Config.TokenHeadersNames {
-			tokenHeadersNames = append(tokenHeadersNames, tokenHeadersNamesItem.ValueString())
+		for tokenHeadersNamesIndex := range r.Config.TokenHeadersNames {
+			tokenHeadersNames = append(tokenHeadersNames, r.Config.TokenHeadersNames[tokenHeadersNamesIndex].ValueString())
 		}
 	}
 	tokenHeadersPrefix := new(string)
@@ -2724,36 +2724,36 @@ func (r *GatewayPluginOpenidConnectResourceModel) ToSharedOpenidConnectPlugin(ct
 	var tokenHeadersReplay []string
 	if r.Config.TokenHeadersReplay != nil {
 		tokenHeadersReplay = make([]string, 0, len(r.Config.TokenHeadersReplay))
-		for _, tokenHeadersReplayItem := range r.Config.TokenHeadersReplay {
-			tokenHeadersReplay = append(tokenHeadersReplay, tokenHeadersReplayItem.ValueString())
+		for tokenHeadersReplayIndex := range r.Config.TokenHeadersReplay {
+			tokenHeadersReplay = append(tokenHeadersReplay, r.Config.TokenHeadersReplay[tokenHeadersReplayIndex].ValueString())
 		}
 	}
 	var tokenHeadersValues []string
 	if r.Config.TokenHeadersValues != nil {
 		tokenHeadersValues = make([]string, 0, len(r.Config.TokenHeadersValues))
-		for _, tokenHeadersValuesItem := range r.Config.TokenHeadersValues {
-			tokenHeadersValues = append(tokenHeadersValues, tokenHeadersValuesItem.ValueString())
+		for tokenHeadersValuesIndex := range r.Config.TokenHeadersValues {
+			tokenHeadersValues = append(tokenHeadersValues, r.Config.TokenHeadersValues[tokenHeadersValuesIndex].ValueString())
 		}
 	}
 	var tokenPostArgsClient []string
 	if r.Config.TokenPostArgsClient != nil {
 		tokenPostArgsClient = make([]string, 0, len(r.Config.TokenPostArgsClient))
-		for _, tokenPostArgsClientItem := range r.Config.TokenPostArgsClient {
-			tokenPostArgsClient = append(tokenPostArgsClient, tokenPostArgsClientItem.ValueString())
+		for tokenPostArgsClientIndex := range r.Config.TokenPostArgsClient {
+			tokenPostArgsClient = append(tokenPostArgsClient, r.Config.TokenPostArgsClient[tokenPostArgsClientIndex].ValueString())
 		}
 	}
 	var tokenPostArgsNames []string
 	if r.Config.TokenPostArgsNames != nil {
 		tokenPostArgsNames = make([]string, 0, len(r.Config.TokenPostArgsNames))
-		for _, tokenPostArgsNamesItem := range r.Config.TokenPostArgsNames {
-			tokenPostArgsNames = append(tokenPostArgsNames, tokenPostArgsNamesItem.ValueString())
+		for tokenPostArgsNamesIndex := range r.Config.TokenPostArgsNames {
+			tokenPostArgsNames = append(tokenPostArgsNames, r.Config.TokenPostArgsNames[tokenPostArgsNamesIndex].ValueString())
 		}
 	}
 	var tokenPostArgsValues []string
 	if r.Config.TokenPostArgsValues != nil {
 		tokenPostArgsValues = make([]string, 0, len(r.Config.TokenPostArgsValues))
-		for _, tokenPostArgsValuesItem := range r.Config.TokenPostArgsValues {
-			tokenPostArgsValues = append(tokenPostArgsValues, tokenPostArgsValuesItem.ValueString())
+		for tokenPostArgsValuesIndex := range r.Config.TokenPostArgsValues {
+			tokenPostArgsValues = append(tokenPostArgsValues, r.Config.TokenPostArgsValues[tokenPostArgsValuesIndex].ValueString())
 		}
 	}
 	unauthorizedDestroySession := new(bool)
@@ -2771,15 +2771,15 @@ func (r *GatewayPluginOpenidConnectResourceModel) ToSharedOpenidConnectPlugin(ct
 	var unauthorizedRedirectURI []string
 	if r.Config.UnauthorizedRedirectURI != nil {
 		unauthorizedRedirectURI = make([]string, 0, len(r.Config.UnauthorizedRedirectURI))
-		for _, unauthorizedRedirectURIItem := range r.Config.UnauthorizedRedirectURI {
-			unauthorizedRedirectURI = append(unauthorizedRedirectURI, unauthorizedRedirectURIItem.ValueString())
+		for unauthorizedRedirectURIIndex := range r.Config.UnauthorizedRedirectURI {
+			unauthorizedRedirectURI = append(unauthorizedRedirectURI, r.Config.UnauthorizedRedirectURI[unauthorizedRedirectURIIndex].ValueString())
 		}
 	}
 	var unexpectedRedirectURI []string
 	if r.Config.UnexpectedRedirectURI != nil {
 		unexpectedRedirectURI = make([]string, 0, len(r.Config.UnexpectedRedirectURI))
-		for _, unexpectedRedirectURIItem := range r.Config.UnexpectedRedirectURI {
-			unexpectedRedirectURI = append(unexpectedRedirectURI, unexpectedRedirectURIItem.ValueString())
+		for unexpectedRedirectURIIndex := range r.Config.UnexpectedRedirectURI {
+			unexpectedRedirectURI = append(unexpectedRedirectURI, r.Config.UnexpectedRedirectURI[unexpectedRedirectURIIndex].ValueString())
 		}
 	}
 	upstreamAccessTokenHeader := new(string)
@@ -2797,15 +2797,15 @@ func (r *GatewayPluginOpenidConnectResourceModel) ToSharedOpenidConnectPlugin(ct
 	var upstreamHeadersClaims []string
 	if r.Config.UpstreamHeadersClaims != nil {
 		upstreamHeadersClaims = make([]string, 0, len(r.Config.UpstreamHeadersClaims))
-		for _, upstreamHeadersClaimsItem := range r.Config.UpstreamHeadersClaims {
-			upstreamHeadersClaims = append(upstreamHeadersClaims, upstreamHeadersClaimsItem.ValueString())
+		for upstreamHeadersClaimsIndex := range r.Config.UpstreamHeadersClaims {
+			upstreamHeadersClaims = append(upstreamHeadersClaims, r.Config.UpstreamHeadersClaims[upstreamHeadersClaimsIndex].ValueString())
 		}
 	}
 	var upstreamHeadersNames []string
 	if r.Config.UpstreamHeadersNames != nil {
 		upstreamHeadersNames = make([]string, 0, len(r.Config.UpstreamHeadersNames))
-		for _, upstreamHeadersNamesItem := range r.Config.UpstreamHeadersNames {
-			upstreamHeadersNames = append(upstreamHeadersNames, upstreamHeadersNamesItem.ValueString())
+		for upstreamHeadersNamesIndex := range r.Config.UpstreamHeadersNames {
+			upstreamHeadersNames = append(upstreamHeadersNames, r.Config.UpstreamHeadersNames[upstreamHeadersNamesIndex].ValueString())
 		}
 	}
 	upstreamIDTokenHeader := new(string)
@@ -2871,43 +2871,43 @@ func (r *GatewayPluginOpenidConnectResourceModel) ToSharedOpenidConnectPlugin(ct
 	var userinfoHeadersClient []string
 	if r.Config.UserinfoHeadersClient != nil {
 		userinfoHeadersClient = make([]string, 0, len(r.Config.UserinfoHeadersClient))
-		for _, userinfoHeadersClientItem := range r.Config.UserinfoHeadersClient {
-			userinfoHeadersClient = append(userinfoHeadersClient, userinfoHeadersClientItem.ValueString())
+		for userinfoHeadersClientIndex := range r.Config.UserinfoHeadersClient {
+			userinfoHeadersClient = append(userinfoHeadersClient, r.Config.UserinfoHeadersClient[userinfoHeadersClientIndex].ValueString())
 		}
 	}
 	var userinfoHeadersNames []string
 	if r.Config.UserinfoHeadersNames != nil {
 		userinfoHeadersNames = make([]string, 0, len(r.Config.UserinfoHeadersNames))
-		for _, userinfoHeadersNamesItem := range r.Config.UserinfoHeadersNames {
-			userinfoHeadersNames = append(userinfoHeadersNames, userinfoHeadersNamesItem.ValueString())
+		for userinfoHeadersNamesIndex := range r.Config.UserinfoHeadersNames {
+			userinfoHeadersNames = append(userinfoHeadersNames, r.Config.UserinfoHeadersNames[userinfoHeadersNamesIndex].ValueString())
 		}
 	}
 	var userinfoHeadersValues []string
 	if r.Config.UserinfoHeadersValues != nil {
 		userinfoHeadersValues = make([]string, 0, len(r.Config.UserinfoHeadersValues))
-		for _, userinfoHeadersValuesItem := range r.Config.UserinfoHeadersValues {
-			userinfoHeadersValues = append(userinfoHeadersValues, userinfoHeadersValuesItem.ValueString())
+		for userinfoHeadersValuesIndex := range r.Config.UserinfoHeadersValues {
+			userinfoHeadersValues = append(userinfoHeadersValues, r.Config.UserinfoHeadersValues[userinfoHeadersValuesIndex].ValueString())
 		}
 	}
 	var userinfoQueryArgsClient []string
 	if r.Config.UserinfoQueryArgsClient != nil {
 		userinfoQueryArgsClient = make([]string, 0, len(r.Config.UserinfoQueryArgsClient))
-		for _, userinfoQueryArgsClientItem := range r.Config.UserinfoQueryArgsClient {
-			userinfoQueryArgsClient = append(userinfoQueryArgsClient, userinfoQueryArgsClientItem.ValueString())
+		for userinfoQueryArgsClientIndex := range r.Config.UserinfoQueryArgsClient {
+			userinfoQueryArgsClient = append(userinfoQueryArgsClient, r.Config.UserinfoQueryArgsClient[userinfoQueryArgsClientIndex].ValueString())
 		}
 	}
 	var userinfoQueryArgsNames []string
 	if r.Config.UserinfoQueryArgsNames != nil {
 		userinfoQueryArgsNames = make([]string, 0, len(r.Config.UserinfoQueryArgsNames))
-		for _, userinfoQueryArgsNamesItem := range r.Config.UserinfoQueryArgsNames {
-			userinfoQueryArgsNames = append(userinfoQueryArgsNames, userinfoQueryArgsNamesItem.ValueString())
+		for userinfoQueryArgsNamesIndex := range r.Config.UserinfoQueryArgsNames {
+			userinfoQueryArgsNames = append(userinfoQueryArgsNames, r.Config.UserinfoQueryArgsNames[userinfoQueryArgsNamesIndex].ValueString())
 		}
 	}
 	var userinfoQueryArgsValues []string
 	if r.Config.UserinfoQueryArgsValues != nil {
 		userinfoQueryArgsValues = make([]string, 0, len(r.Config.UserinfoQueryArgsValues))
-		for _, userinfoQueryArgsValuesItem := range r.Config.UserinfoQueryArgsValues {
-			userinfoQueryArgsValues = append(userinfoQueryArgsValues, userinfoQueryArgsValuesItem.ValueString())
+		for userinfoQueryArgsValuesIndex := range r.Config.UserinfoQueryArgsValues {
+			userinfoQueryArgsValues = append(userinfoQueryArgsValues, r.Config.UserinfoQueryArgsValues[userinfoQueryArgsValuesIndex].ValueString())
 		}
 	}
 	usingPseudoIssuer := new(bool)

--- a/internal/provider/gatewaypluginopentelemetry_resource.go
+++ b/internal/provider/gatewaypluginopentelemetry_resource.go
@@ -681,7 +681,10 @@ func (r *GatewayPluginOpentelemetryResource) Delete(ctx context.Context, req res
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginopentelemetry_resource_sdk.go
+++ b/internal/provider/gatewaypluginopentelemetry_resource_sdk.go
@@ -282,8 +282,8 @@ func (r *GatewayPluginOpentelemetryResourceModel) ToSharedOpentelemetryPlugin(ct
 		var after *shared.OpentelemetryPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.OpentelemetryPluginAfter{
 				Access: access,
@@ -292,8 +292,8 @@ func (r *GatewayPluginOpentelemetryResourceModel) ToSharedOpentelemetryPlugin(ct
 		var before *shared.OpentelemetryPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.OpentelemetryPluginBefore{
 				Access: access1,
@@ -307,22 +307,22 @@ func (r *GatewayPluginOpentelemetryResourceModel) ToSharedOpentelemetryPlugin(ct
 	var partials []shared.OpentelemetryPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.OpentelemetryPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -336,8 +336,8 @@ func (r *GatewayPluginOpentelemetryResourceModel) ToSharedOpentelemetryPlugin(ct
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -375,9 +375,9 @@ func (r *GatewayPluginOpentelemetryResourceModel) ToSharedOpentelemetryPlugin(ct
 		var headers map[string]string
 		if r.Config.Headers != nil {
 			headers = make(map[string]string)
-			for headersKey, headersValue := range r.Config.Headers {
+			for headersKey := range r.Config.Headers {
 				var headersInst string
-				headersInst = headersValue.ValueString()
+				headersInst = r.Config.Headers[headersKey].ValueString()
 
 				headers[headersKey] = headersInst
 			}
@@ -399,8 +399,8 @@ func (r *GatewayPluginOpentelemetryResourceModel) ToSharedOpentelemetryPlugin(ct
 			var clear []string
 			if r.Config.Propagation.Clear != nil {
 				clear = make([]string, 0, len(r.Config.Propagation.Clear))
-				for _, clearItem := range r.Config.Propagation.Clear {
-					clear = append(clear, clearItem.ValueString())
+				for clearIndex := range r.Config.Propagation.Clear {
+					clear = append(clear, r.Config.Propagation.Clear[clearIndex].ValueString())
 				}
 			}
 			defaultFormat := new(shared.DefaultFormat)
@@ -498,9 +498,9 @@ func (r *GatewayPluginOpentelemetryResourceModel) ToSharedOpentelemetryPlugin(ct
 			readTimeout = nil
 		}
 		resourceAttributes := make(map[string]string)
-		for resourceAttributesKey, resourceAttributesValue := range r.Config.ResourceAttributes {
+		for resourceAttributesKey := range r.Config.ResourceAttributes {
 			var resourceAttributesInst string
-			resourceAttributesInst = resourceAttributesValue.ValueString()
+			resourceAttributesInst = r.Config.ResourceAttributes[resourceAttributesKey].ValueString()
 
 			resourceAttributes[resourceAttributesKey] = resourceAttributesInst
 		}

--- a/internal/provider/gatewaypluginpostfunction_resource.go
+++ b/internal/provider/gatewaypluginpostfunction_resource.go
@@ -559,7 +559,10 @@ func (r *GatewayPluginPostFunctionResource) Delete(ctx context.Context, req reso
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginpostfunction_resource_sdk.go
+++ b/internal/provider/gatewaypluginpostfunction_resource_sdk.go
@@ -240,8 +240,8 @@ func (r *GatewayPluginPostFunctionResourceModel) ToSharedPostFunctionPlugin(ctx 
 		var after *shared.PostFunctionPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.PostFunctionPluginAfter{
 				Access: access,
@@ -250,8 +250,8 @@ func (r *GatewayPluginPostFunctionResourceModel) ToSharedPostFunctionPlugin(ctx 
 		var before *shared.PostFunctionPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.PostFunctionPluginBefore{
 				Access: access1,
@@ -265,22 +265,22 @@ func (r *GatewayPluginPostFunctionResourceModel) ToSharedPostFunctionPlugin(ctx 
 	var partials []shared.PostFunctionPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.PostFunctionPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -294,8 +294,8 @@ func (r *GatewayPluginPostFunctionResourceModel) ToSharedPostFunctionPlugin(ctx 
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -307,44 +307,44 @@ func (r *GatewayPluginPostFunctionResourceModel) ToSharedPostFunctionPlugin(ctx 
 	var config *shared.PostFunctionPluginConfig
 	if r.Config != nil {
 		access2 := make([]string, 0, len(r.Config.Access))
-		for _, accessItem2 := range r.Config.Access {
-			access2 = append(access2, accessItem2.ValueString())
+		for accessIndex2 := range r.Config.Access {
+			access2 = append(access2, r.Config.Access[accessIndex2].ValueString())
 		}
 		bodyFilter := make([]string, 0, len(r.Config.BodyFilter))
-		for _, bodyFilterItem := range r.Config.BodyFilter {
-			bodyFilter = append(bodyFilter, bodyFilterItem.ValueString())
+		for bodyFilterIndex := range r.Config.BodyFilter {
+			bodyFilter = append(bodyFilter, r.Config.BodyFilter[bodyFilterIndex].ValueString())
 		}
 		certificate := make([]string, 0, len(r.Config.Certificate))
-		for _, certificateItem := range r.Config.Certificate {
-			certificate = append(certificate, certificateItem.ValueString())
+		for certificateIndex := range r.Config.Certificate {
+			certificate = append(certificate, r.Config.Certificate[certificateIndex].ValueString())
 		}
 		headerFilter := make([]string, 0, len(r.Config.HeaderFilter))
-		for _, headerFilterItem := range r.Config.HeaderFilter {
-			headerFilter = append(headerFilter, headerFilterItem.ValueString())
+		for headerFilterIndex := range r.Config.HeaderFilter {
+			headerFilter = append(headerFilter, r.Config.HeaderFilter[headerFilterIndex].ValueString())
 		}
 		log := make([]string, 0, len(r.Config.Log))
-		for _, logItem := range r.Config.Log {
-			log = append(log, logItem.ValueString())
+		for logIndex := range r.Config.Log {
+			log = append(log, r.Config.Log[logIndex].ValueString())
 		}
 		rewrite := make([]string, 0, len(r.Config.Rewrite))
-		for _, rewriteItem := range r.Config.Rewrite {
-			rewrite = append(rewrite, rewriteItem.ValueString())
+		for rewriteIndex := range r.Config.Rewrite {
+			rewrite = append(rewrite, r.Config.Rewrite[rewriteIndex].ValueString())
 		}
 		wsClientFrame := make([]string, 0, len(r.Config.WsClientFrame))
-		for _, wsClientFrameItem := range r.Config.WsClientFrame {
-			wsClientFrame = append(wsClientFrame, wsClientFrameItem.ValueString())
+		for wsClientFrameIndex := range r.Config.WsClientFrame {
+			wsClientFrame = append(wsClientFrame, r.Config.WsClientFrame[wsClientFrameIndex].ValueString())
 		}
 		wsClose := make([]string, 0, len(r.Config.WsClose))
-		for _, wsCloseItem := range r.Config.WsClose {
-			wsClose = append(wsClose, wsCloseItem.ValueString())
+		for wsCloseIndex := range r.Config.WsClose {
+			wsClose = append(wsClose, r.Config.WsClose[wsCloseIndex].ValueString())
 		}
 		wsHandshake := make([]string, 0, len(r.Config.WsHandshake))
-		for _, wsHandshakeItem := range r.Config.WsHandshake {
-			wsHandshake = append(wsHandshake, wsHandshakeItem.ValueString())
+		for wsHandshakeIndex := range r.Config.WsHandshake {
+			wsHandshake = append(wsHandshake, r.Config.WsHandshake[wsHandshakeIndex].ValueString())
 		}
 		wsUpstreamFrame := make([]string, 0, len(r.Config.WsUpstreamFrame))
-		for _, wsUpstreamFrameItem := range r.Config.WsUpstreamFrame {
-			wsUpstreamFrame = append(wsUpstreamFrame, wsUpstreamFrameItem.ValueString())
+		for wsUpstreamFrameIndex := range r.Config.WsUpstreamFrame {
+			wsUpstreamFrame = append(wsUpstreamFrame, r.Config.WsUpstreamFrame[wsUpstreamFrameIndex].ValueString())
 		}
 		config = &shared.PostFunctionPluginConfig{
 			Access:          access2,

--- a/internal/provider/gatewaypluginprefunction_resource.go
+++ b/internal/provider/gatewaypluginprefunction_resource.go
@@ -559,7 +559,10 @@ func (r *GatewayPluginPreFunctionResource) Delete(ctx context.Context, req resou
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginprefunction_resource_sdk.go
+++ b/internal/provider/gatewaypluginprefunction_resource_sdk.go
@@ -240,8 +240,8 @@ func (r *GatewayPluginPreFunctionResourceModel) ToSharedPreFunctionPlugin(ctx co
 		var after *shared.PreFunctionPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.PreFunctionPluginAfter{
 				Access: access,
@@ -250,8 +250,8 @@ func (r *GatewayPluginPreFunctionResourceModel) ToSharedPreFunctionPlugin(ctx co
 		var before *shared.PreFunctionPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.PreFunctionPluginBefore{
 				Access: access1,
@@ -265,22 +265,22 @@ func (r *GatewayPluginPreFunctionResourceModel) ToSharedPreFunctionPlugin(ctx co
 	var partials []shared.PreFunctionPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.PreFunctionPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -294,8 +294,8 @@ func (r *GatewayPluginPreFunctionResourceModel) ToSharedPreFunctionPlugin(ctx co
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -307,44 +307,44 @@ func (r *GatewayPluginPreFunctionResourceModel) ToSharedPreFunctionPlugin(ctx co
 	var config *shared.PreFunctionPluginConfig
 	if r.Config != nil {
 		access2 := make([]string, 0, len(r.Config.Access))
-		for _, accessItem2 := range r.Config.Access {
-			access2 = append(access2, accessItem2.ValueString())
+		for accessIndex2 := range r.Config.Access {
+			access2 = append(access2, r.Config.Access[accessIndex2].ValueString())
 		}
 		bodyFilter := make([]string, 0, len(r.Config.BodyFilter))
-		for _, bodyFilterItem := range r.Config.BodyFilter {
-			bodyFilter = append(bodyFilter, bodyFilterItem.ValueString())
+		for bodyFilterIndex := range r.Config.BodyFilter {
+			bodyFilter = append(bodyFilter, r.Config.BodyFilter[bodyFilterIndex].ValueString())
 		}
 		certificate := make([]string, 0, len(r.Config.Certificate))
-		for _, certificateItem := range r.Config.Certificate {
-			certificate = append(certificate, certificateItem.ValueString())
+		for certificateIndex := range r.Config.Certificate {
+			certificate = append(certificate, r.Config.Certificate[certificateIndex].ValueString())
 		}
 		headerFilter := make([]string, 0, len(r.Config.HeaderFilter))
-		for _, headerFilterItem := range r.Config.HeaderFilter {
-			headerFilter = append(headerFilter, headerFilterItem.ValueString())
+		for headerFilterIndex := range r.Config.HeaderFilter {
+			headerFilter = append(headerFilter, r.Config.HeaderFilter[headerFilterIndex].ValueString())
 		}
 		log := make([]string, 0, len(r.Config.Log))
-		for _, logItem := range r.Config.Log {
-			log = append(log, logItem.ValueString())
+		for logIndex := range r.Config.Log {
+			log = append(log, r.Config.Log[logIndex].ValueString())
 		}
 		rewrite := make([]string, 0, len(r.Config.Rewrite))
-		for _, rewriteItem := range r.Config.Rewrite {
-			rewrite = append(rewrite, rewriteItem.ValueString())
+		for rewriteIndex := range r.Config.Rewrite {
+			rewrite = append(rewrite, r.Config.Rewrite[rewriteIndex].ValueString())
 		}
 		wsClientFrame := make([]string, 0, len(r.Config.WsClientFrame))
-		for _, wsClientFrameItem := range r.Config.WsClientFrame {
-			wsClientFrame = append(wsClientFrame, wsClientFrameItem.ValueString())
+		for wsClientFrameIndex := range r.Config.WsClientFrame {
+			wsClientFrame = append(wsClientFrame, r.Config.WsClientFrame[wsClientFrameIndex].ValueString())
 		}
 		wsClose := make([]string, 0, len(r.Config.WsClose))
-		for _, wsCloseItem := range r.Config.WsClose {
-			wsClose = append(wsClose, wsCloseItem.ValueString())
+		for wsCloseIndex := range r.Config.WsClose {
+			wsClose = append(wsClose, r.Config.WsClose[wsCloseIndex].ValueString())
 		}
 		wsHandshake := make([]string, 0, len(r.Config.WsHandshake))
-		for _, wsHandshakeItem := range r.Config.WsHandshake {
-			wsHandshake = append(wsHandshake, wsHandshakeItem.ValueString())
+		for wsHandshakeIndex := range r.Config.WsHandshake {
+			wsHandshake = append(wsHandshake, r.Config.WsHandshake[wsHandshakeIndex].ValueString())
 		}
 		wsUpstreamFrame := make([]string, 0, len(r.Config.WsUpstreamFrame))
-		for _, wsUpstreamFrameItem := range r.Config.WsUpstreamFrame {
-			wsUpstreamFrame = append(wsUpstreamFrame, wsUpstreamFrameItem.ValueString())
+		for wsUpstreamFrameIndex := range r.Config.WsUpstreamFrame {
+			wsUpstreamFrame = append(wsUpstreamFrame, r.Config.WsUpstreamFrame[wsUpstreamFrameIndex].ValueString())
 		}
 		config = &shared.PreFunctionPluginConfig{
 			Access:          access2,

--- a/internal/provider/gatewaypluginprometheus_resource.go
+++ b/internal/provider/gatewaypluginprometheus_resource.go
@@ -519,7 +519,10 @@ func (r *GatewayPluginPrometheusResource) Delete(ctx context.Context, req resour
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginprometheus_resource_sdk.go
+++ b/internal/provider/gatewaypluginprometheus_resource_sdk.go
@@ -213,8 +213,8 @@ func (r *GatewayPluginPrometheusResourceModel) ToSharedPrometheusPlugin(ctx cont
 		var after *shared.PrometheusPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.PrometheusPluginAfter{
 				Access: access,
@@ -223,8 +223,8 @@ func (r *GatewayPluginPrometheusResourceModel) ToSharedPrometheusPlugin(ctx cont
 		var before *shared.PrometheusPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.PrometheusPluginBefore{
 				Access: access1,
@@ -238,22 +238,22 @@ func (r *GatewayPluginPrometheusResourceModel) ToSharedPrometheusPlugin(ctx cont
 	var partials []shared.PrometheusPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.PrometheusPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -267,8 +267,8 @@ func (r *GatewayPluginPrometheusResourceModel) ToSharedPrometheusPlugin(ctx cont
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)

--- a/internal/provider/gatewaypluginproxycache_resource.go
+++ b/internal/provider/gatewaypluginproxycache_resource.go
@@ -595,7 +595,10 @@ func (r *GatewayPluginProxyCacheResource) Delete(ctx context.Context, req resour
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginproxycache_resource_sdk.go
+++ b/internal/provider/gatewaypluginproxycache_resource_sdk.go
@@ -250,8 +250,8 @@ func (r *GatewayPluginProxyCacheResourceModel) ToSharedProxyCachePlugin(ctx cont
 		var after *shared.ProxyCachePluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.ProxyCachePluginAfter{
 				Access: access,
@@ -260,8 +260,8 @@ func (r *GatewayPluginProxyCacheResourceModel) ToSharedProxyCachePlugin(ctx cont
 		var before *shared.ProxyCachePluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.ProxyCachePluginBefore{
 				Access: access1,
@@ -275,22 +275,22 @@ func (r *GatewayPluginProxyCacheResourceModel) ToSharedProxyCachePlugin(ctx cont
 	var partials []shared.ProxyCachePluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.ProxyCachePluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -304,8 +304,8 @@ func (r *GatewayPluginProxyCacheResourceModel) ToSharedProxyCachePlugin(ctx cont
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -327,8 +327,8 @@ func (r *GatewayPluginProxyCacheResourceModel) ToSharedProxyCachePlugin(ctx cont
 		cacheTTL = nil
 	}
 	contentType := make([]string, 0, len(r.Config.ContentType))
-	for _, contentTypeItem := range r.Config.ContentType {
-		contentType = append(contentType, contentTypeItem.ValueString())
+	for contentTypeIndex := range r.Config.ContentType {
+		contentType = append(contentType, r.Config.ContentType[contentTypeIndex].ValueString())
 	}
 	ignoreURICase := new(bool)
 	if !r.Config.IgnoreURICase.IsUnknown() && !r.Config.IgnoreURICase.IsNull() {
@@ -353,8 +353,8 @@ func (r *GatewayPluginProxyCacheResourceModel) ToSharedProxyCachePlugin(ctx cont
 		requestMethod = append(requestMethod, shared.RequestMethod(requestMethodItem.ValueString()))
 	}
 	responseCode := make([]int64, 0, len(r.Config.ResponseCode))
-	for _, responseCodeItem := range r.Config.ResponseCode {
-		responseCode = append(responseCode, responseCodeItem.ValueInt64())
+	for responseCodeIndex := range r.Config.ResponseCode {
+		responseCode = append(responseCode, r.Config.ResponseCode[responseCodeIndex].ValueInt64())
 	}
 	var responseHeaders *shared.ResponseHeaders
 	if r.Config.ResponseHeaders != nil {
@@ -392,15 +392,15 @@ func (r *GatewayPluginProxyCacheResourceModel) ToSharedProxyCachePlugin(ctx cont
 	var varyHeaders []string
 	if r.Config.VaryHeaders != nil {
 		varyHeaders = make([]string, 0, len(r.Config.VaryHeaders))
-		for _, varyHeadersItem := range r.Config.VaryHeaders {
-			varyHeaders = append(varyHeaders, varyHeadersItem.ValueString())
+		for varyHeadersIndex := range r.Config.VaryHeaders {
+			varyHeaders = append(varyHeaders, r.Config.VaryHeaders[varyHeadersIndex].ValueString())
 		}
 	}
 	var varyQueryParams []string
 	if r.Config.VaryQueryParams != nil {
 		varyQueryParams = make([]string, 0, len(r.Config.VaryQueryParams))
-		for _, varyQueryParamsItem := range r.Config.VaryQueryParams {
-			varyQueryParams = append(varyQueryParams, varyQueryParamsItem.ValueString())
+		for varyQueryParamsIndex := range r.Config.VaryQueryParams {
+			varyQueryParams = append(varyQueryParams, r.Config.VaryQueryParams[varyQueryParamsIndex].ValueString())
 		}
 	}
 	config := shared.ProxyCachePluginConfig{

--- a/internal/provider/gatewaypluginproxycacheadvanced_resource.go
+++ b/internal/provider/gatewaypluginproxycacheadvanced_resource.go
@@ -832,7 +832,10 @@ func (r *GatewayPluginProxyCacheAdvancedResource) Delete(ctx context.Context, re
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginproxycacheadvanced_resource_sdk.go
+++ b/internal/provider/gatewaypluginproxycacheadvanced_resource_sdk.go
@@ -303,8 +303,8 @@ func (r *GatewayPluginProxyCacheAdvancedResourceModel) ToSharedProxyCacheAdvance
 		var after *shared.ProxyCacheAdvancedPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.ProxyCacheAdvancedPluginAfter{
 				Access: access,
@@ -313,8 +313,8 @@ func (r *GatewayPluginProxyCacheAdvancedResourceModel) ToSharedProxyCacheAdvance
 		var before *shared.ProxyCacheAdvancedPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.ProxyCacheAdvancedPluginBefore{
 				Access: access1,
@@ -328,22 +328,22 @@ func (r *GatewayPluginProxyCacheAdvancedResourceModel) ToSharedProxyCacheAdvance
 	var partials []shared.ProxyCacheAdvancedPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.ProxyCacheAdvancedPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -357,8 +357,8 @@ func (r *GatewayPluginProxyCacheAdvancedResourceModel) ToSharedProxyCacheAdvance
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -386,8 +386,8 @@ func (r *GatewayPluginProxyCacheAdvancedResourceModel) ToSharedProxyCacheAdvance
 		cacheTTL = nil
 	}
 	contentType := make([]string, 0, len(r.Config.ContentType))
-	for _, contentTypeItem := range r.Config.ContentType {
-		contentType = append(contentType, contentTypeItem.ValueString())
+	for contentTypeIndex := range r.Config.ContentType {
+		contentType = append(contentType, r.Config.ContentType[contentTypeIndex].ValueString())
 	}
 	ignoreURICase := new(bool)
 	if !r.Config.IgnoreURICase.IsUnknown() && !r.Config.IgnoreURICase.IsNull() {
@@ -418,16 +418,16 @@ func (r *GatewayPluginProxyCacheAdvancedResourceModel) ToSharedProxyCacheAdvance
 		var clusterNodes []shared.ProxyCacheAdvancedPluginClusterNodes
 		if r.Config.Redis.ClusterNodes != nil {
 			clusterNodes = make([]shared.ProxyCacheAdvancedPluginClusterNodes, 0, len(r.Config.Redis.ClusterNodes))
-			for _, clusterNodesItem := range r.Config.Redis.ClusterNodes {
+			for clusterNodesIndex := range r.Config.Redis.ClusterNodes {
 				ip := new(string)
-				if !clusterNodesItem.IP.IsUnknown() && !clusterNodesItem.IP.IsNull() {
-					*ip = clusterNodesItem.IP.ValueString()
+				if !r.Config.Redis.ClusterNodes[clusterNodesIndex].IP.IsUnknown() && !r.Config.Redis.ClusterNodes[clusterNodesIndex].IP.IsNull() {
+					*ip = r.Config.Redis.ClusterNodes[clusterNodesIndex].IP.ValueString()
 				} else {
 					ip = nil
 				}
 				port := new(int64)
-				if !clusterNodesItem.Port.IsUnknown() && !clusterNodesItem.Port.IsNull() {
-					*port = clusterNodesItem.Port.ValueInt64()
+				if !r.Config.Redis.ClusterNodes[clusterNodesIndex].Port.IsUnknown() && !r.Config.Redis.ClusterNodes[clusterNodesIndex].Port.IsNull() {
+					*port = r.Config.Redis.ClusterNodes[clusterNodesIndex].Port.ValueInt64()
 				} else {
 					port = nil
 				}
@@ -506,16 +506,16 @@ func (r *GatewayPluginProxyCacheAdvancedResourceModel) ToSharedProxyCacheAdvance
 		var sentinelNodes []shared.ProxyCacheAdvancedPluginSentinelNodes
 		if r.Config.Redis.SentinelNodes != nil {
 			sentinelNodes = make([]shared.ProxyCacheAdvancedPluginSentinelNodes, 0, len(r.Config.Redis.SentinelNodes))
-			for _, sentinelNodesItem := range r.Config.Redis.SentinelNodes {
+			for sentinelNodesIndex := range r.Config.Redis.SentinelNodes {
 				host1 := new(string)
-				if !sentinelNodesItem.Host.IsUnknown() && !sentinelNodesItem.Host.IsNull() {
-					*host1 = sentinelNodesItem.Host.ValueString()
+				if !r.Config.Redis.SentinelNodes[sentinelNodesIndex].Host.IsUnknown() && !r.Config.Redis.SentinelNodes[sentinelNodesIndex].Host.IsNull() {
+					*host1 = r.Config.Redis.SentinelNodes[sentinelNodesIndex].Host.ValueString()
 				} else {
 					host1 = nil
 				}
 				port2 := new(int64)
-				if !sentinelNodesItem.Port.IsUnknown() && !sentinelNodesItem.Port.IsNull() {
-					*port2 = sentinelNodesItem.Port.ValueInt64()
+				if !r.Config.Redis.SentinelNodes[sentinelNodesIndex].Port.IsUnknown() && !r.Config.Redis.SentinelNodes[sentinelNodesIndex].Port.IsNull() {
+					*port2 = r.Config.Redis.SentinelNodes[sentinelNodesIndex].Port.ValueInt64()
 				} else {
 					port2 = nil
 				}
@@ -596,8 +596,8 @@ func (r *GatewayPluginProxyCacheAdvancedResourceModel) ToSharedProxyCacheAdvance
 		requestMethod = append(requestMethod, shared.ProxyCacheAdvancedPluginRequestMethod(requestMethodItem.ValueString()))
 	}
 	responseCode := make([]int64, 0, len(r.Config.ResponseCode))
-	for _, responseCodeItem := range r.Config.ResponseCode {
-		responseCode = append(responseCode, responseCodeItem.ValueInt64())
+	for responseCodeIndex := range r.Config.ResponseCode {
+		responseCode = append(responseCode, r.Config.ResponseCode[responseCodeIndex].ValueInt64())
 	}
 	var responseHeaders *shared.ProxyCacheAdvancedPluginResponseHeaders
 	if r.Config.ResponseHeaders != nil {
@@ -635,15 +635,15 @@ func (r *GatewayPluginProxyCacheAdvancedResourceModel) ToSharedProxyCacheAdvance
 	var varyHeaders []string
 	if r.Config.VaryHeaders != nil {
 		varyHeaders = make([]string, 0, len(r.Config.VaryHeaders))
-		for _, varyHeadersItem := range r.Config.VaryHeaders {
-			varyHeaders = append(varyHeaders, varyHeadersItem.ValueString())
+		for varyHeadersIndex := range r.Config.VaryHeaders {
+			varyHeaders = append(varyHeaders, r.Config.VaryHeaders[varyHeadersIndex].ValueString())
 		}
 	}
 	var varyQueryParams []string
 	if r.Config.VaryQueryParams != nil {
 		varyQueryParams = make([]string, 0, len(r.Config.VaryQueryParams))
-		for _, varyQueryParamsItem := range r.Config.VaryQueryParams {
-			varyQueryParams = append(varyQueryParams, varyQueryParamsItem.ValueString())
+		for varyQueryParamsIndex := range r.Config.VaryQueryParams {
+			varyQueryParams = append(varyQueryParams, r.Config.VaryQueryParams[varyQueryParamsIndex].ValueString())
 		}
 	}
 	config := shared.ProxyCacheAdvancedPluginConfig{

--- a/internal/provider/gatewaypluginratelimiting_resource.go
+++ b/internal/provider/gatewaypluginratelimiting_resource.go
@@ -671,7 +671,10 @@ func (r *GatewayPluginRateLimitingResource) Delete(ctx context.Context, req reso
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginratelimiting_resource_sdk.go
+++ b/internal/provider/gatewaypluginratelimiting_resource_sdk.go
@@ -249,8 +249,8 @@ func (r *GatewayPluginRateLimitingResourceModel) ToSharedRateLimitingPlugin(ctx 
 		var after *shared.RateLimitingPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.RateLimitingPluginAfter{
 				Access: access,
@@ -259,8 +259,8 @@ func (r *GatewayPluginRateLimitingResourceModel) ToSharedRateLimitingPlugin(ctx 
 		var before *shared.RateLimitingPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.RateLimitingPluginBefore{
 				Access: access1,
@@ -274,22 +274,22 @@ func (r *GatewayPluginRateLimitingResourceModel) ToSharedRateLimitingPlugin(ctx 
 	var partials []shared.RateLimitingPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.RateLimitingPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -303,8 +303,8 @@ func (r *GatewayPluginRateLimitingResourceModel) ToSharedRateLimitingPlugin(ctx 
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)

--- a/internal/provider/gatewaypluginratelimitingadvanced_resource.go
+++ b/internal/provider/gatewaypluginratelimitingadvanced_resource.go
@@ -853,7 +853,10 @@ func (r *GatewayPluginRateLimitingAdvancedResource) Delete(ctx context.Context, 
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginratelimitingadvanced_resource_sdk.go
+++ b/internal/provider/gatewaypluginratelimitingadvanced_resource_sdk.go
@@ -320,8 +320,8 @@ func (r *GatewayPluginRateLimitingAdvancedResourceModel) ToSharedRateLimitingAdv
 		var after *shared.RateLimitingAdvancedPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.RateLimitingAdvancedPluginAfter{
 				Access: access,
@@ -330,8 +330,8 @@ func (r *GatewayPluginRateLimitingAdvancedResourceModel) ToSharedRateLimitingAdv
 		var before *shared.RateLimitingAdvancedPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.RateLimitingAdvancedPluginBefore{
 				Access: access1,
@@ -345,22 +345,22 @@ func (r *GatewayPluginRateLimitingAdvancedResourceModel) ToSharedRateLimitingAdv
 	var partials []shared.RateLimitingAdvancedPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.RateLimitingAdvancedPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -374,8 +374,8 @@ func (r *GatewayPluginRateLimitingAdvancedResourceModel) ToSharedRateLimitingAdv
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -394,8 +394,8 @@ func (r *GatewayPluginRateLimitingAdvancedResourceModel) ToSharedRateLimitingAdv
 	var consumerGroups []string
 	if r.Config.ConsumerGroups != nil {
 		consumerGroups = make([]string, 0, len(r.Config.ConsumerGroups))
-		for _, consumerGroupsItem := range r.Config.ConsumerGroups {
-			consumerGroups = append(consumerGroups, consumerGroupsItem.ValueString())
+		for consumerGroupsIndex := range r.Config.ConsumerGroups {
+			consumerGroups = append(consumerGroups, r.Config.ConsumerGroups[consumerGroupsIndex].ValueString())
 		}
 	}
 	dictionaryName := new(string)
@@ -447,8 +447,8 @@ func (r *GatewayPluginRateLimitingAdvancedResourceModel) ToSharedRateLimitingAdv
 		identifier = nil
 	}
 	limit := make([]float64, 0, len(r.Config.Limit))
-	for _, limitItem := range r.Config.Limit {
-		limit = append(limit, limitItem.ValueFloat64())
+	for limitIndex := range r.Config.Limit {
+		limit = append(limit, r.Config.Limit[limitIndex].ValueFloat64())
 	}
 	lockDictionaryName := new(string)
 	if !r.Config.LockDictionaryName.IsUnknown() && !r.Config.LockDictionaryName.IsNull() {
@@ -479,16 +479,16 @@ func (r *GatewayPluginRateLimitingAdvancedResourceModel) ToSharedRateLimitingAdv
 		var clusterNodes []shared.RateLimitingAdvancedPluginClusterNodes
 		if r.Config.Redis.ClusterNodes != nil {
 			clusterNodes = make([]shared.RateLimitingAdvancedPluginClusterNodes, 0, len(r.Config.Redis.ClusterNodes))
-			for _, clusterNodesItem := range r.Config.Redis.ClusterNodes {
+			for clusterNodesIndex := range r.Config.Redis.ClusterNodes {
 				ip := new(string)
-				if !clusterNodesItem.IP.IsUnknown() && !clusterNodesItem.IP.IsNull() {
-					*ip = clusterNodesItem.IP.ValueString()
+				if !r.Config.Redis.ClusterNodes[clusterNodesIndex].IP.IsUnknown() && !r.Config.Redis.ClusterNodes[clusterNodesIndex].IP.IsNull() {
+					*ip = r.Config.Redis.ClusterNodes[clusterNodesIndex].IP.ValueString()
 				} else {
 					ip = nil
 				}
 				port := new(int64)
-				if !clusterNodesItem.Port.IsUnknown() && !clusterNodesItem.Port.IsNull() {
-					*port = clusterNodesItem.Port.ValueInt64()
+				if !r.Config.Redis.ClusterNodes[clusterNodesIndex].Port.IsUnknown() && !r.Config.Redis.ClusterNodes[clusterNodesIndex].Port.IsNull() {
+					*port = r.Config.Redis.ClusterNodes[clusterNodesIndex].Port.ValueInt64()
 				} else {
 					port = nil
 				}
@@ -573,16 +573,16 @@ func (r *GatewayPluginRateLimitingAdvancedResourceModel) ToSharedRateLimitingAdv
 		var sentinelNodes []shared.RateLimitingAdvancedPluginSentinelNodes
 		if r.Config.Redis.SentinelNodes != nil {
 			sentinelNodes = make([]shared.RateLimitingAdvancedPluginSentinelNodes, 0, len(r.Config.Redis.SentinelNodes))
-			for _, sentinelNodesItem := range r.Config.Redis.SentinelNodes {
+			for sentinelNodesIndex := range r.Config.Redis.SentinelNodes {
 				host1 := new(string)
-				if !sentinelNodesItem.Host.IsUnknown() && !sentinelNodesItem.Host.IsNull() {
-					*host1 = sentinelNodesItem.Host.ValueString()
+				if !r.Config.Redis.SentinelNodes[sentinelNodesIndex].Host.IsUnknown() && !r.Config.Redis.SentinelNodes[sentinelNodesIndex].Host.IsNull() {
+					*host1 = r.Config.Redis.SentinelNodes[sentinelNodesIndex].Host.ValueString()
 				} else {
 					host1 = nil
 				}
 				port2 := new(int64)
-				if !sentinelNodesItem.Port.IsUnknown() && !sentinelNodesItem.Port.IsNull() {
-					*port2 = sentinelNodesItem.Port.ValueInt64()
+				if !r.Config.Redis.SentinelNodes[sentinelNodesIndex].Port.IsUnknown() && !r.Config.Redis.SentinelNodes[sentinelNodesIndex].Port.IsNull() {
+					*port2 = r.Config.Redis.SentinelNodes[sentinelNodesIndex].Port.ValueInt64()
 				} else {
 					port2 = nil
 				}
@@ -711,8 +711,8 @@ func (r *GatewayPluginRateLimitingAdvancedResourceModel) ToSharedRateLimitingAdv
 		}
 	}
 	windowSize := make([]float64, 0, len(r.Config.WindowSize))
-	for _, windowSizeItem := range r.Config.WindowSize {
-		windowSize = append(windowSize, windowSizeItem.ValueFloat64())
+	for windowSizeIndex := range r.Config.WindowSize {
+		windowSize = append(windowSize, r.Config.WindowSize[windowSizeIndex].ValueFloat64())
 	}
 	windowType := new(shared.RateLimitingAdvancedPluginWindowType)
 	if !r.Config.WindowType.IsUnknown() && !r.Config.WindowType.IsNull() {

--- a/internal/provider/gatewaypluginredirect_resource.go
+++ b/internal/provider/gatewaypluginredirect_resource.go
@@ -506,7 +506,10 @@ func (r *GatewayPluginRedirectResource) Delete(ctx context.Context, req resource
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginredirect_resource_sdk.go
+++ b/internal/provider/gatewaypluginredirect_resource_sdk.go
@@ -210,8 +210,8 @@ func (r *GatewayPluginRedirectResourceModel) ToSharedRedirectPlugin(ctx context.
 		var after *shared.RedirectPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.RedirectPluginAfter{
 				Access: access,
@@ -220,8 +220,8 @@ func (r *GatewayPluginRedirectResourceModel) ToSharedRedirectPlugin(ctx context.
 		var before *shared.RedirectPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.RedirectPluginBefore{
 				Access: access1,
@@ -235,22 +235,22 @@ func (r *GatewayPluginRedirectResourceModel) ToSharedRedirectPlugin(ctx context.
 	var partials []shared.RedirectPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.RedirectPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -264,8 +264,8 @@ func (r *GatewayPluginRedirectResourceModel) ToSharedRedirectPlugin(ctx context.
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)

--- a/internal/provider/gatewaypluginrequestcallout_resource.go
+++ b/internal/provider/gatewaypluginrequestcallout_resource.go
@@ -1143,7 +1143,10 @@ func (r *GatewayPluginRequestCalloutResource) Delete(ctx context.Context, req re
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginrequestcallout_resource_sdk.go
+++ b/internal/provider/gatewaypluginrequestcallout_resource_sdk.go
@@ -440,8 +440,8 @@ func (r *GatewayPluginRequestCalloutResourceModel) ToSharedRequestCalloutPlugin(
 		var after *shared.RequestCalloutPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.RequestCalloutPluginAfter{
 				Access: access,
@@ -450,8 +450,8 @@ func (r *GatewayPluginRequestCalloutResourceModel) ToSharedRequestCalloutPlugin(
 		var before *shared.RequestCalloutPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.RequestCalloutPluginBefore{
 				Access: access1,
@@ -465,22 +465,22 @@ func (r *GatewayPluginRequestCalloutResourceModel) ToSharedRequestCalloutPlugin(
 	var partials []shared.RequestCalloutPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.RequestCalloutPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -494,8 +494,8 @@ func (r *GatewayPluginRequestCalloutResourceModel) ToSharedRequestCalloutPlugin(
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -535,16 +535,16 @@ func (r *GatewayPluginRequestCalloutResourceModel) ToSharedRequestCalloutPlugin(
 			var clusterNodes []shared.RequestCalloutPluginClusterNodes
 			if r.Config.Cache.Redis.ClusterNodes != nil {
 				clusterNodes = make([]shared.RequestCalloutPluginClusterNodes, 0, len(r.Config.Cache.Redis.ClusterNodes))
-				for _, clusterNodesItem := range r.Config.Cache.Redis.ClusterNodes {
+				for clusterNodesIndex := range r.Config.Cache.Redis.ClusterNodes {
 					ip := new(string)
-					if !clusterNodesItem.IP.IsUnknown() && !clusterNodesItem.IP.IsNull() {
-						*ip = clusterNodesItem.IP.ValueString()
+					if !r.Config.Cache.Redis.ClusterNodes[clusterNodesIndex].IP.IsUnknown() && !r.Config.Cache.Redis.ClusterNodes[clusterNodesIndex].IP.IsNull() {
+						*ip = r.Config.Cache.Redis.ClusterNodes[clusterNodesIndex].IP.ValueString()
 					} else {
 						ip = nil
 					}
 					port := new(int64)
-					if !clusterNodesItem.Port.IsUnknown() && !clusterNodesItem.Port.IsNull() {
-						*port = clusterNodesItem.Port.ValueInt64()
+					if !r.Config.Cache.Redis.ClusterNodes[clusterNodesIndex].Port.IsUnknown() && !r.Config.Cache.Redis.ClusterNodes[clusterNodesIndex].Port.IsNull() {
+						*port = r.Config.Cache.Redis.ClusterNodes[clusterNodesIndex].Port.ValueInt64()
 					} else {
 						port = nil
 					}
@@ -623,16 +623,16 @@ func (r *GatewayPluginRequestCalloutResourceModel) ToSharedRequestCalloutPlugin(
 			var sentinelNodes []shared.RequestCalloutPluginSentinelNodes
 			if r.Config.Cache.Redis.SentinelNodes != nil {
 				sentinelNodes = make([]shared.RequestCalloutPluginSentinelNodes, 0, len(r.Config.Cache.Redis.SentinelNodes))
-				for _, sentinelNodesItem := range r.Config.Cache.Redis.SentinelNodes {
+				for sentinelNodesIndex := range r.Config.Cache.Redis.SentinelNodes {
 					host1 := new(string)
-					if !sentinelNodesItem.Host.IsUnknown() && !sentinelNodesItem.Host.IsNull() {
-						*host1 = sentinelNodesItem.Host.ValueString()
+					if !r.Config.Cache.Redis.SentinelNodes[sentinelNodesIndex].Host.IsUnknown() && !r.Config.Cache.Redis.SentinelNodes[sentinelNodesIndex].Host.IsNull() {
+						*host1 = r.Config.Cache.Redis.SentinelNodes[sentinelNodesIndex].Host.ValueString()
 					} else {
 						host1 = nil
 					}
 					port2 := new(int64)
-					if !sentinelNodesItem.Port.IsUnknown() && !sentinelNodesItem.Port.IsNull() {
-						*port2 = sentinelNodesItem.Port.ValueInt64()
+					if !r.Config.Cache.Redis.SentinelNodes[sentinelNodesIndex].Port.IsUnknown() && !r.Config.Cache.Redis.SentinelNodes[sentinelNodesIndex].Port.IsNull() {
+						*port2 = r.Config.Cache.Redis.SentinelNodes[sentinelNodesIndex].Port.ValueInt64()
 					} else {
 						port2 = nil
 					}
@@ -722,12 +722,12 @@ func (r *GatewayPluginRequestCalloutResourceModel) ToSharedRequestCalloutPlugin(
 		}
 	}
 	callouts := make([]shared.Callouts, 0, len(r.Config.Callouts))
-	for _, calloutsItem := range r.Config.Callouts {
+	for calloutsIndex := range r.Config.Callouts {
 		var cache1 *shared.RequestCalloutPluginCache
-		if calloutsItem.Cache != nil {
+		if r.Config.Callouts[calloutsIndex].Cache != nil {
 			bypass := new(bool)
-			if !calloutsItem.Cache.Bypass.IsUnknown() && !calloutsItem.Cache.Bypass.IsNull() {
-				*bypass = calloutsItem.Cache.Bypass.ValueBool()
+			if !r.Config.Callouts[calloutsIndex].Cache.Bypass.IsUnknown() && !r.Config.Callouts[calloutsIndex].Cache.Bypass.IsNull() {
+				*bypass = r.Config.Callouts[calloutsIndex].Cache.Bypass.ValueBool()
 			} else {
 				bypass = nil
 			}
@@ -735,34 +735,34 @@ func (r *GatewayPluginRequestCalloutResourceModel) ToSharedRequestCalloutPlugin(
 				Bypass: bypass,
 			}
 		}
-		dependsOn := make([]string, 0, len(calloutsItem.DependsOn))
-		for _, dependsOnItem := range calloutsItem.DependsOn {
-			dependsOn = append(dependsOn, dependsOnItem.ValueString())
+		dependsOn := make([]string, 0, len(r.Config.Callouts[calloutsIndex].DependsOn))
+		for dependsOnIndex := range r.Config.Callouts[calloutsIndex].DependsOn {
+			dependsOn = append(dependsOn, r.Config.Callouts[calloutsIndex].DependsOn[dependsOnIndex].ValueString())
 		}
 		var name1 string
-		name1 = calloutsItem.Name.ValueString()
+		name1 = r.Config.Callouts[calloutsIndex].Name.ValueString()
 
 		var body *shared.RequestCalloutPluginConfigBody
-		if calloutsItem.Request.Body != nil {
+		if r.Config.Callouts[calloutsIndex].Request.Body != nil {
 			var custom map[string]string
-			if calloutsItem.Request.Body.Custom != nil {
+			if r.Config.Callouts[calloutsIndex].Request.Body.Custom != nil {
 				custom = make(map[string]string)
-				for customKey, customValue := range calloutsItem.Request.Body.Custom {
+				for customKey := range r.Config.Callouts[calloutsIndex].Request.Body.Custom {
 					var customInst string
-					customInst = customValue.ValueString()
+					customInst = r.Config.Callouts[calloutsIndex].Request.Body.Custom[customKey].ValueString()
 
 					custom[customKey] = customInst
 				}
 			}
 			decode := new(bool)
-			if !calloutsItem.Request.Body.Decode.IsUnknown() && !calloutsItem.Request.Body.Decode.IsNull() {
-				*decode = calloutsItem.Request.Body.Decode.ValueBool()
+			if !r.Config.Callouts[calloutsIndex].Request.Body.Decode.IsUnknown() && !r.Config.Callouts[calloutsIndex].Request.Body.Decode.IsNull() {
+				*decode = r.Config.Callouts[calloutsIndex].Request.Body.Decode.ValueBool()
 			} else {
 				decode = nil
 			}
 			forward := new(bool)
-			if !calloutsItem.Request.Body.Forward.IsUnknown() && !calloutsItem.Request.Body.Forward.IsNull() {
-				*forward = calloutsItem.Request.Body.Forward.ValueBool()
+			if !r.Config.Callouts[calloutsIndex].Request.Body.Forward.IsUnknown() && !r.Config.Callouts[calloutsIndex].Request.Body.Forward.IsNull() {
+				*forward = r.Config.Callouts[calloutsIndex].Request.Body.Forward.ValueBool()
 			} else {
 				forward = nil
 			}
@@ -773,41 +773,41 @@ func (r *GatewayPluginRequestCalloutResourceModel) ToSharedRequestCalloutPlugin(
 			}
 		}
 		byLua := new(string)
-		if !calloutsItem.Request.ByLua.IsUnknown() && !calloutsItem.Request.ByLua.IsNull() {
-			*byLua = calloutsItem.Request.ByLua.ValueString()
+		if !r.Config.Callouts[calloutsIndex].Request.ByLua.IsUnknown() && !r.Config.Callouts[calloutsIndex].Request.ByLua.IsNull() {
+			*byLua = r.Config.Callouts[calloutsIndex].Request.ByLua.ValueString()
 		} else {
 			byLua = nil
 		}
 		var error *shared.Error
-		if calloutsItem.Request.Error != nil {
+		if r.Config.Callouts[calloutsIndex].Request.Error != nil {
 			errorResponseCode := new(int64)
-			if !calloutsItem.Request.Error.ErrorResponseCode.IsUnknown() && !calloutsItem.Request.Error.ErrorResponseCode.IsNull() {
-				*errorResponseCode = calloutsItem.Request.Error.ErrorResponseCode.ValueInt64()
+			if !r.Config.Callouts[calloutsIndex].Request.Error.ErrorResponseCode.IsUnknown() && !r.Config.Callouts[calloutsIndex].Request.Error.ErrorResponseCode.IsNull() {
+				*errorResponseCode = r.Config.Callouts[calloutsIndex].Request.Error.ErrorResponseCode.ValueInt64()
 			} else {
 				errorResponseCode = nil
 			}
 			errorResponseMsg := new(string)
-			if !calloutsItem.Request.Error.ErrorResponseMsg.IsUnknown() && !calloutsItem.Request.Error.ErrorResponseMsg.IsNull() {
-				*errorResponseMsg = calloutsItem.Request.Error.ErrorResponseMsg.ValueString()
+			if !r.Config.Callouts[calloutsIndex].Request.Error.ErrorResponseMsg.IsUnknown() && !r.Config.Callouts[calloutsIndex].Request.Error.ErrorResponseMsg.IsNull() {
+				*errorResponseMsg = r.Config.Callouts[calloutsIndex].Request.Error.ErrorResponseMsg.ValueString()
 			} else {
 				errorResponseMsg = nil
 			}
 			var httpStatuses []int64
-			if calloutsItem.Request.Error.HTTPStatuses != nil {
-				httpStatuses = make([]int64, 0, len(calloutsItem.Request.Error.HTTPStatuses))
-				for _, httpStatusesItem := range calloutsItem.Request.Error.HTTPStatuses {
-					httpStatuses = append(httpStatuses, httpStatusesItem.ValueInt64())
+			if r.Config.Callouts[calloutsIndex].Request.Error.HTTPStatuses != nil {
+				httpStatuses = make([]int64, 0, len(r.Config.Callouts[calloutsIndex].Request.Error.HTTPStatuses))
+				for httpStatusesIndex := range r.Config.Callouts[calloutsIndex].Request.Error.HTTPStatuses {
+					httpStatuses = append(httpStatuses, r.Config.Callouts[calloutsIndex].Request.Error.HTTPStatuses[httpStatusesIndex].ValueInt64())
 				}
 			}
 			onError := new(shared.OnError)
-			if !calloutsItem.Request.Error.OnError.IsUnknown() && !calloutsItem.Request.Error.OnError.IsNull() {
-				*onError = shared.OnError(calloutsItem.Request.Error.OnError.ValueString())
+			if !r.Config.Callouts[calloutsIndex].Request.Error.OnError.IsUnknown() && !r.Config.Callouts[calloutsIndex].Request.Error.OnError.IsNull() {
+				*onError = shared.OnError(r.Config.Callouts[calloutsIndex].Request.Error.OnError.ValueString())
 			} else {
 				onError = nil
 			}
 			retries := new(int64)
-			if !calloutsItem.Request.Error.Retries.IsUnknown() && !calloutsItem.Request.Error.Retries.IsNull() {
-				*retries = calloutsItem.Request.Error.Retries.ValueInt64()
+			if !r.Config.Callouts[calloutsIndex].Request.Error.Retries.IsUnknown() && !r.Config.Callouts[calloutsIndex].Request.Error.Retries.IsNull() {
+				*retries = r.Config.Callouts[calloutsIndex].Request.Error.Retries.ValueInt64()
 			} else {
 				retries = nil
 			}
@@ -820,20 +820,20 @@ func (r *GatewayPluginRequestCalloutResourceModel) ToSharedRequestCalloutPlugin(
 			}
 		}
 		var headers *shared.RequestCalloutPluginConfigCalloutsHeaders
-		if calloutsItem.Request.Headers != nil {
+		if r.Config.Callouts[calloutsIndex].Request.Headers != nil {
 			var custom1 map[string]string
-			if calloutsItem.Request.Headers.Custom != nil {
+			if r.Config.Callouts[calloutsIndex].Request.Headers.Custom != nil {
 				custom1 = make(map[string]string)
-				for customKey1, customValue1 := range calloutsItem.Request.Headers.Custom {
+				for customKey1 := range r.Config.Callouts[calloutsIndex].Request.Headers.Custom {
 					var customInst1 string
-					customInst1 = customValue1.ValueString()
+					customInst1 = r.Config.Callouts[calloutsIndex].Request.Headers.Custom[customKey1].ValueString()
 
 					custom1[customKey1] = customInst1
 				}
 			}
 			forward1 := new(bool)
-			if !calloutsItem.Request.Headers.Forward.IsUnknown() && !calloutsItem.Request.Headers.Forward.IsNull() {
-				*forward1 = calloutsItem.Request.Headers.Forward.ValueBool()
+			if !r.Config.Callouts[calloutsIndex].Request.Headers.Forward.IsUnknown() && !r.Config.Callouts[calloutsIndex].Request.Headers.Forward.IsNull() {
+				*forward1 = r.Config.Callouts[calloutsIndex].Request.Headers.Forward.ValueBool()
 			} else {
 				forward1 = nil
 			}
@@ -843,30 +843,30 @@ func (r *GatewayPluginRequestCalloutResourceModel) ToSharedRequestCalloutPlugin(
 			}
 		}
 		var httpOpts *shared.HTTPOpts
-		if calloutsItem.Request.HTTPOpts != nil {
+		if r.Config.Callouts[calloutsIndex].Request.HTTPOpts != nil {
 			var proxy *shared.Proxy
-			if calloutsItem.Request.HTTPOpts.Proxy != nil {
+			if r.Config.Callouts[calloutsIndex].Request.HTTPOpts.Proxy != nil {
 				authPassword := new(string)
-				if !calloutsItem.Request.HTTPOpts.Proxy.AuthPassword.IsUnknown() && !calloutsItem.Request.HTTPOpts.Proxy.AuthPassword.IsNull() {
-					*authPassword = calloutsItem.Request.HTTPOpts.Proxy.AuthPassword.ValueString()
+				if !r.Config.Callouts[calloutsIndex].Request.HTTPOpts.Proxy.AuthPassword.IsUnknown() && !r.Config.Callouts[calloutsIndex].Request.HTTPOpts.Proxy.AuthPassword.IsNull() {
+					*authPassword = r.Config.Callouts[calloutsIndex].Request.HTTPOpts.Proxy.AuthPassword.ValueString()
 				} else {
 					authPassword = nil
 				}
 				authUsername := new(string)
-				if !calloutsItem.Request.HTTPOpts.Proxy.AuthUsername.IsUnknown() && !calloutsItem.Request.HTTPOpts.Proxy.AuthUsername.IsNull() {
-					*authUsername = calloutsItem.Request.HTTPOpts.Proxy.AuthUsername.ValueString()
+				if !r.Config.Callouts[calloutsIndex].Request.HTTPOpts.Proxy.AuthUsername.IsUnknown() && !r.Config.Callouts[calloutsIndex].Request.HTTPOpts.Proxy.AuthUsername.IsNull() {
+					*authUsername = r.Config.Callouts[calloutsIndex].Request.HTTPOpts.Proxy.AuthUsername.ValueString()
 				} else {
 					authUsername = nil
 				}
 				httpProxy := new(string)
-				if !calloutsItem.Request.HTTPOpts.Proxy.HTTPProxy.IsUnknown() && !calloutsItem.Request.HTTPOpts.Proxy.HTTPProxy.IsNull() {
-					*httpProxy = calloutsItem.Request.HTTPOpts.Proxy.HTTPProxy.ValueString()
+				if !r.Config.Callouts[calloutsIndex].Request.HTTPOpts.Proxy.HTTPProxy.IsUnknown() && !r.Config.Callouts[calloutsIndex].Request.HTTPOpts.Proxy.HTTPProxy.IsNull() {
+					*httpProxy = r.Config.Callouts[calloutsIndex].Request.HTTPOpts.Proxy.HTTPProxy.ValueString()
 				} else {
 					httpProxy = nil
 				}
 				httpsProxy := new(string)
-				if !calloutsItem.Request.HTTPOpts.Proxy.HTTPSProxy.IsUnknown() && !calloutsItem.Request.HTTPOpts.Proxy.HTTPSProxy.IsNull() {
-					*httpsProxy = calloutsItem.Request.HTTPOpts.Proxy.HTTPSProxy.ValueString()
+				if !r.Config.Callouts[calloutsIndex].Request.HTTPOpts.Proxy.HTTPSProxy.IsUnknown() && !r.Config.Callouts[calloutsIndex].Request.HTTPOpts.Proxy.HTTPSProxy.IsNull() {
+					*httpsProxy = r.Config.Callouts[calloutsIndex].Request.HTTPOpts.Proxy.HTTPSProxy.ValueString()
 				} else {
 					httpsProxy = nil
 				}
@@ -878,34 +878,34 @@ func (r *GatewayPluginRequestCalloutResourceModel) ToSharedRequestCalloutPlugin(
 				}
 			}
 			sslServerName := new(string)
-			if !calloutsItem.Request.HTTPOpts.SslServerName.IsUnknown() && !calloutsItem.Request.HTTPOpts.SslServerName.IsNull() {
-				*sslServerName = calloutsItem.Request.HTTPOpts.SslServerName.ValueString()
+			if !r.Config.Callouts[calloutsIndex].Request.HTTPOpts.SslServerName.IsUnknown() && !r.Config.Callouts[calloutsIndex].Request.HTTPOpts.SslServerName.IsNull() {
+				*sslServerName = r.Config.Callouts[calloutsIndex].Request.HTTPOpts.SslServerName.ValueString()
 			} else {
 				sslServerName = nil
 			}
 			sslVerify1 := new(bool)
-			if !calloutsItem.Request.HTTPOpts.SslVerify.IsUnknown() && !calloutsItem.Request.HTTPOpts.SslVerify.IsNull() {
-				*sslVerify1 = calloutsItem.Request.HTTPOpts.SslVerify.ValueBool()
+			if !r.Config.Callouts[calloutsIndex].Request.HTTPOpts.SslVerify.IsUnknown() && !r.Config.Callouts[calloutsIndex].Request.HTTPOpts.SslVerify.IsNull() {
+				*sslVerify1 = r.Config.Callouts[calloutsIndex].Request.HTTPOpts.SslVerify.ValueBool()
 			} else {
 				sslVerify1 = nil
 			}
 			var timeouts *shared.Timeouts
-			if calloutsItem.Request.HTTPOpts.Timeouts != nil {
+			if r.Config.Callouts[calloutsIndex].Request.HTTPOpts.Timeouts != nil {
 				connect := new(int64)
-				if !calloutsItem.Request.HTTPOpts.Timeouts.Connect.IsUnknown() && !calloutsItem.Request.HTTPOpts.Timeouts.Connect.IsNull() {
-					*connect = calloutsItem.Request.HTTPOpts.Timeouts.Connect.ValueInt64()
+				if !r.Config.Callouts[calloutsIndex].Request.HTTPOpts.Timeouts.Connect.IsUnknown() && !r.Config.Callouts[calloutsIndex].Request.HTTPOpts.Timeouts.Connect.IsNull() {
+					*connect = r.Config.Callouts[calloutsIndex].Request.HTTPOpts.Timeouts.Connect.ValueInt64()
 				} else {
 					connect = nil
 				}
 				read := new(int64)
-				if !calloutsItem.Request.HTTPOpts.Timeouts.Read.IsUnknown() && !calloutsItem.Request.HTTPOpts.Timeouts.Read.IsNull() {
-					*read = calloutsItem.Request.HTTPOpts.Timeouts.Read.ValueInt64()
+				if !r.Config.Callouts[calloutsIndex].Request.HTTPOpts.Timeouts.Read.IsUnknown() && !r.Config.Callouts[calloutsIndex].Request.HTTPOpts.Timeouts.Read.IsNull() {
+					*read = r.Config.Callouts[calloutsIndex].Request.HTTPOpts.Timeouts.Read.ValueInt64()
 				} else {
 					read = nil
 				}
 				write := new(int64)
-				if !calloutsItem.Request.HTTPOpts.Timeouts.Write.IsUnknown() && !calloutsItem.Request.HTTPOpts.Timeouts.Write.IsNull() {
-					*write = calloutsItem.Request.HTTPOpts.Timeouts.Write.ValueInt64()
+				if !r.Config.Callouts[calloutsIndex].Request.HTTPOpts.Timeouts.Write.IsUnknown() && !r.Config.Callouts[calloutsIndex].Request.HTTPOpts.Timeouts.Write.IsNull() {
+					*write = r.Config.Callouts[calloutsIndex].Request.HTTPOpts.Timeouts.Write.ValueInt64()
 				} else {
 					write = nil
 				}
@@ -923,26 +923,26 @@ func (r *GatewayPluginRequestCalloutResourceModel) ToSharedRequestCalloutPlugin(
 			}
 		}
 		method := new(string)
-		if !calloutsItem.Request.Method.IsUnknown() && !calloutsItem.Request.Method.IsNull() {
-			*method = calloutsItem.Request.Method.ValueString()
+		if !r.Config.Callouts[calloutsIndex].Request.Method.IsUnknown() && !r.Config.Callouts[calloutsIndex].Request.Method.IsNull() {
+			*method = r.Config.Callouts[calloutsIndex].Request.Method.ValueString()
 		} else {
 			method = nil
 		}
 		var query *shared.RequestCalloutPluginQuery
-		if calloutsItem.Request.Query != nil {
+		if r.Config.Callouts[calloutsIndex].Request.Query != nil {
 			var custom2 map[string]string
-			if calloutsItem.Request.Query.Custom != nil {
+			if r.Config.Callouts[calloutsIndex].Request.Query.Custom != nil {
 				custom2 = make(map[string]string)
-				for customKey2, customValue2 := range calloutsItem.Request.Query.Custom {
+				for customKey2 := range r.Config.Callouts[calloutsIndex].Request.Query.Custom {
 					var customInst2 string
-					customInst2 = customValue2.ValueString()
+					customInst2 = r.Config.Callouts[calloutsIndex].Request.Query.Custom[customKey2].ValueString()
 
 					custom2[customKey2] = customInst2
 				}
 			}
 			forward2 := new(bool)
-			if !calloutsItem.Request.Query.Forward.IsUnknown() && !calloutsItem.Request.Query.Forward.IsNull() {
-				*forward2 = calloutsItem.Request.Query.Forward.ValueBool()
+			if !r.Config.Callouts[calloutsIndex].Request.Query.Forward.IsUnknown() && !r.Config.Callouts[calloutsIndex].Request.Query.Forward.IsNull() {
+				*forward2 = r.Config.Callouts[calloutsIndex].Request.Query.Forward.ValueBool()
 			} else {
 				forward2 = nil
 			}
@@ -952,7 +952,7 @@ func (r *GatewayPluginRequestCalloutResourceModel) ToSharedRequestCalloutPlugin(
 			}
 		}
 		var url string
-		url = calloutsItem.Request.URL.ValueString()
+		url = r.Config.Callouts[calloutsIndex].Request.URL.ValueString()
 
 		request := shared.Request{
 			Body:     body,
@@ -965,18 +965,18 @@ func (r *GatewayPluginRequestCalloutResourceModel) ToSharedRequestCalloutPlugin(
 			URL:      url,
 		}
 		var response *shared.Response
-		if calloutsItem.Response != nil {
+		if r.Config.Callouts[calloutsIndex].Response != nil {
 			var body1 *shared.RequestCalloutPluginBody
-			if calloutsItem.Response.Body != nil {
+			if r.Config.Callouts[calloutsIndex].Response.Body != nil {
 				decode1 := new(bool)
-				if !calloutsItem.Response.Body.Decode.IsUnknown() && !calloutsItem.Response.Body.Decode.IsNull() {
-					*decode1 = calloutsItem.Response.Body.Decode.ValueBool()
+				if !r.Config.Callouts[calloutsIndex].Response.Body.Decode.IsUnknown() && !r.Config.Callouts[calloutsIndex].Response.Body.Decode.IsNull() {
+					*decode1 = r.Config.Callouts[calloutsIndex].Response.Body.Decode.ValueBool()
 				} else {
 					decode1 = nil
 				}
 				store := new(bool)
-				if !calloutsItem.Response.Body.Store.IsUnknown() && !calloutsItem.Response.Body.Store.IsNull() {
-					*store = calloutsItem.Response.Body.Store.ValueBool()
+				if !r.Config.Callouts[calloutsIndex].Response.Body.Store.IsUnknown() && !r.Config.Callouts[calloutsIndex].Response.Body.Store.IsNull() {
+					*store = r.Config.Callouts[calloutsIndex].Response.Body.Store.ValueBool()
 				} else {
 					store = nil
 				}
@@ -986,16 +986,16 @@ func (r *GatewayPluginRequestCalloutResourceModel) ToSharedRequestCalloutPlugin(
 				}
 			}
 			byLua1 := new(string)
-			if !calloutsItem.Response.ByLua.IsUnknown() && !calloutsItem.Response.ByLua.IsNull() {
-				*byLua1 = calloutsItem.Response.ByLua.ValueString()
+			if !r.Config.Callouts[calloutsIndex].Response.ByLua.IsUnknown() && !r.Config.Callouts[calloutsIndex].Response.ByLua.IsNull() {
+				*byLua1 = r.Config.Callouts[calloutsIndex].Response.ByLua.ValueString()
 			} else {
 				byLua1 = nil
 			}
 			var headers1 *shared.RequestCalloutPluginConfigHeaders
-			if calloutsItem.Response.Headers != nil {
+			if r.Config.Callouts[calloutsIndex].Response.Headers != nil {
 				store1 := new(bool)
-				if !calloutsItem.Response.Headers.Store.IsUnknown() && !calloutsItem.Response.Headers.Store.IsNull() {
-					*store1 = calloutsItem.Response.Headers.Store.ValueBool()
+				if !r.Config.Callouts[calloutsIndex].Response.Headers.Store.IsUnknown() && !r.Config.Callouts[calloutsIndex].Response.Headers.Store.IsNull() {
+					*store1 = r.Config.Callouts[calloutsIndex].Response.Headers.Store.ValueBool()
 				} else {
 					store1 = nil
 				}
@@ -1024,9 +1024,9 @@ func (r *GatewayPluginRequestCalloutResourceModel) ToSharedRequestCalloutPlugin(
 			var custom3 map[string]string
 			if r.Config.Upstream.Body.Custom != nil {
 				custom3 = make(map[string]string)
-				for customKey3, customValue3 := range r.Config.Upstream.Body.Custom {
+				for customKey3 := range r.Config.Upstream.Body.Custom {
 					var customInst3 string
-					customInst3 = customValue3.ValueString()
+					customInst3 = r.Config.Upstream.Body.Custom[customKey3].ValueString()
 
 					custom3[customKey3] = customInst3
 				}
@@ -1060,9 +1060,9 @@ func (r *GatewayPluginRequestCalloutResourceModel) ToSharedRequestCalloutPlugin(
 			var custom4 map[string]string
 			if r.Config.Upstream.Headers.Custom != nil {
 				custom4 = make(map[string]string)
-				for customKey4, customValue4 := range r.Config.Upstream.Headers.Custom {
+				for customKey4 := range r.Config.Upstream.Headers.Custom {
 					var customInst4 string
-					customInst4 = customValue4.ValueString()
+					customInst4 = r.Config.Upstream.Headers.Custom[customKey4].ValueString()
 
 					custom4[customKey4] = customInst4
 				}
@@ -1083,9 +1083,9 @@ func (r *GatewayPluginRequestCalloutResourceModel) ToSharedRequestCalloutPlugin(
 			var custom5 map[string]string
 			if r.Config.Upstream.Query.Custom != nil {
 				custom5 = make(map[string]string)
-				for customKey5, customValue5 := range r.Config.Upstream.Query.Custom {
+				for customKey5 := range r.Config.Upstream.Query.Custom {
 					var customInst5 string
-					customInst5 = customValue5.ValueString()
+					customInst5 = r.Config.Upstream.Query.Custom[customKey5].ValueString()
 
 					custom5[customKey5] = customInst5
 				}

--- a/internal/provider/gatewaypluginrequestsizelimiting_resource.go
+++ b/internal/provider/gatewaypluginrequestsizelimiting_resource.go
@@ -503,7 +503,10 @@ func (r *GatewayPluginRequestSizeLimitingResource) Delete(ctx context.Context, r
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginrequestsizelimiting_resource_sdk.go
+++ b/internal/provider/gatewaypluginrequestsizelimiting_resource_sdk.go
@@ -213,8 +213,8 @@ func (r *GatewayPluginRequestSizeLimitingResourceModel) ToSharedRequestSizeLimit
 		var after *shared.RequestSizeLimitingPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.RequestSizeLimitingPluginAfter{
 				Access: access,
@@ -223,8 +223,8 @@ func (r *GatewayPluginRequestSizeLimitingResourceModel) ToSharedRequestSizeLimit
 		var before *shared.RequestSizeLimitingPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.RequestSizeLimitingPluginBefore{
 				Access: access1,
@@ -238,22 +238,22 @@ func (r *GatewayPluginRequestSizeLimitingResourceModel) ToSharedRequestSizeLimit
 	var partials []shared.RequestSizeLimitingPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.RequestSizeLimitingPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -267,8 +267,8 @@ func (r *GatewayPluginRequestSizeLimitingResourceModel) ToSharedRequestSizeLimit
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)

--- a/internal/provider/gatewaypluginrequesttermination_resource.go
+++ b/internal/provider/gatewaypluginrequesttermination_resource.go
@@ -527,7 +527,10 @@ func (r *GatewayPluginRequestTerminationResource) Delete(ctx context.Context, re
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginrequesttermination_resource_sdk.go
+++ b/internal/provider/gatewaypluginrequesttermination_resource_sdk.go
@@ -218,8 +218,8 @@ func (r *GatewayPluginRequestTerminationResourceModel) ToSharedRequestTerminatio
 		var after *shared.RequestTerminationPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.RequestTerminationPluginAfter{
 				Access: access,
@@ -228,8 +228,8 @@ func (r *GatewayPluginRequestTerminationResourceModel) ToSharedRequestTerminatio
 		var before *shared.RequestTerminationPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.RequestTerminationPluginBefore{
 				Access: access1,
@@ -243,22 +243,22 @@ func (r *GatewayPluginRequestTerminationResourceModel) ToSharedRequestTerminatio
 	var partials []shared.RequestTerminationPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.RequestTerminationPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -272,8 +272,8 @@ func (r *GatewayPluginRequestTerminationResourceModel) ToSharedRequestTerminatio
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)

--- a/internal/provider/gatewaypluginrequesttransformer_resource.go
+++ b/internal/provider/gatewaypluginrequesttransformer_resource.go
@@ -698,7 +698,10 @@ func (r *GatewayPluginRequestTransformerResource) Delete(ctx context.Context, re
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginrequesttransformer_resource_sdk.go
+++ b/internal/provider/gatewaypluginrequesttransformer_resource_sdk.go
@@ -299,8 +299,8 @@ func (r *GatewayPluginRequestTransformerResourceModel) ToSharedRequestTransforme
 		var after *shared.RequestTransformerPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.RequestTransformerPluginAfter{
 				Access: access,
@@ -309,8 +309,8 @@ func (r *GatewayPluginRequestTransformerResourceModel) ToSharedRequestTransforme
 		var before *shared.RequestTransformerPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.RequestTransformerPluginBefore{
 				Access: access1,
@@ -324,22 +324,22 @@ func (r *GatewayPluginRequestTransformerResourceModel) ToSharedRequestTransforme
 	var partials []shared.RequestTransformerPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.RequestTransformerPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -353,8 +353,8 @@ func (r *GatewayPluginRequestTransformerResourceModel) ToSharedRequestTransforme
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -368,16 +368,16 @@ func (r *GatewayPluginRequestTransformerResourceModel) ToSharedRequestTransforme
 		var add *shared.Add
 		if r.Config.Add != nil {
 			body := make([]string, 0, len(r.Config.Add.Body))
-			for _, bodyItem := range r.Config.Add.Body {
-				body = append(body, bodyItem.ValueString())
+			for bodyIndex := range r.Config.Add.Body {
+				body = append(body, r.Config.Add.Body[bodyIndex].ValueString())
 			}
 			headers := make([]string, 0, len(r.Config.Add.Headers))
-			for _, headersItem := range r.Config.Add.Headers {
-				headers = append(headers, headersItem.ValueString())
+			for headersIndex := range r.Config.Add.Headers {
+				headers = append(headers, r.Config.Add.Headers[headersIndex].ValueString())
 			}
 			querystring := make([]string, 0, len(r.Config.Add.Querystring))
-			for _, querystringItem := range r.Config.Add.Querystring {
-				querystring = append(querystring, querystringItem.ValueString())
+			for querystringIndex := range r.Config.Add.Querystring {
+				querystring = append(querystring, r.Config.Add.Querystring[querystringIndex].ValueString())
 			}
 			add = &shared.Add{
 				Body:        body,
@@ -388,16 +388,16 @@ func (r *GatewayPluginRequestTransformerResourceModel) ToSharedRequestTransforme
 		var append1 *shared.Append
 		if r.Config.Append != nil {
 			body1 := make([]string, 0, len(r.Config.Append.Body))
-			for _, bodyItem1 := range r.Config.Append.Body {
-				body1 = append(body1, bodyItem1.ValueString())
+			for bodyIndex1 := range r.Config.Append.Body {
+				body1 = append(body1, r.Config.Append.Body[bodyIndex1].ValueString())
 			}
 			headers1 := make([]string, 0, len(r.Config.Append.Headers))
-			for _, headersItem1 := range r.Config.Append.Headers {
-				headers1 = append(headers1, headersItem1.ValueString())
+			for headersIndex1 := range r.Config.Append.Headers {
+				headers1 = append(headers1, r.Config.Append.Headers[headersIndex1].ValueString())
 			}
 			querystring1 := make([]string, 0, len(r.Config.Append.Querystring))
-			for _, querystringItem1 := range r.Config.Append.Querystring {
-				querystring1 = append(querystring1, querystringItem1.ValueString())
+			for querystringIndex1 := range r.Config.Append.Querystring {
+				querystring1 = append(querystring1, r.Config.Append.Querystring[querystringIndex1].ValueString())
 			}
 			append1 = &shared.Append{
 				Body:        body1,
@@ -414,16 +414,16 @@ func (r *GatewayPluginRequestTransformerResourceModel) ToSharedRequestTransforme
 		var remove *shared.Remove
 		if r.Config.Remove != nil {
 			body2 := make([]string, 0, len(r.Config.Remove.Body))
-			for _, bodyItem2 := range r.Config.Remove.Body {
-				body2 = append(body2, bodyItem2.ValueString())
+			for bodyIndex2 := range r.Config.Remove.Body {
+				body2 = append(body2, r.Config.Remove.Body[bodyIndex2].ValueString())
 			}
 			headers2 := make([]string, 0, len(r.Config.Remove.Headers))
-			for _, headersItem2 := range r.Config.Remove.Headers {
-				headers2 = append(headers2, headersItem2.ValueString())
+			for headersIndex2 := range r.Config.Remove.Headers {
+				headers2 = append(headers2, r.Config.Remove.Headers[headersIndex2].ValueString())
 			}
 			querystring2 := make([]string, 0, len(r.Config.Remove.Querystring))
-			for _, querystringItem2 := range r.Config.Remove.Querystring {
-				querystring2 = append(querystring2, querystringItem2.ValueString())
+			for querystringIndex2 := range r.Config.Remove.Querystring {
+				querystring2 = append(querystring2, r.Config.Remove.Querystring[querystringIndex2].ValueString())
 			}
 			remove = &shared.Remove{
 				Body:        body2,
@@ -434,16 +434,16 @@ func (r *GatewayPluginRequestTransformerResourceModel) ToSharedRequestTransforme
 		var rename *shared.Rename
 		if r.Config.Rename != nil {
 			body3 := make([]string, 0, len(r.Config.Rename.Body))
-			for _, bodyItem3 := range r.Config.Rename.Body {
-				body3 = append(body3, bodyItem3.ValueString())
+			for bodyIndex3 := range r.Config.Rename.Body {
+				body3 = append(body3, r.Config.Rename.Body[bodyIndex3].ValueString())
 			}
 			headers3 := make([]string, 0, len(r.Config.Rename.Headers))
-			for _, headersItem3 := range r.Config.Rename.Headers {
-				headers3 = append(headers3, headersItem3.ValueString())
+			for headersIndex3 := range r.Config.Rename.Headers {
+				headers3 = append(headers3, r.Config.Rename.Headers[headersIndex3].ValueString())
 			}
 			querystring3 := make([]string, 0, len(r.Config.Rename.Querystring))
-			for _, querystringItem3 := range r.Config.Rename.Querystring {
-				querystring3 = append(querystring3, querystringItem3.ValueString())
+			for querystringIndex3 := range r.Config.Rename.Querystring {
+				querystring3 = append(querystring3, r.Config.Rename.Querystring[querystringIndex3].ValueString())
 			}
 			rename = &shared.Rename{
 				Body:        body3,
@@ -454,16 +454,16 @@ func (r *GatewayPluginRequestTransformerResourceModel) ToSharedRequestTransforme
 		var replace *shared.Replace
 		if r.Config.Replace != nil {
 			body4 := make([]string, 0, len(r.Config.Replace.Body))
-			for _, bodyItem4 := range r.Config.Replace.Body {
-				body4 = append(body4, bodyItem4.ValueString())
+			for bodyIndex4 := range r.Config.Replace.Body {
+				body4 = append(body4, r.Config.Replace.Body[bodyIndex4].ValueString())
 			}
 			headers4 := make([]string, 0, len(r.Config.Replace.Headers))
-			for _, headersItem4 := range r.Config.Replace.Headers {
-				headers4 = append(headers4, headersItem4.ValueString())
+			for headersIndex4 := range r.Config.Replace.Headers {
+				headers4 = append(headers4, r.Config.Replace.Headers[headersIndex4].ValueString())
 			}
 			querystring4 := make([]string, 0, len(r.Config.Replace.Querystring))
-			for _, querystringItem4 := range r.Config.Replace.Querystring {
-				querystring4 = append(querystring4, querystringItem4.ValueString())
+			for querystringIndex4 := range r.Config.Replace.Querystring {
+				querystring4 = append(querystring4, r.Config.Replace.Querystring[querystringIndex4].ValueString())
 			}
 			uri := new(string)
 			if !r.Config.Replace.URI.IsUnknown() && !r.Config.Replace.URI.IsNull() {

--- a/internal/provider/gatewaypluginrequesttransformeradvanced_resource.go
+++ b/internal/provider/gatewaypluginrequesttransformeradvanced_resource.go
@@ -752,7 +752,10 @@ func (r *GatewayPluginRequestTransformerAdvancedResource) Delete(ctx context.Con
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginrequesttransformeradvanced_resource_sdk.go
+++ b/internal/provider/gatewaypluginrequesttransformeradvanced_resource_sdk.go
@@ -323,8 +323,8 @@ func (r *GatewayPluginRequestTransformerAdvancedResourceModel) ToSharedRequestTr
 		var after *shared.RequestTransformerAdvancedPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.RequestTransformerAdvancedPluginAfter{
 				Access: access,
@@ -333,8 +333,8 @@ func (r *GatewayPluginRequestTransformerAdvancedResourceModel) ToSharedRequestTr
 		var before *shared.RequestTransformerAdvancedPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.RequestTransformerAdvancedPluginBefore{
 				Access: access1,
@@ -348,22 +348,22 @@ func (r *GatewayPluginRequestTransformerAdvancedResourceModel) ToSharedRequestTr
 	var partials []shared.RequestTransformerAdvancedPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.RequestTransformerAdvancedPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -377,8 +377,8 @@ func (r *GatewayPluginRequestTransformerAdvancedResourceModel) ToSharedRequestTr
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -392,20 +392,20 @@ func (r *GatewayPluginRequestTransformerAdvancedResourceModel) ToSharedRequestTr
 		var add *shared.RequestTransformerAdvancedPluginAdd
 		if r.Config.Add != nil {
 			body := make([]string, 0, len(r.Config.Add.Body))
-			for _, bodyItem := range r.Config.Add.Body {
-				body = append(body, bodyItem.ValueString())
+			for bodyIndex := range r.Config.Add.Body {
+				body = append(body, r.Config.Add.Body[bodyIndex].ValueString())
 			}
 			headers := make([]string, 0, len(r.Config.Add.Headers))
-			for _, headersItem := range r.Config.Add.Headers {
-				headers = append(headers, headersItem.ValueString())
+			for headersIndex := range r.Config.Add.Headers {
+				headers = append(headers, r.Config.Add.Headers[headersIndex].ValueString())
 			}
 			jsonTypes := make([]shared.JSONTypes, 0, len(r.Config.Add.JSONTypes))
 			for _, jsonTypesItem := range r.Config.Add.JSONTypes {
 				jsonTypes = append(jsonTypes, shared.JSONTypes(jsonTypesItem.ValueString()))
 			}
 			querystring := make([]string, 0, len(r.Config.Add.Querystring))
-			for _, querystringItem := range r.Config.Add.Querystring {
-				querystring = append(querystring, querystringItem.ValueString())
+			for querystringIndex := range r.Config.Add.Querystring {
+				querystring = append(querystring, r.Config.Add.Querystring[querystringIndex].ValueString())
 			}
 			add = &shared.RequestTransformerAdvancedPluginAdd{
 				Body:        body,
@@ -419,8 +419,8 @@ func (r *GatewayPluginRequestTransformerAdvancedResourceModel) ToSharedRequestTr
 			var body1 []string
 			if r.Config.Allow.Body != nil {
 				body1 = make([]string, 0, len(r.Config.Allow.Body))
-				for _, bodyItem1 := range r.Config.Allow.Body {
-					body1 = append(body1, bodyItem1.ValueString())
+				for bodyIndex1 := range r.Config.Allow.Body {
+					body1 = append(body1, r.Config.Allow.Body[bodyIndex1].ValueString())
 				}
 			}
 			allow = &shared.Allow{
@@ -430,20 +430,20 @@ func (r *GatewayPluginRequestTransformerAdvancedResourceModel) ToSharedRequestTr
 		var append1 *shared.RequestTransformerAdvancedPluginAppend
 		if r.Config.Append != nil {
 			body2 := make([]string, 0, len(r.Config.Append.Body))
-			for _, bodyItem2 := range r.Config.Append.Body {
-				body2 = append(body2, bodyItem2.ValueString())
+			for bodyIndex2 := range r.Config.Append.Body {
+				body2 = append(body2, r.Config.Append.Body[bodyIndex2].ValueString())
 			}
 			headers1 := make([]string, 0, len(r.Config.Append.Headers))
-			for _, headersItem1 := range r.Config.Append.Headers {
-				headers1 = append(headers1, headersItem1.ValueString())
+			for headersIndex1 := range r.Config.Append.Headers {
+				headers1 = append(headers1, r.Config.Append.Headers[headersIndex1].ValueString())
 			}
 			jsonTypes1 := make([]shared.RequestTransformerAdvancedPluginJSONTypes, 0, len(r.Config.Append.JSONTypes))
 			for _, jsonTypesItem1 := range r.Config.Append.JSONTypes {
 				jsonTypes1 = append(jsonTypes1, shared.RequestTransformerAdvancedPluginJSONTypes(jsonTypesItem1.ValueString()))
 			}
 			querystring1 := make([]string, 0, len(r.Config.Append.Querystring))
-			for _, querystringItem1 := range r.Config.Append.Querystring {
-				querystring1 = append(querystring1, querystringItem1.ValueString())
+			for querystringIndex1 := range r.Config.Append.Querystring {
+				querystring1 = append(querystring1, r.Config.Append.Querystring[querystringIndex1].ValueString())
 			}
 			append1 = &shared.RequestTransformerAdvancedPluginAppend{
 				Body:        body2,
@@ -467,16 +467,16 @@ func (r *GatewayPluginRequestTransformerAdvancedResourceModel) ToSharedRequestTr
 		var remove *shared.RequestTransformerAdvancedPluginRemove
 		if r.Config.Remove != nil {
 			body3 := make([]string, 0, len(r.Config.Remove.Body))
-			for _, bodyItem3 := range r.Config.Remove.Body {
-				body3 = append(body3, bodyItem3.ValueString())
+			for bodyIndex3 := range r.Config.Remove.Body {
+				body3 = append(body3, r.Config.Remove.Body[bodyIndex3].ValueString())
 			}
 			headers2 := make([]string, 0, len(r.Config.Remove.Headers))
-			for _, headersItem2 := range r.Config.Remove.Headers {
-				headers2 = append(headers2, headersItem2.ValueString())
+			for headersIndex2 := range r.Config.Remove.Headers {
+				headers2 = append(headers2, r.Config.Remove.Headers[headersIndex2].ValueString())
 			}
 			querystring2 := make([]string, 0, len(r.Config.Remove.Querystring))
-			for _, querystringItem2 := range r.Config.Remove.Querystring {
-				querystring2 = append(querystring2, querystringItem2.ValueString())
+			for querystringIndex2 := range r.Config.Remove.Querystring {
+				querystring2 = append(querystring2, r.Config.Remove.Querystring[querystringIndex2].ValueString())
 			}
 			remove = &shared.RequestTransformerAdvancedPluginRemove{
 				Body:        body3,
@@ -487,16 +487,16 @@ func (r *GatewayPluginRequestTransformerAdvancedResourceModel) ToSharedRequestTr
 		var rename *shared.RequestTransformerAdvancedPluginRename
 		if r.Config.Rename != nil {
 			body4 := make([]string, 0, len(r.Config.Rename.Body))
-			for _, bodyItem4 := range r.Config.Rename.Body {
-				body4 = append(body4, bodyItem4.ValueString())
+			for bodyIndex4 := range r.Config.Rename.Body {
+				body4 = append(body4, r.Config.Rename.Body[bodyIndex4].ValueString())
 			}
 			headers3 := make([]string, 0, len(r.Config.Rename.Headers))
-			for _, headersItem3 := range r.Config.Rename.Headers {
-				headers3 = append(headers3, headersItem3.ValueString())
+			for headersIndex3 := range r.Config.Rename.Headers {
+				headers3 = append(headers3, r.Config.Rename.Headers[headersIndex3].ValueString())
 			}
 			querystring3 := make([]string, 0, len(r.Config.Rename.Querystring))
-			for _, querystringItem3 := range r.Config.Rename.Querystring {
-				querystring3 = append(querystring3, querystringItem3.ValueString())
+			for querystringIndex3 := range r.Config.Rename.Querystring {
+				querystring3 = append(querystring3, r.Config.Rename.Querystring[querystringIndex3].ValueString())
 			}
 			rename = &shared.RequestTransformerAdvancedPluginRename{
 				Body:        body4,
@@ -507,20 +507,20 @@ func (r *GatewayPluginRequestTransformerAdvancedResourceModel) ToSharedRequestTr
 		var replace *shared.RequestTransformerAdvancedPluginReplace
 		if r.Config.Replace != nil {
 			body5 := make([]string, 0, len(r.Config.Replace.Body))
-			for _, bodyItem5 := range r.Config.Replace.Body {
-				body5 = append(body5, bodyItem5.ValueString())
+			for bodyIndex5 := range r.Config.Replace.Body {
+				body5 = append(body5, r.Config.Replace.Body[bodyIndex5].ValueString())
 			}
 			headers4 := make([]string, 0, len(r.Config.Replace.Headers))
-			for _, headersItem4 := range r.Config.Replace.Headers {
-				headers4 = append(headers4, headersItem4.ValueString())
+			for headersIndex4 := range r.Config.Replace.Headers {
+				headers4 = append(headers4, r.Config.Replace.Headers[headersIndex4].ValueString())
 			}
 			jsonTypes2 := make([]shared.RequestTransformerAdvancedPluginConfigJSONTypes, 0, len(r.Config.Replace.JSONTypes))
 			for _, jsonTypesItem2 := range r.Config.Replace.JSONTypes {
 				jsonTypes2 = append(jsonTypes2, shared.RequestTransformerAdvancedPluginConfigJSONTypes(jsonTypesItem2.ValueString()))
 			}
 			querystring4 := make([]string, 0, len(r.Config.Replace.Querystring))
-			for _, querystringItem4 := range r.Config.Replace.Querystring {
-				querystring4 = append(querystring4, querystringItem4.ValueString())
+			for querystringIndex4 := range r.Config.Replace.Querystring {
+				querystring4 = append(querystring4, r.Config.Replace.Querystring[querystringIndex4].ValueString())
 			}
 			uri := new(string)
 			if !r.Config.Replace.URI.IsUnknown() && !r.Config.Replace.URI.IsNull() {

--- a/internal/provider/gatewaypluginrequestvalidator_resource.go
+++ b/internal/provider/gatewaypluginrequestvalidator_resource.go
@@ -599,7 +599,10 @@ func (r *GatewayPluginRequestValidatorResource) Delete(ctx context.Context, req 
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginrequestvalidator_resource_sdk.go
+++ b/internal/provider/gatewaypluginrequestvalidator_resource_sdk.go
@@ -238,8 +238,8 @@ func (r *GatewayPluginRequestValidatorResourceModel) ToSharedRequestValidatorPlu
 		var after *shared.RequestValidatorPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.RequestValidatorPluginAfter{
 				Access: access,
@@ -248,8 +248,8 @@ func (r *GatewayPluginRequestValidatorResourceModel) ToSharedRequestValidatorPlu
 		var before *shared.RequestValidatorPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.RequestValidatorPluginBefore{
 				Access: access1,
@@ -263,22 +263,22 @@ func (r *GatewayPluginRequestValidatorResourceModel) ToSharedRequestValidatorPlu
 	var partials []shared.RequestValidatorPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.RequestValidatorPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -292,8 +292,8 @@ func (r *GatewayPluginRequestValidatorResourceModel) ToSharedRequestValidatorPlu
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -305,8 +305,8 @@ func (r *GatewayPluginRequestValidatorResourceModel) ToSharedRequestValidatorPlu
 	var config *shared.RequestValidatorPluginConfig
 	if r.Config != nil {
 		allowedContentTypes := make([]string, 0, len(r.Config.AllowedContentTypes))
-		for _, allowedContentTypesItem := range r.Config.AllowedContentTypes {
-			allowedContentTypes = append(allowedContentTypes, allowedContentTypesItem.ValueString())
+		for allowedContentTypesIndex := range r.Config.AllowedContentTypes {
+			allowedContentTypes = append(allowedContentTypes, r.Config.AllowedContentTypes[allowedContentTypesIndex].ValueString())
 		}
 		bodySchema := new(string)
 		if !r.Config.BodySchema.IsUnknown() && !r.Config.BodySchema.IsNull() {
@@ -323,29 +323,29 @@ func (r *GatewayPluginRequestValidatorResourceModel) ToSharedRequestValidatorPlu
 		var parameterSchema []shared.ParameterSchema
 		if r.Config.ParameterSchema != nil {
 			parameterSchema = make([]shared.ParameterSchema, 0, len(r.Config.ParameterSchema))
-			for _, parameterSchemaItem := range r.Config.ParameterSchema {
+			for parameterSchemaIndex := range r.Config.ParameterSchema {
 				explode := new(bool)
-				if !parameterSchemaItem.Explode.IsUnknown() && !parameterSchemaItem.Explode.IsNull() {
-					*explode = parameterSchemaItem.Explode.ValueBool()
+				if !r.Config.ParameterSchema[parameterSchemaIndex].Explode.IsUnknown() && !r.Config.ParameterSchema[parameterSchemaIndex].Explode.IsNull() {
+					*explode = r.Config.ParameterSchema[parameterSchemaIndex].Explode.ValueBool()
 				} else {
 					explode = nil
 				}
-				in := shared.In(parameterSchemaItem.In.ValueString())
+				in := shared.In(r.Config.ParameterSchema[parameterSchemaIndex].In.ValueString())
 				var name1 string
-				name1 = parameterSchemaItem.Name.ValueString()
+				name1 = r.Config.ParameterSchema[parameterSchemaIndex].Name.ValueString()
 
 				var required bool
-				required = parameterSchemaItem.Required.ValueBool()
+				required = r.Config.ParameterSchema[parameterSchemaIndex].Required.ValueBool()
 
 				schema := new(string)
-				if !parameterSchemaItem.Schema.IsUnknown() && !parameterSchemaItem.Schema.IsNull() {
-					*schema = parameterSchemaItem.Schema.ValueString()
+				if !r.Config.ParameterSchema[parameterSchemaIndex].Schema.IsUnknown() && !r.Config.ParameterSchema[parameterSchemaIndex].Schema.IsNull() {
+					*schema = r.Config.ParameterSchema[parameterSchemaIndex].Schema.ValueString()
 				} else {
 					schema = nil
 				}
 				style := new(shared.Style)
-				if !parameterSchemaItem.Style.IsUnknown() && !parameterSchemaItem.Style.IsNull() {
-					*style = shared.Style(parameterSchemaItem.Style.ValueString())
+				if !r.Config.ParameterSchema[parameterSchemaIndex].Style.IsUnknown() && !r.Config.ParameterSchema[parameterSchemaIndex].Style.IsNull() {
+					*style = shared.Style(r.Config.ParameterSchema[parameterSchemaIndex].Style.ValueString())
 				} else {
 					style = nil
 				}

--- a/internal/provider/gatewaypluginresponseratelimiting_resource.go
+++ b/internal/provider/gatewaypluginresponseratelimiting_resource.go
@@ -656,7 +656,10 @@ func (r *GatewayPluginResponseRatelimitingResource) Delete(ctx context.Context, 
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginresponseratelimiting_resource_sdk.go
+++ b/internal/provider/gatewaypluginresponseratelimiting_resource_sdk.go
@@ -248,8 +248,8 @@ func (r *GatewayPluginResponseRatelimitingResourceModel) ToSharedResponseRatelim
 		var after *shared.ResponseRatelimitingPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.ResponseRatelimitingPluginAfter{
 				Access: access,
@@ -258,8 +258,8 @@ func (r *GatewayPluginResponseRatelimitingResourceModel) ToSharedResponseRatelim
 		var before *shared.ResponseRatelimitingPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.ResponseRatelimitingPluginBefore{
 				Access: access1,
@@ -273,22 +273,22 @@ func (r *GatewayPluginResponseRatelimitingResourceModel) ToSharedResponseRatelim
 	var partials []shared.ResponseRatelimitingPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.ResponseRatelimitingPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -302,8 +302,8 @@ func (r *GatewayPluginResponseRatelimitingResourceModel) ToSharedResponseRatelim
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -347,40 +347,40 @@ func (r *GatewayPluginResponseRatelimitingResourceModel) ToSharedResponseRatelim
 		var limits map[string]shared.Limits
 		if r.Config.Limits != nil {
 			limits = make(map[string]shared.Limits)
-			for limitsKey, limitsValue := range r.Config.Limits {
+			for limitsKey := range r.Config.Limits {
 				day := new(float64)
-				if !limitsValue.Day.IsUnknown() && !limitsValue.Day.IsNull() {
-					*day = limitsValue.Day.ValueFloat64()
+				if !r.Config.Limits[limitsKey].Day.IsUnknown() && !r.Config.Limits[limitsKey].Day.IsNull() {
+					*day = r.Config.Limits[limitsKey].Day.ValueFloat64()
 				} else {
 					day = nil
 				}
 				hour := new(float64)
-				if !limitsValue.Hour.IsUnknown() && !limitsValue.Hour.IsNull() {
-					*hour = limitsValue.Hour.ValueFloat64()
+				if !r.Config.Limits[limitsKey].Hour.IsUnknown() && !r.Config.Limits[limitsKey].Hour.IsNull() {
+					*hour = r.Config.Limits[limitsKey].Hour.ValueFloat64()
 				} else {
 					hour = nil
 				}
 				minute := new(float64)
-				if !limitsValue.Minute.IsUnknown() && !limitsValue.Minute.IsNull() {
-					*minute = limitsValue.Minute.ValueFloat64()
+				if !r.Config.Limits[limitsKey].Minute.IsUnknown() && !r.Config.Limits[limitsKey].Minute.IsNull() {
+					*minute = r.Config.Limits[limitsKey].Minute.ValueFloat64()
 				} else {
 					minute = nil
 				}
 				month := new(float64)
-				if !limitsValue.Month.IsUnknown() && !limitsValue.Month.IsNull() {
-					*month = limitsValue.Month.ValueFloat64()
+				if !r.Config.Limits[limitsKey].Month.IsUnknown() && !r.Config.Limits[limitsKey].Month.IsNull() {
+					*month = r.Config.Limits[limitsKey].Month.ValueFloat64()
 				} else {
 					month = nil
 				}
 				second := new(float64)
-				if !limitsValue.Second.IsUnknown() && !limitsValue.Second.IsNull() {
-					*second = limitsValue.Second.ValueFloat64()
+				if !r.Config.Limits[limitsKey].Second.IsUnknown() && !r.Config.Limits[limitsKey].Second.IsNull() {
+					*second = r.Config.Limits[limitsKey].Second.ValueFloat64()
 				} else {
 					second = nil
 				}
 				year := new(float64)
-				if !limitsValue.Year.IsUnknown() && !limitsValue.Year.IsNull() {
-					*year = limitsValue.Year.ValueFloat64()
+				if !r.Config.Limits[limitsKey].Year.IsUnknown() && !r.Config.Limits[limitsKey].Year.IsNull() {
+					*year = r.Config.Limits[limitsKey].Year.ValueFloat64()
 				} else {
 					year = nil
 				}

--- a/internal/provider/gatewaypluginresponsetransformer_resource.go
+++ b/internal/provider/gatewaypluginresponsetransformer_resource.go
@@ -675,7 +675,10 @@ func (r *GatewayPluginResponseTransformerResource) Delete(ctx context.Context, r
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginresponsetransformer_resource_sdk.go
+++ b/internal/provider/gatewaypluginresponsetransformer_resource_sdk.go
@@ -289,8 +289,8 @@ func (r *GatewayPluginResponseTransformerResourceModel) ToSharedResponseTransfor
 		var after *shared.ResponseTransformerPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.ResponseTransformerPluginAfter{
 				Access: access,
@@ -299,8 +299,8 @@ func (r *GatewayPluginResponseTransformerResourceModel) ToSharedResponseTransfor
 		var before *shared.ResponseTransformerPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.ResponseTransformerPluginBefore{
 				Access: access1,
@@ -314,22 +314,22 @@ func (r *GatewayPluginResponseTransformerResourceModel) ToSharedResponseTransfor
 	var partials []shared.ResponseTransformerPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.ResponseTransformerPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -343,8 +343,8 @@ func (r *GatewayPluginResponseTransformerResourceModel) ToSharedResponseTransfor
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -358,12 +358,12 @@ func (r *GatewayPluginResponseTransformerResourceModel) ToSharedResponseTransfor
 		var add *shared.ResponseTransformerPluginAdd
 		if r.Config.Add != nil {
 			headers := make([]string, 0, len(r.Config.Add.Headers))
-			for _, headersItem := range r.Config.Add.Headers {
-				headers = append(headers, headersItem.ValueString())
+			for headersIndex := range r.Config.Add.Headers {
+				headers = append(headers, r.Config.Add.Headers[headersIndex].ValueString())
 			}
 			jsonVar := make([]string, 0, len(r.Config.Add.JSON))
-			for _, jsonItem := range r.Config.Add.JSON {
-				jsonVar = append(jsonVar, jsonItem.ValueString())
+			for jsonIndex := range r.Config.Add.JSON {
+				jsonVar = append(jsonVar, r.Config.Add.JSON[jsonIndex].ValueString())
 			}
 			jsonTypes := make([]shared.ResponseTransformerPluginJSONTypes, 0, len(r.Config.Add.JSONTypes))
 			for _, jsonTypesItem := range r.Config.Add.JSONTypes {
@@ -378,12 +378,12 @@ func (r *GatewayPluginResponseTransformerResourceModel) ToSharedResponseTransfor
 		var append1 *shared.ResponseTransformerPluginAppend
 		if r.Config.Append != nil {
 			headers1 := make([]string, 0, len(r.Config.Append.Headers))
-			for _, headersItem1 := range r.Config.Append.Headers {
-				headers1 = append(headers1, headersItem1.ValueString())
+			for headersIndex1 := range r.Config.Append.Headers {
+				headers1 = append(headers1, r.Config.Append.Headers[headersIndex1].ValueString())
 			}
 			jsonVar1 := make([]string, 0, len(r.Config.Append.JSON))
-			for _, jsonItem1 := range r.Config.Append.JSON {
-				jsonVar1 = append(jsonVar1, jsonItem1.ValueString())
+			for jsonIndex1 := range r.Config.Append.JSON {
+				jsonVar1 = append(jsonVar1, r.Config.Append.JSON[jsonIndex1].ValueString())
 			}
 			jsonTypes1 := make([]shared.ResponseTransformerPluginConfigJSONTypes, 0, len(r.Config.Append.JSONTypes))
 			for _, jsonTypesItem1 := range r.Config.Append.JSONTypes {
@@ -398,12 +398,12 @@ func (r *GatewayPluginResponseTransformerResourceModel) ToSharedResponseTransfor
 		var remove *shared.ResponseTransformerPluginRemove
 		if r.Config.Remove != nil {
 			headers2 := make([]string, 0, len(r.Config.Remove.Headers))
-			for _, headersItem2 := range r.Config.Remove.Headers {
-				headers2 = append(headers2, headersItem2.ValueString())
+			for headersIndex2 := range r.Config.Remove.Headers {
+				headers2 = append(headers2, r.Config.Remove.Headers[headersIndex2].ValueString())
 			}
 			jsonVar2 := make([]string, 0, len(r.Config.Remove.JSON))
-			for _, jsonItem2 := range r.Config.Remove.JSON {
-				jsonVar2 = append(jsonVar2, jsonItem2.ValueString())
+			for jsonIndex2 := range r.Config.Remove.JSON {
+				jsonVar2 = append(jsonVar2, r.Config.Remove.JSON[jsonIndex2].ValueString())
 			}
 			remove = &shared.ResponseTransformerPluginRemove{
 				Headers: headers2,
@@ -413,12 +413,12 @@ func (r *GatewayPluginResponseTransformerResourceModel) ToSharedResponseTransfor
 		var rename *shared.ResponseTransformerPluginRename
 		if r.Config.Rename != nil {
 			headers3 := make([]string, 0, len(r.Config.Rename.Headers))
-			for _, headersItem3 := range r.Config.Rename.Headers {
-				headers3 = append(headers3, headersItem3.ValueString())
+			for headersIndex3 := range r.Config.Rename.Headers {
+				headers3 = append(headers3, r.Config.Rename.Headers[headersIndex3].ValueString())
 			}
 			jsonVar3 := make([]string, 0, len(r.Config.Rename.JSON))
-			for _, jsonItem3 := range r.Config.Rename.JSON {
-				jsonVar3 = append(jsonVar3, jsonItem3.ValueString())
+			for jsonIndex3 := range r.Config.Rename.JSON {
+				jsonVar3 = append(jsonVar3, r.Config.Rename.JSON[jsonIndex3].ValueString())
 			}
 			rename = &shared.ResponseTransformerPluginRename{
 				Headers: headers3,
@@ -428,12 +428,12 @@ func (r *GatewayPluginResponseTransformerResourceModel) ToSharedResponseTransfor
 		var replace *shared.ResponseTransformerPluginReplace
 		if r.Config.Replace != nil {
 			headers4 := make([]string, 0, len(r.Config.Replace.Headers))
-			for _, headersItem4 := range r.Config.Replace.Headers {
-				headers4 = append(headers4, headersItem4.ValueString())
+			for headersIndex4 := range r.Config.Replace.Headers {
+				headers4 = append(headers4, r.Config.Replace.Headers[headersIndex4].ValueString())
 			}
 			jsonVar4 := make([]string, 0, len(r.Config.Replace.JSON))
-			for _, jsonItem4 := range r.Config.Replace.JSON {
-				jsonVar4 = append(jsonVar4, jsonItem4.ValueString())
+			for jsonIndex4 := range r.Config.Replace.JSON {
+				jsonVar4 = append(jsonVar4, r.Config.Replace.JSON[jsonIndex4].ValueString())
 			}
 			jsonTypes2 := make([]shared.ResponseTransformerPluginConfigReplaceJSONTypes, 0, len(r.Config.Replace.JSONTypes))
 			for _, jsonTypesItem2 := range r.Config.Replace.JSONTypes {

--- a/internal/provider/gatewaypluginresponsetransformeradvanced_resource.go
+++ b/internal/provider/gatewaypluginresponsetransformeradvanced_resource.go
@@ -778,7 +778,10 @@ func (r *GatewayPluginResponseTransformerAdvancedResource) Delete(ctx context.Co
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginresponsetransformeradvanced_resource_sdk.go
+++ b/internal/provider/gatewaypluginresponsetransformeradvanced_resource_sdk.go
@@ -335,8 +335,8 @@ func (r *GatewayPluginResponseTransformerAdvancedResourceModel) ToSharedResponse
 		var after *shared.ResponseTransformerAdvancedPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.ResponseTransformerAdvancedPluginAfter{
 				Access: access,
@@ -345,8 +345,8 @@ func (r *GatewayPluginResponseTransformerAdvancedResourceModel) ToSharedResponse
 		var before *shared.ResponseTransformerAdvancedPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.ResponseTransformerAdvancedPluginBefore{
 				Access: access1,
@@ -360,22 +360,22 @@ func (r *GatewayPluginResponseTransformerAdvancedResourceModel) ToSharedResponse
 	var partials []shared.ResponseTransformerAdvancedPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.ResponseTransformerAdvancedPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -389,8 +389,8 @@ func (r *GatewayPluginResponseTransformerAdvancedResourceModel) ToSharedResponse
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -404,16 +404,16 @@ func (r *GatewayPluginResponseTransformerAdvancedResourceModel) ToSharedResponse
 		var add *shared.ResponseTransformerAdvancedPluginAdd
 		if r.Config.Add != nil {
 			headers := make([]string, 0, len(r.Config.Add.Headers))
-			for _, headersItem := range r.Config.Add.Headers {
-				headers = append(headers, headersItem.ValueString())
+			for headersIndex := range r.Config.Add.Headers {
+				headers = append(headers, r.Config.Add.Headers[headersIndex].ValueString())
 			}
 			ifStatus := make([]string, 0, len(r.Config.Add.IfStatus))
-			for _, ifStatusItem := range r.Config.Add.IfStatus {
-				ifStatus = append(ifStatus, ifStatusItem.ValueString())
+			for ifStatusIndex := range r.Config.Add.IfStatus {
+				ifStatus = append(ifStatus, r.Config.Add.IfStatus[ifStatusIndex].ValueString())
 			}
 			jsonVar := make([]string, 0, len(r.Config.Add.JSON))
-			for _, jsonItem := range r.Config.Add.JSON {
-				jsonVar = append(jsonVar, jsonItem.ValueString())
+			for jsonIndex := range r.Config.Add.JSON {
+				jsonVar = append(jsonVar, r.Config.Add.JSON[jsonIndex].ValueString())
 			}
 			jsonTypes := make([]shared.ResponseTransformerAdvancedPluginJSONTypes, 0, len(r.Config.Add.JSONTypes))
 			for _, jsonTypesItem := range r.Config.Add.JSONTypes {
@@ -431,8 +431,8 @@ func (r *GatewayPluginResponseTransformerAdvancedResourceModel) ToSharedResponse
 			var jsonVar1 []string
 			if r.Config.Allow.JSON != nil {
 				jsonVar1 = make([]string, 0, len(r.Config.Allow.JSON))
-				for _, jsonItem1 := range r.Config.Allow.JSON {
-					jsonVar1 = append(jsonVar1, jsonItem1.ValueString())
+				for jsonIndex1 := range r.Config.Allow.JSON {
+					jsonVar1 = append(jsonVar1, r.Config.Allow.JSON[jsonIndex1].ValueString())
 				}
 			}
 			allow = &shared.ResponseTransformerAdvancedPluginAllow{
@@ -442,16 +442,16 @@ func (r *GatewayPluginResponseTransformerAdvancedResourceModel) ToSharedResponse
 		var append1 *shared.ResponseTransformerAdvancedPluginAppend
 		if r.Config.Append != nil {
 			headers1 := make([]string, 0, len(r.Config.Append.Headers))
-			for _, headersItem1 := range r.Config.Append.Headers {
-				headers1 = append(headers1, headersItem1.ValueString())
+			for headersIndex1 := range r.Config.Append.Headers {
+				headers1 = append(headers1, r.Config.Append.Headers[headersIndex1].ValueString())
 			}
 			ifStatus1 := make([]string, 0, len(r.Config.Append.IfStatus))
-			for _, ifStatusItem1 := range r.Config.Append.IfStatus {
-				ifStatus1 = append(ifStatus1, ifStatusItem1.ValueString())
+			for ifStatusIndex1 := range r.Config.Append.IfStatus {
+				ifStatus1 = append(ifStatus1, r.Config.Append.IfStatus[ifStatusIndex1].ValueString())
 			}
 			jsonVar2 := make([]string, 0, len(r.Config.Append.JSON))
-			for _, jsonItem2 := range r.Config.Append.JSON {
-				jsonVar2 = append(jsonVar2, jsonItem2.ValueString())
+			for jsonIndex2 := range r.Config.Append.JSON {
+				jsonVar2 = append(jsonVar2, r.Config.Append.JSON[jsonIndex2].ValueString())
 			}
 			jsonTypes1 := make([]shared.ResponseTransformerAdvancedPluginConfigJSONTypes, 0, len(r.Config.Append.JSONTypes))
 			for _, jsonTypesItem1 := range r.Config.Append.JSONTypes {
@@ -473,16 +473,16 @@ func (r *GatewayPluginResponseTransformerAdvancedResourceModel) ToSharedResponse
 		var remove *shared.ResponseTransformerAdvancedPluginRemove
 		if r.Config.Remove != nil {
 			headers2 := make([]string, 0, len(r.Config.Remove.Headers))
-			for _, headersItem2 := range r.Config.Remove.Headers {
-				headers2 = append(headers2, headersItem2.ValueString())
+			for headersIndex2 := range r.Config.Remove.Headers {
+				headers2 = append(headers2, r.Config.Remove.Headers[headersIndex2].ValueString())
 			}
 			ifStatus2 := make([]string, 0, len(r.Config.Remove.IfStatus))
-			for _, ifStatusItem2 := range r.Config.Remove.IfStatus {
-				ifStatus2 = append(ifStatus2, ifStatusItem2.ValueString())
+			for ifStatusIndex2 := range r.Config.Remove.IfStatus {
+				ifStatus2 = append(ifStatus2, r.Config.Remove.IfStatus[ifStatusIndex2].ValueString())
 			}
 			jsonVar3 := make([]string, 0, len(r.Config.Remove.JSON))
-			for _, jsonItem3 := range r.Config.Remove.JSON {
-				jsonVar3 = append(jsonVar3, jsonItem3.ValueString())
+			for jsonIndex3 := range r.Config.Remove.JSON {
+				jsonVar3 = append(jsonVar3, r.Config.Remove.JSON[jsonIndex3].ValueString())
 			}
 			remove = &shared.ResponseTransformerAdvancedPluginRemove{
 				Headers:  headers2,
@@ -493,12 +493,12 @@ func (r *GatewayPluginResponseTransformerAdvancedResourceModel) ToSharedResponse
 		var rename *shared.ResponseTransformerAdvancedPluginRename
 		if r.Config.Rename != nil {
 			headers3 := make([]string, 0, len(r.Config.Rename.Headers))
-			for _, headersItem3 := range r.Config.Rename.Headers {
-				headers3 = append(headers3, headersItem3.ValueString())
+			for headersIndex3 := range r.Config.Rename.Headers {
+				headers3 = append(headers3, r.Config.Rename.Headers[headersIndex3].ValueString())
 			}
 			ifStatus3 := make([]string, 0, len(r.Config.Rename.IfStatus))
-			for _, ifStatusItem3 := range r.Config.Rename.IfStatus {
-				ifStatus3 = append(ifStatus3, ifStatusItem3.ValueString())
+			for ifStatusIndex3 := range r.Config.Rename.IfStatus {
+				ifStatus3 = append(ifStatus3, r.Config.Rename.IfStatus[ifStatusIndex3].ValueString())
 			}
 			rename = &shared.ResponseTransformerAdvancedPluginRename{
 				Headers:  headers3,
@@ -514,16 +514,16 @@ func (r *GatewayPluginResponseTransformerAdvancedResourceModel) ToSharedResponse
 				body = nil
 			}
 			headers4 := make([]string, 0, len(r.Config.Replace.Headers))
-			for _, headersItem4 := range r.Config.Replace.Headers {
-				headers4 = append(headers4, headersItem4.ValueString())
+			for headersIndex4 := range r.Config.Replace.Headers {
+				headers4 = append(headers4, r.Config.Replace.Headers[headersIndex4].ValueString())
 			}
 			ifStatus4 := make([]string, 0, len(r.Config.Replace.IfStatus))
-			for _, ifStatusItem4 := range r.Config.Replace.IfStatus {
-				ifStatus4 = append(ifStatus4, ifStatusItem4.ValueString())
+			for ifStatusIndex4 := range r.Config.Replace.IfStatus {
+				ifStatus4 = append(ifStatus4, r.Config.Replace.IfStatus[ifStatusIndex4].ValueString())
 			}
 			jsonVar4 := make([]string, 0, len(r.Config.Replace.JSON))
-			for _, jsonItem4 := range r.Config.Replace.JSON {
-				jsonVar4 = append(jsonVar4, jsonItem4.ValueString())
+			for jsonIndex4 := range r.Config.Replace.JSON {
+				jsonVar4 = append(jsonVar4, r.Config.Replace.JSON[jsonIndex4].ValueString())
 			}
 			jsonTypes2 := make([]shared.ResponseTransformerAdvancedPluginConfigReplaceJSONTypes, 0, len(r.Config.Replace.JSONTypes))
 			for _, jsonTypesItem2 := range r.Config.Replace.JSONTypes {
@@ -540,16 +540,16 @@ func (r *GatewayPluginResponseTransformerAdvancedResourceModel) ToSharedResponse
 		var transform *shared.Transform
 		if r.Config.Transform != nil {
 			functions := make([]string, 0, len(r.Config.Transform.Functions))
-			for _, functionsItem := range r.Config.Transform.Functions {
-				functions = append(functions, functionsItem.ValueString())
+			for functionsIndex := range r.Config.Transform.Functions {
+				functions = append(functions, r.Config.Transform.Functions[functionsIndex].ValueString())
 			}
 			ifStatus5 := make([]string, 0, len(r.Config.Transform.IfStatus))
-			for _, ifStatusItem5 := range r.Config.Transform.IfStatus {
-				ifStatus5 = append(ifStatus5, ifStatusItem5.ValueString())
+			for ifStatusIndex5 := range r.Config.Transform.IfStatus {
+				ifStatus5 = append(ifStatus5, r.Config.Transform.IfStatus[ifStatusIndex5].ValueString())
 			}
 			jsonVar5 := make([]string, 0, len(r.Config.Transform.JSON))
-			for _, jsonItem5 := range r.Config.Transform.JSON {
-				jsonVar5 = append(jsonVar5, jsonItem5.ValueString())
+			for jsonIndex5 := range r.Config.Transform.JSON {
+				jsonVar5 = append(jsonVar5, r.Config.Transform.JSON[jsonIndex5].ValueString())
 			}
 			transform = &shared.Transform{
 				Functions: functions,

--- a/internal/provider/gatewaypluginroutebyheader_resource.go
+++ b/internal/provider/gatewaypluginroutebyheader_resource.go
@@ -508,7 +508,10 @@ func (r *GatewayPluginRouteByHeaderResource) Delete(ctx context.Context, req res
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginroutebyheader_resource_sdk.go
+++ b/internal/provider/gatewaypluginroutebyheader_resource_sdk.go
@@ -221,8 +221,8 @@ func (r *GatewayPluginRouteByHeaderResourceModel) ToSharedRouteByHeaderPlugin(ct
 		var after *shared.RouteByHeaderPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.RouteByHeaderPluginAfter{
 				Access: access,
@@ -231,8 +231,8 @@ func (r *GatewayPluginRouteByHeaderResourceModel) ToSharedRouteByHeaderPlugin(ct
 		var before *shared.RouteByHeaderPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.RouteByHeaderPluginBefore{
 				Access: access1,
@@ -246,22 +246,22 @@ func (r *GatewayPluginRouteByHeaderResourceModel) ToSharedRouteByHeaderPlugin(ct
 	var partials []shared.RouteByHeaderPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.RouteByHeaderPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -275,8 +275,8 @@ func (r *GatewayPluginRouteByHeaderResourceModel) ToSharedRouteByHeaderPlugin(ct
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -288,19 +288,19 @@ func (r *GatewayPluginRouteByHeaderResourceModel) ToSharedRouteByHeaderPlugin(ct
 	var config *shared.RouteByHeaderPluginConfig
 	if r.Config != nil {
 		rules := make([]shared.RouteByHeaderPluginRules, 0, len(r.Config.Rules))
-		for _, rulesItem := range r.Config.Rules {
+		for rulesIndex := range r.Config.Rules {
 			var condition map[string]string
-			if rulesItem.Condition != nil {
+			if r.Config.Rules[rulesIndex].Condition != nil {
 				condition = make(map[string]string)
-				for conditionKey, conditionValue := range rulesItem.Condition {
+				for conditionKey := range r.Config.Rules[rulesIndex].Condition {
 					var conditionInst string
-					conditionInst = conditionValue.ValueString()
+					conditionInst = r.Config.Rules[rulesIndex].Condition[conditionKey].ValueString()
 
 					condition[conditionKey] = conditionInst
 				}
 			}
 			var upstreamName string
-			upstreamName = rulesItem.UpstreamName.ValueString()
+			upstreamName = r.Config.Rules[rulesIndex].UpstreamName.ValueString()
 
 			rules = append(rules, shared.RouteByHeaderPluginRules{
 				Condition:    condition,

--- a/internal/provider/gatewaypluginroutetransformeradvanced_resource.go
+++ b/internal/provider/gatewaypluginroutetransformeradvanced_resource.go
@@ -492,7 +492,10 @@ func (r *GatewayPluginRouteTransformerAdvancedResource) Delete(ctx context.Conte
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginroutetransformeradvanced_resource_sdk.go
+++ b/internal/provider/gatewaypluginroutetransformeradvanced_resource_sdk.go
@@ -210,8 +210,8 @@ func (r *GatewayPluginRouteTransformerAdvancedResourceModel) ToSharedRouteTransf
 		var after *shared.RouteTransformerAdvancedPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.RouteTransformerAdvancedPluginAfter{
 				Access: access,
@@ -220,8 +220,8 @@ func (r *GatewayPluginRouteTransformerAdvancedResourceModel) ToSharedRouteTransf
 		var before *shared.RouteTransformerAdvancedPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.RouteTransformerAdvancedPluginBefore{
 				Access: access1,
@@ -235,22 +235,22 @@ func (r *GatewayPluginRouteTransformerAdvancedResourceModel) ToSharedRouteTransf
 	var partials []shared.RouteTransformerAdvancedPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.RouteTransformerAdvancedPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -264,8 +264,8 @@ func (r *GatewayPluginRouteTransformerAdvancedResourceModel) ToSharedRouteTransf
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)

--- a/internal/provider/gatewaypluginsaml_resource.go
+++ b/internal/provider/gatewaypluginsaml_resource.go
@@ -954,7 +954,10 @@ func (r *GatewayPluginSamlResource) Delete(ctx context.Context, req resource.Del
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginsaml_resource_sdk.go
+++ b/internal/provider/gatewaypluginsaml_resource_sdk.go
@@ -327,8 +327,8 @@ func (r *GatewayPluginSamlResourceModel) ToSharedSamlPlugin(ctx context.Context)
 		var after *shared.SamlPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.SamlPluginAfter{
 				Access: access,
@@ -337,8 +337,8 @@ func (r *GatewayPluginSamlResourceModel) ToSharedSamlPlugin(ctx context.Context)
 		var before *shared.SamlPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.SamlPluginBefore{
 				Access: access1,
@@ -352,22 +352,22 @@ func (r *GatewayPluginSamlResourceModel) ToSharedSamlPlugin(ctx context.Context)
 	var partials []shared.SamlPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.SamlPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -381,8 +381,8 @@ func (r *GatewayPluginSamlResourceModel) ToSharedSamlPlugin(ctx context.Context)
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -429,16 +429,16 @@ func (r *GatewayPluginSamlResourceModel) ToSharedSamlPlugin(ctx context.Context)
 		var clusterNodes []shared.SamlPluginClusterNodes
 		if r.Config.Redis.ClusterNodes != nil {
 			clusterNodes = make([]shared.SamlPluginClusterNodes, 0, len(r.Config.Redis.ClusterNodes))
-			for _, clusterNodesItem := range r.Config.Redis.ClusterNodes {
+			for clusterNodesIndex := range r.Config.Redis.ClusterNodes {
 				ip := new(string)
-				if !clusterNodesItem.IP.IsUnknown() && !clusterNodesItem.IP.IsNull() {
-					*ip = clusterNodesItem.IP.ValueString()
+				if !r.Config.Redis.ClusterNodes[clusterNodesIndex].IP.IsUnknown() && !r.Config.Redis.ClusterNodes[clusterNodesIndex].IP.IsNull() {
+					*ip = r.Config.Redis.ClusterNodes[clusterNodesIndex].IP.ValueString()
 				} else {
 					ip = nil
 				}
 				port := new(int64)
-				if !clusterNodesItem.Port.IsUnknown() && !clusterNodesItem.Port.IsNull() {
-					*port = clusterNodesItem.Port.ValueInt64()
+				if !r.Config.Redis.ClusterNodes[clusterNodesIndex].Port.IsUnknown() && !r.Config.Redis.ClusterNodes[clusterNodesIndex].Port.IsNull() {
+					*port = r.Config.Redis.ClusterNodes[clusterNodesIndex].Port.ValueInt64()
 				} else {
 					port = nil
 				}
@@ -523,16 +523,16 @@ func (r *GatewayPluginSamlResourceModel) ToSharedSamlPlugin(ctx context.Context)
 		var sentinelNodes []shared.SamlPluginSentinelNodes
 		if r.Config.Redis.SentinelNodes != nil {
 			sentinelNodes = make([]shared.SamlPluginSentinelNodes, 0, len(r.Config.Redis.SentinelNodes))
-			for _, sentinelNodesItem := range r.Config.Redis.SentinelNodes {
+			for sentinelNodesIndex := range r.Config.Redis.SentinelNodes {
 				host1 := new(string)
-				if !sentinelNodesItem.Host.IsUnknown() && !sentinelNodesItem.Host.IsNull() {
-					*host1 = sentinelNodesItem.Host.ValueString()
+				if !r.Config.Redis.SentinelNodes[sentinelNodesIndex].Host.IsUnknown() && !r.Config.Redis.SentinelNodes[sentinelNodesIndex].Host.IsNull() {
+					*host1 = r.Config.Redis.SentinelNodes[sentinelNodesIndex].Host.ValueString()
 				} else {
 					host1 = nil
 				}
 				port2 := new(int64)
-				if !sentinelNodesItem.Port.IsUnknown() && !sentinelNodesItem.Port.IsNull() {
-					*port2 = sentinelNodesItem.Port.ValueInt64()
+				if !r.Config.Redis.SentinelNodes[sentinelNodesIndex].Port.IsUnknown() && !r.Config.Redis.SentinelNodes[sentinelNodesIndex].Port.IsNull() {
+					*port2 = r.Config.Redis.SentinelNodes[sentinelNodesIndex].Port.ValueInt64()
 				} else {
 					port2 = nil
 				}

--- a/internal/provider/gatewaypluginserviceprotection_resource.go
+++ b/internal/provider/gatewaypluginserviceprotection_resource.go
@@ -748,7 +748,10 @@ func (r *GatewayPluginServiceProtectionResource) Delete(ctx context.Context, req
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginserviceprotection_resource_sdk.go
+++ b/internal/provider/gatewaypluginserviceprotection_resource_sdk.go
@@ -268,8 +268,8 @@ func (r *GatewayPluginServiceProtectionResourceModel) ToSharedServiceProtectionP
 		var after *shared.ServiceProtectionPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.ServiceProtectionPluginAfter{
 				Access: access,
@@ -278,8 +278,8 @@ func (r *GatewayPluginServiceProtectionResourceModel) ToSharedServiceProtectionP
 		var before *shared.ServiceProtectionPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.ServiceProtectionPluginBefore{
 				Access: access1,
@@ -293,22 +293,22 @@ func (r *GatewayPluginServiceProtectionResourceModel) ToSharedServiceProtectionP
 	var partials []shared.ServiceProtectionPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.ServiceProtectionPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -322,8 +322,8 @@ func (r *GatewayPluginServiceProtectionResourceModel) ToSharedServiceProtectionP
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -363,8 +363,8 @@ func (r *GatewayPluginServiceProtectionResourceModel) ToSharedServiceProtectionP
 		hideClientHeaders = nil
 	}
 	limit := make([]float64, 0, len(r.Config.Limit))
-	for _, limitItem := range r.Config.Limit {
-		limit = append(limit, limitItem.ValueFloat64())
+	for limitIndex := range r.Config.Limit {
+		limit = append(limit, r.Config.Limit[limitIndex].ValueFloat64())
 	}
 	lockDictionaryName := new(string)
 	if !r.Config.LockDictionaryName.IsUnknown() && !r.Config.LockDictionaryName.IsNull() {
@@ -389,16 +389,16 @@ func (r *GatewayPluginServiceProtectionResourceModel) ToSharedServiceProtectionP
 		var clusterNodes []shared.ServiceProtectionPluginClusterNodes
 		if r.Config.Redis.ClusterNodes != nil {
 			clusterNodes = make([]shared.ServiceProtectionPluginClusterNodes, 0, len(r.Config.Redis.ClusterNodes))
-			for _, clusterNodesItem := range r.Config.Redis.ClusterNodes {
+			for clusterNodesIndex := range r.Config.Redis.ClusterNodes {
 				ip := new(string)
-				if !clusterNodesItem.IP.IsUnknown() && !clusterNodesItem.IP.IsNull() {
-					*ip = clusterNodesItem.IP.ValueString()
+				if !r.Config.Redis.ClusterNodes[clusterNodesIndex].IP.IsUnknown() && !r.Config.Redis.ClusterNodes[clusterNodesIndex].IP.IsNull() {
+					*ip = r.Config.Redis.ClusterNodes[clusterNodesIndex].IP.ValueString()
 				} else {
 					ip = nil
 				}
 				port := new(int64)
-				if !clusterNodesItem.Port.IsUnknown() && !clusterNodesItem.Port.IsNull() {
-					*port = clusterNodesItem.Port.ValueInt64()
+				if !r.Config.Redis.ClusterNodes[clusterNodesIndex].Port.IsUnknown() && !r.Config.Redis.ClusterNodes[clusterNodesIndex].Port.IsNull() {
+					*port = r.Config.Redis.ClusterNodes[clusterNodesIndex].Port.ValueInt64()
 				} else {
 					port = nil
 				}
@@ -477,16 +477,16 @@ func (r *GatewayPluginServiceProtectionResourceModel) ToSharedServiceProtectionP
 		var sentinelNodes []shared.ServiceProtectionPluginSentinelNodes
 		if r.Config.Redis.SentinelNodes != nil {
 			sentinelNodes = make([]shared.ServiceProtectionPluginSentinelNodes, 0, len(r.Config.Redis.SentinelNodes))
-			for _, sentinelNodesItem := range r.Config.Redis.SentinelNodes {
+			for sentinelNodesIndex := range r.Config.Redis.SentinelNodes {
 				host1 := new(string)
-				if !sentinelNodesItem.Host.IsUnknown() && !sentinelNodesItem.Host.IsNull() {
-					*host1 = sentinelNodesItem.Host.ValueString()
+				if !r.Config.Redis.SentinelNodes[sentinelNodesIndex].Host.IsUnknown() && !r.Config.Redis.SentinelNodes[sentinelNodesIndex].Host.IsNull() {
+					*host1 = r.Config.Redis.SentinelNodes[sentinelNodesIndex].Host.ValueString()
 				} else {
 					host1 = nil
 				}
 				port2 := new(int64)
-				if !sentinelNodesItem.Port.IsUnknown() && !sentinelNodesItem.Port.IsNull() {
-					*port2 = sentinelNodesItem.Port.ValueInt64()
+				if !r.Config.Redis.SentinelNodes[sentinelNodesIndex].Port.IsUnknown() && !r.Config.Redis.SentinelNodes[sentinelNodesIndex].Port.IsNull() {
+					*port2 = r.Config.Redis.SentinelNodes[sentinelNodesIndex].Port.ValueInt64()
 				} else {
 					port2 = nil
 				}
@@ -581,8 +581,8 @@ func (r *GatewayPluginServiceProtectionResourceModel) ToSharedServiceProtectionP
 		syncRate = nil
 	}
 	windowSize := make([]float64, 0, len(r.Config.WindowSize))
-	for _, windowSizeItem := range r.Config.WindowSize {
-		windowSize = append(windowSize, windowSizeItem.ValueFloat64())
+	for windowSizeIndex := range r.Config.WindowSize {
+		windowSize = append(windowSize, r.Config.WindowSize[windowSizeIndex].ValueFloat64())
 	}
 	windowType := new(shared.ServiceProtectionPluginWindowType)
 	if !r.Config.WindowType.IsUnknown() && !r.Config.WindowType.IsNull() {

--- a/internal/provider/gatewaypluginsession_resource.go
+++ b/internal/provider/gatewaypluginsession_resource.go
@@ -662,7 +662,10 @@ func (r *GatewayPluginSessionResource) Delete(ctx context.Context, req resource.
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginsession_resource_sdk.go
+++ b/internal/provider/gatewaypluginsession_resource_sdk.go
@@ -252,8 +252,8 @@ func (r *GatewayPluginSessionResourceModel) ToSharedSessionPlugin(ctx context.Co
 		var after *shared.SessionPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.SessionPluginAfter{
 				Access: access,
@@ -262,8 +262,8 @@ func (r *GatewayPluginSessionResourceModel) ToSharedSessionPlugin(ctx context.Co
 		var before *shared.SessionPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.SessionPluginBefore{
 				Access: access1,
@@ -277,22 +277,22 @@ func (r *GatewayPluginSessionResourceModel) ToSharedSessionPlugin(ctx context.Co
 	var partials []shared.SessionPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.SessionPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -306,8 +306,8 @@ func (r *GatewayPluginSessionResourceModel) ToSharedSessionPlugin(ctx context.Co
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)

--- a/internal/provider/gatewaypluginsolaceconsume_resource.go
+++ b/internal/provider/gatewaypluginsolaceconsume_resource.go
@@ -724,7 +724,10 @@ func (r *GatewayPluginSolaceConsumeResource) Delete(ctx context.Context, req res
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginsolaceconsume_resource_sdk.go
+++ b/internal/provider/gatewaypluginsolaceconsume_resource_sdk.go
@@ -280,8 +280,8 @@ func (r *GatewayPluginSolaceConsumeResourceModel) ToSharedSolaceConsumePlugin(ct
 		var after *shared.SolaceConsumePluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.SolaceConsumePluginAfter{
 				Access: access,
@@ -290,8 +290,8 @@ func (r *GatewayPluginSolaceConsumeResourceModel) ToSharedSolaceConsumePlugin(ct
 		var before *shared.SolaceConsumePluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.SolaceConsumePluginBefore{
 				Access: access1,
@@ -305,22 +305,22 @@ func (r *GatewayPluginSolaceConsumeResourceModel) ToSharedSolaceConsumePlugin(ct
 	var partials []shared.SolaceConsumePluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.SolaceConsumePluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -334,8 +334,8 @@ func (r *GatewayPluginSolaceConsumeResourceModel) ToSharedSolaceConsumePlugin(ct
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -351,13 +351,13 @@ func (r *GatewayPluginSolaceConsumeResourceModel) ToSharedSolaceConsumePlugin(ct
 		ackMode = nil
 	}
 	binds := make([]shared.Binds, 0, len(r.Config.Flow.Binds))
-	for _, bindsItem := range r.Config.Flow.Binds {
+	for bindsIndex := range r.Config.Flow.Binds {
 		var name1 string
-		name1 = bindsItem.Name.ValueString()
+		name1 = r.Config.Flow.Binds[bindsIndex].Name.ValueString()
 
 		typeVar := new(shared.SolaceConsumePluginType)
-		if !bindsItem.Type.IsUnknown() && !bindsItem.Type.IsNull() {
-			*typeVar = shared.SolaceConsumePluginType(bindsItem.Type.ValueString())
+		if !r.Config.Flow.Binds[bindsIndex].Type.IsUnknown() && !r.Config.Flow.Binds[bindsIndex].Type.IsNull() {
+			*typeVar = shared.SolaceConsumePluginType(r.Config.Flow.Binds[bindsIndex].Type.ValueString())
 		} else {
 			typeVar = nil
 		}
@@ -369,8 +369,8 @@ func (r *GatewayPluginSolaceConsumeResourceModel) ToSharedSolaceConsumePlugin(ct
 	var functions []string
 	if r.Config.Flow.Functions != nil {
 		functions = make([]string, 0, len(r.Config.Flow.Functions))
-		for _, functionsItem := range r.Config.Flow.Functions {
-			functions = append(functions, functionsItem.ValueString())
+		for functionsIndex := range r.Config.Flow.Functions {
+			functions = append(functions, r.Config.Flow.Functions[functionsIndex].ValueString())
 		}
 	}
 	maxUnackedMessages := new(int64)
@@ -382,9 +382,9 @@ func (r *GatewayPluginSolaceConsumeResourceModel) ToSharedSolaceConsumePlugin(ct
 	var properties map[string]string
 	if r.Config.Flow.Properties != nil {
 		properties = make(map[string]string)
-		for propertiesKey, propertiesValue := range r.Config.Flow.Properties {
+		for propertiesKey := range r.Config.Flow.Properties {
 			var propertiesInst string
-			propertiesInst = propertiesValue.ValueString()
+			propertiesInst = r.Config.Flow.Properties[propertiesKey].ValueString()
 
 			properties[propertiesKey] = propertiesInst
 		}
@@ -531,9 +531,9 @@ func (r *GatewayPluginSolaceConsumeResourceModel) ToSharedSolaceConsumePlugin(ct
 	var properties1 map[string]string
 	if r.Config.Session.Properties != nil {
 		properties1 = make(map[string]string)
-		for propertiesKey1, propertiesValue1 := range r.Config.Session.Properties {
+		for propertiesKey1 := range r.Config.Session.Properties {
 			var propertiesInst1 string
-			propertiesInst1 = propertiesValue1.ValueString()
+			propertiesInst1 = r.Config.Session.Properties[propertiesKey1].ValueString()
 
 			properties1[propertiesKey1] = propertiesInst1
 		}

--- a/internal/provider/gatewaypluginsolacelog_resource.go
+++ b/internal/provider/gatewaypluginsolacelog_resource.go
@@ -685,7 +685,10 @@ func (r *GatewayPluginSolaceLogResource) Delete(ctx context.Context, req resourc
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginsolacelog_resource_sdk.go
+++ b/internal/provider/gatewaypluginsolacelog_resource_sdk.go
@@ -258,8 +258,8 @@ func (r *GatewayPluginSolaceLogResourceModel) ToSharedSolaceLogPlugin(ctx contex
 		var after *shared.SolaceLogPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.SolaceLogPluginAfter{
 				Access: access,
@@ -268,8 +268,8 @@ func (r *GatewayPluginSolaceLogResourceModel) ToSharedSolaceLogPlugin(ctx contex
 		var before *shared.SolaceLogPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.SolaceLogPluginBefore{
 				Access: access1,
@@ -283,22 +283,22 @@ func (r *GatewayPluginSolaceLogResourceModel) ToSharedSolaceLogPlugin(ctx contex
 	var partials []shared.SolaceLogPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.SolaceLogPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -312,8 +312,8 @@ func (r *GatewayPluginSolaceLogResourceModel) ToSharedSolaceLogPlugin(ctx contex
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -331,9 +331,9 @@ func (r *GatewayPluginSolaceLogResourceModel) ToSharedSolaceLogPlugin(ctx contex
 	var customFieldsByLua map[string]string
 	if r.Config.Message.CustomFieldsByLua != nil {
 		customFieldsByLua = make(map[string]string)
-		for customFieldsByLuaKey, customFieldsByLuaValue := range r.Config.Message.CustomFieldsByLua {
+		for customFieldsByLuaKey := range r.Config.Message.CustomFieldsByLua {
 			var customFieldsByLuaInst string
-			customFieldsByLuaInst = customFieldsByLuaValue.ValueString()
+			customFieldsByLuaInst = r.Config.Message.CustomFieldsByLua[customFieldsByLuaKey].ValueString()
 
 			customFieldsByLua[customFieldsByLuaKey] = customFieldsByLuaInst
 		}
@@ -345,13 +345,13 @@ func (r *GatewayPluginSolaceLogResourceModel) ToSharedSolaceLogPlugin(ctx contex
 		deliveryMode = nil
 	}
 	destinations := make([]shared.SolaceLogPluginDestinations, 0, len(r.Config.Message.Destinations))
-	for _, destinationsItem := range r.Config.Message.Destinations {
+	for destinationsIndex := range r.Config.Message.Destinations {
 		var name1 string
-		name1 = destinationsItem.Name.ValueString()
+		name1 = r.Config.Message.Destinations[destinationsIndex].Name.ValueString()
 
 		typeVar := new(shared.SolaceLogPluginType)
-		if !destinationsItem.Type.IsUnknown() && !destinationsItem.Type.IsNull() {
-			*typeVar = shared.SolaceLogPluginType(destinationsItem.Type.ValueString())
+		if !r.Config.Message.Destinations[destinationsIndex].Type.IsUnknown() && !r.Config.Message.Destinations[destinationsIndex].Type.IsNull() {
+			*typeVar = shared.SolaceLogPluginType(r.Config.Message.Destinations[destinationsIndex].Type.ValueString())
 		} else {
 			typeVar = nil
 		}
@@ -504,9 +504,9 @@ func (r *GatewayPluginSolaceLogResourceModel) ToSharedSolaceLogPlugin(ctx contex
 	var properties map[string]string
 	if r.Config.Session.Properties != nil {
 		properties = make(map[string]string)
-		for propertiesKey, propertiesValue := range r.Config.Session.Properties {
+		for propertiesKey := range r.Config.Session.Properties {
 			var propertiesInst string
-			propertiesInst = propertiesValue.ValueString()
+			propertiesInst = r.Config.Session.Properties[propertiesKey].ValueString()
 
 			properties[propertiesKey] = propertiesInst
 		}

--- a/internal/provider/gatewaypluginsolaceupstream_resource.go
+++ b/internal/provider/gatewaypluginsolaceupstream_resource.go
@@ -711,7 +711,10 @@ func (r *GatewayPluginSolaceUpstreamResource) Delete(ctx context.Context, req re
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginsolaceupstream_resource_sdk.go
+++ b/internal/provider/gatewaypluginsolaceupstream_resource_sdk.go
@@ -263,8 +263,8 @@ func (r *GatewayPluginSolaceUpstreamResourceModel) ToSharedSolaceUpstreamPlugin(
 		var after *shared.SolaceUpstreamPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.SolaceUpstreamPluginAfter{
 				Access: access,
@@ -273,8 +273,8 @@ func (r *GatewayPluginSolaceUpstreamResourceModel) ToSharedSolaceUpstreamPlugin(
 		var before *shared.SolaceUpstreamPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.SolaceUpstreamPluginBefore{
 				Access: access1,
@@ -288,22 +288,22 @@ func (r *GatewayPluginSolaceUpstreamResourceModel) ToSharedSolaceUpstreamPlugin(
 	var partials []shared.SolaceUpstreamPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.SolaceUpstreamPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -317,8 +317,8 @@ func (r *GatewayPluginSolaceUpstreamResourceModel) ToSharedSolaceUpstreamPlugin(
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -346,13 +346,13 @@ func (r *GatewayPluginSolaceUpstreamResourceModel) ToSharedSolaceUpstreamPlugin(
 		deliveryMode = nil
 	}
 	destinations := make([]shared.SolaceUpstreamPluginDestinations, 0, len(r.Config.Message.Destinations))
-	for _, destinationsItem := range r.Config.Message.Destinations {
+	for destinationsIndex := range r.Config.Message.Destinations {
 		var name1 string
-		name1 = destinationsItem.Name.ValueString()
+		name1 = r.Config.Message.Destinations[destinationsIndex].Name.ValueString()
 
 		typeVar := new(shared.SolaceUpstreamPluginType)
-		if !destinationsItem.Type.IsUnknown() && !destinationsItem.Type.IsNull() {
-			*typeVar = shared.SolaceUpstreamPluginType(destinationsItem.Type.ValueString())
+		if !r.Config.Message.Destinations[destinationsIndex].Type.IsUnknown() && !r.Config.Message.Destinations[destinationsIndex].Type.IsNull() {
+			*typeVar = shared.SolaceUpstreamPluginType(r.Config.Message.Destinations[destinationsIndex].Type.ValueString())
 		} else {
 			typeVar = nil
 		}
@@ -394,8 +394,8 @@ func (r *GatewayPluginSolaceUpstreamResourceModel) ToSharedSolaceUpstreamPlugin(
 	var functions []string
 	if r.Config.Message.Functions != nil {
 		functions = make([]string, 0, len(r.Config.Message.Functions))
-		for _, functionsItem := range r.Config.Message.Functions {
-			functions = append(functions, functionsItem.ValueString())
+		for functionsIndex := range r.Config.Message.Functions {
+			functions = append(functions, r.Config.Message.Functions[functionsIndex].ValueString())
 		}
 	}
 	priority := new(int64)
@@ -541,9 +541,9 @@ func (r *GatewayPluginSolaceUpstreamResourceModel) ToSharedSolaceUpstreamPlugin(
 	var properties map[string]string
 	if r.Config.Session.Properties != nil {
 		properties = make(map[string]string)
-		for propertiesKey, propertiesValue := range r.Config.Session.Properties {
+		for propertiesKey := range r.Config.Session.Properties {
 			var propertiesInst string
-			propertiesInst = propertiesValue.ValueString()
+			propertiesInst = r.Config.Session.Properties[propertiesKey].ValueString()
 
 			properties[propertiesKey] = propertiesInst
 		}

--- a/internal/provider/gatewaypluginstandardwebhooks_resource.go
+++ b/internal/provider/gatewaypluginstandardwebhooks_resource.go
@@ -481,7 +481,10 @@ func (r *GatewayPluginStandardWebhooksResource) Delete(ctx context.Context, req 
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginstandardwebhooks_resource_sdk.go
+++ b/internal/provider/gatewaypluginstandardwebhooks_resource_sdk.go
@@ -203,8 +203,8 @@ func (r *GatewayPluginStandardWebhooksResourceModel) ToSharedStandardWebhooksPlu
 		var after *shared.StandardWebhooksPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.StandardWebhooksPluginAfter{
 				Access: access,
@@ -213,8 +213,8 @@ func (r *GatewayPluginStandardWebhooksResourceModel) ToSharedStandardWebhooksPlu
 		var before *shared.StandardWebhooksPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.StandardWebhooksPluginBefore{
 				Access: access1,
@@ -228,22 +228,22 @@ func (r *GatewayPluginStandardWebhooksResourceModel) ToSharedStandardWebhooksPlu
 	var partials []shared.StandardWebhooksPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.StandardWebhooksPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -257,8 +257,8 @@ func (r *GatewayPluginStandardWebhooksResourceModel) ToSharedStandardWebhooksPlu
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)

--- a/internal/provider/gatewaypluginstatsd_resource.go
+++ b/internal/provider/gatewaypluginstatsd_resource.go
@@ -798,7 +798,10 @@ func (r *GatewayPluginStatsdResource) Delete(ctx context.Context, req resource.D
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginstatsd_resource_sdk.go
+++ b/internal/provider/gatewaypluginstatsd_resource_sdk.go
@@ -286,8 +286,8 @@ func (r *GatewayPluginStatsdResourceModel) ToSharedStatsdPlugin(ctx context.Cont
 		var after *shared.StatsdPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.StatsdPluginAfter{
 				Access: access,
@@ -296,8 +296,8 @@ func (r *GatewayPluginStatsdResourceModel) ToSharedStatsdPlugin(ctx context.Cont
 		var before *shared.StatsdPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.StatsdPluginBefore{
 				Access: access1,
@@ -311,22 +311,22 @@ func (r *GatewayPluginStatsdResourceModel) ToSharedStatsdPlugin(ctx context.Cont
 	var partials []shared.StatsdPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.StatsdPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -340,8 +340,8 @@ func (r *GatewayPluginStatsdResourceModel) ToSharedStatsdPlugin(ctx context.Cont
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -355,8 +355,8 @@ func (r *GatewayPluginStatsdResourceModel) ToSharedStatsdPlugin(ctx context.Cont
 		var allowStatusCodes []string
 		if r.Config.AllowStatusCodes != nil {
 			allowStatusCodes = make([]string, 0, len(r.Config.AllowStatusCodes))
-			for _, allowStatusCodesItem := range r.Config.AllowStatusCodes {
-				allowStatusCodes = append(allowStatusCodes, allowStatusCodesItem.ValueString())
+			for allowStatusCodesIndex := range r.Config.AllowStatusCodes {
+				allowStatusCodes = append(allowStatusCodes, r.Config.AllowStatusCodes[allowStatusCodesIndex].ValueString())
 			}
 		}
 		consumerIdentifierDefault := new(shared.ConsumerIdentifierDefault)
@@ -386,30 +386,30 @@ func (r *GatewayPluginStatsdResourceModel) ToSharedStatsdPlugin(ctx context.Cont
 		var metrics []shared.StatsdPluginMetrics
 		if r.Config.Metrics != nil {
 			metrics = make([]shared.StatsdPluginMetrics, 0, len(r.Config.Metrics))
-			for _, metricsItem := range r.Config.Metrics {
+			for metricsIndex := range r.Config.Metrics {
 				consumerIdentifier := new(shared.StatsdPluginConsumerIdentifier)
-				if !metricsItem.ConsumerIdentifier.IsUnknown() && !metricsItem.ConsumerIdentifier.IsNull() {
-					*consumerIdentifier = shared.StatsdPluginConsumerIdentifier(metricsItem.ConsumerIdentifier.ValueString())
+				if !r.Config.Metrics[metricsIndex].ConsumerIdentifier.IsUnknown() && !r.Config.Metrics[metricsIndex].ConsumerIdentifier.IsNull() {
+					*consumerIdentifier = shared.StatsdPluginConsumerIdentifier(r.Config.Metrics[metricsIndex].ConsumerIdentifier.ValueString())
 				} else {
 					consumerIdentifier = nil
 				}
-				name1 := shared.StatsdPluginName(metricsItem.Name.ValueString())
+				name1 := shared.StatsdPluginName(r.Config.Metrics[metricsIndex].Name.ValueString())
 				sampleRate := new(float64)
-				if !metricsItem.SampleRate.IsUnknown() && !metricsItem.SampleRate.IsNull() {
-					*sampleRate = metricsItem.SampleRate.ValueFloat64()
+				if !r.Config.Metrics[metricsIndex].SampleRate.IsUnknown() && !r.Config.Metrics[metricsIndex].SampleRate.IsNull() {
+					*sampleRate = r.Config.Metrics[metricsIndex].SampleRate.ValueFloat64()
 				} else {
 					sampleRate = nil
 				}
 				serviceIdentifier := new(shared.ServiceIdentifier)
-				if !metricsItem.ServiceIdentifier.IsUnknown() && !metricsItem.ServiceIdentifier.IsNull() {
-					*serviceIdentifier = shared.ServiceIdentifier(metricsItem.ServiceIdentifier.ValueString())
+				if !r.Config.Metrics[metricsIndex].ServiceIdentifier.IsUnknown() && !r.Config.Metrics[metricsIndex].ServiceIdentifier.IsNull() {
+					*serviceIdentifier = shared.ServiceIdentifier(r.Config.Metrics[metricsIndex].ServiceIdentifier.ValueString())
 				} else {
 					serviceIdentifier = nil
 				}
-				statType := shared.StatsdPluginStatType(metricsItem.StatType.ValueString())
+				statType := shared.StatsdPluginStatType(r.Config.Metrics[metricsIndex].StatType.ValueString())
 				workspaceIdentifier := new(shared.WorkspaceIdentifier)
-				if !metricsItem.WorkspaceIdentifier.IsUnknown() && !metricsItem.WorkspaceIdentifier.IsNull() {
-					*workspaceIdentifier = shared.WorkspaceIdentifier(metricsItem.WorkspaceIdentifier.ValueString())
+				if !r.Config.Metrics[metricsIndex].WorkspaceIdentifier.IsUnknown() && !r.Config.Metrics[metricsIndex].WorkspaceIdentifier.IsNull() {
+					*workspaceIdentifier = shared.WorkspaceIdentifier(r.Config.Metrics[metricsIndex].WorkspaceIdentifier.ValueString())
 				} else {
 					workspaceIdentifier = nil
 				}

--- a/internal/provider/gatewaypluginstatsdadvanced_resource.go
+++ b/internal/provider/gatewaypluginstatsdadvanced_resource.go
@@ -771,7 +771,10 @@ func (r *GatewayPluginStatsdAdvancedResource) Delete(ctx context.Context, req re
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginstatsdadvanced_resource_sdk.go
+++ b/internal/provider/gatewaypluginstatsdadvanced_resource_sdk.go
@@ -278,8 +278,8 @@ func (r *GatewayPluginStatsdAdvancedResourceModel) ToSharedStatsdAdvancedPlugin(
 		var after *shared.StatsdAdvancedPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.StatsdAdvancedPluginAfter{
 				Access: access,
@@ -288,8 +288,8 @@ func (r *GatewayPluginStatsdAdvancedResourceModel) ToSharedStatsdAdvancedPlugin(
 		var before *shared.StatsdAdvancedPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.StatsdAdvancedPluginBefore{
 				Access: access1,
@@ -303,22 +303,22 @@ func (r *GatewayPluginStatsdAdvancedResourceModel) ToSharedStatsdAdvancedPlugin(
 	var partials []shared.StatsdAdvancedPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.StatsdAdvancedPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -332,8 +332,8 @@ func (r *GatewayPluginStatsdAdvancedResourceModel) ToSharedStatsdAdvancedPlugin(
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -347,8 +347,8 @@ func (r *GatewayPluginStatsdAdvancedResourceModel) ToSharedStatsdAdvancedPlugin(
 		var allowStatusCodes []string
 		if r.Config.AllowStatusCodes != nil {
 			allowStatusCodes = make([]string, 0, len(r.Config.AllowStatusCodes))
-			for _, allowStatusCodesItem := range r.Config.AllowStatusCodes {
-				allowStatusCodes = append(allowStatusCodes, allowStatusCodesItem.ValueString())
+			for allowStatusCodesIndex := range r.Config.AllowStatusCodes {
+				allowStatusCodes = append(allowStatusCodes, r.Config.AllowStatusCodes[allowStatusCodesIndex].ValueString())
 			}
 		}
 		consumerIdentifierDefault := new(shared.StatsdAdvancedPluginConsumerIdentifierDefault)
@@ -372,30 +372,30 @@ func (r *GatewayPluginStatsdAdvancedResourceModel) ToSharedStatsdAdvancedPlugin(
 		var metrics []shared.StatsdAdvancedPluginMetrics
 		if r.Config.Metrics != nil {
 			metrics = make([]shared.StatsdAdvancedPluginMetrics, 0, len(r.Config.Metrics))
-			for _, metricsItem := range r.Config.Metrics {
+			for metricsIndex := range r.Config.Metrics {
 				consumerIdentifier := new(shared.StatsdAdvancedPluginConsumerIdentifier)
-				if !metricsItem.ConsumerIdentifier.IsUnknown() && !metricsItem.ConsumerIdentifier.IsNull() {
-					*consumerIdentifier = shared.StatsdAdvancedPluginConsumerIdentifier(metricsItem.ConsumerIdentifier.ValueString())
+				if !r.Config.Metrics[metricsIndex].ConsumerIdentifier.IsUnknown() && !r.Config.Metrics[metricsIndex].ConsumerIdentifier.IsNull() {
+					*consumerIdentifier = shared.StatsdAdvancedPluginConsumerIdentifier(r.Config.Metrics[metricsIndex].ConsumerIdentifier.ValueString())
 				} else {
 					consumerIdentifier = nil
 				}
-				name1 := shared.StatsdAdvancedPluginName(metricsItem.Name.ValueString())
+				name1 := shared.StatsdAdvancedPluginName(r.Config.Metrics[metricsIndex].Name.ValueString())
 				sampleRate := new(float64)
-				if !metricsItem.SampleRate.IsUnknown() && !metricsItem.SampleRate.IsNull() {
-					*sampleRate = metricsItem.SampleRate.ValueFloat64()
+				if !r.Config.Metrics[metricsIndex].SampleRate.IsUnknown() && !r.Config.Metrics[metricsIndex].SampleRate.IsNull() {
+					*sampleRate = r.Config.Metrics[metricsIndex].SampleRate.ValueFloat64()
 				} else {
 					sampleRate = nil
 				}
 				serviceIdentifier := new(shared.StatsdAdvancedPluginServiceIdentifier)
-				if !metricsItem.ServiceIdentifier.IsUnknown() && !metricsItem.ServiceIdentifier.IsNull() {
-					*serviceIdentifier = shared.StatsdAdvancedPluginServiceIdentifier(metricsItem.ServiceIdentifier.ValueString())
+				if !r.Config.Metrics[metricsIndex].ServiceIdentifier.IsUnknown() && !r.Config.Metrics[metricsIndex].ServiceIdentifier.IsNull() {
+					*serviceIdentifier = shared.StatsdAdvancedPluginServiceIdentifier(r.Config.Metrics[metricsIndex].ServiceIdentifier.ValueString())
 				} else {
 					serviceIdentifier = nil
 				}
-				statType := shared.StatsdAdvancedPluginStatType(metricsItem.StatType.ValueString())
+				statType := shared.StatsdAdvancedPluginStatType(r.Config.Metrics[metricsIndex].StatType.ValueString())
 				workspaceIdentifier := new(shared.StatsdAdvancedPluginWorkspaceIdentifier)
-				if !metricsItem.WorkspaceIdentifier.IsUnknown() && !metricsItem.WorkspaceIdentifier.IsNull() {
-					*workspaceIdentifier = shared.StatsdAdvancedPluginWorkspaceIdentifier(metricsItem.WorkspaceIdentifier.ValueString())
+				if !r.Config.Metrics[metricsIndex].WorkspaceIdentifier.IsUnknown() && !r.Config.Metrics[metricsIndex].WorkspaceIdentifier.IsNull() {
+					*workspaceIdentifier = shared.StatsdAdvancedPluginWorkspaceIdentifier(r.Config.Metrics[metricsIndex].WorkspaceIdentifier.ValueString())
 				} else {
 					workspaceIdentifier = nil
 				}

--- a/internal/provider/gatewaypluginsyslog_resource.go
+++ b/internal/provider/gatewaypluginsyslog_resource.go
@@ -589,7 +589,10 @@ func (r *GatewayPluginSyslogResource) Delete(ctx context.Context, req resource.D
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginsyslog_resource_sdk.go
+++ b/internal/provider/gatewaypluginsyslog_resource_sdk.go
@@ -237,8 +237,8 @@ func (r *GatewayPluginSyslogResourceModel) ToSharedSyslogPlugin(ctx context.Cont
 		var after *shared.SyslogPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.SyslogPluginAfter{
 				Access: access,
@@ -247,8 +247,8 @@ func (r *GatewayPluginSyslogResourceModel) ToSharedSyslogPlugin(ctx context.Cont
 		var before *shared.SyslogPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.SyslogPluginBefore{
 				Access: access1,
@@ -262,22 +262,22 @@ func (r *GatewayPluginSyslogResourceModel) ToSharedSyslogPlugin(ctx context.Cont
 	var partials []shared.SyslogPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.SyslogPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -291,8 +291,8 @@ func (r *GatewayPluginSyslogResourceModel) ToSharedSyslogPlugin(ctx context.Cont
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -312,9 +312,9 @@ func (r *GatewayPluginSyslogResourceModel) ToSharedSyslogPlugin(ctx context.Cont
 		var customFieldsByLua map[string]string
 		if r.Config.CustomFieldsByLua != nil {
 			customFieldsByLua = make(map[string]string)
-			for customFieldsByLuaKey, customFieldsByLuaValue := range r.Config.CustomFieldsByLua {
+			for customFieldsByLuaKey := range r.Config.CustomFieldsByLua {
 				var customFieldsByLuaInst string
-				customFieldsByLuaInst = customFieldsByLuaValue.ValueString()
+				customFieldsByLuaInst = r.Config.CustomFieldsByLua[customFieldsByLuaKey].ValueString()
 
 				customFieldsByLua[customFieldsByLuaKey] = customFieldsByLuaInst
 			}

--- a/internal/provider/gatewayplugintcplog_resource.go
+++ b/internal/provider/gatewayplugintcplog_resource.go
@@ -510,7 +510,10 @@ func (r *GatewayPluginTCPLogResource) Delete(ctx context.Context, req resource.D
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewayplugintcplog_resource_sdk.go
+++ b/internal/provider/gatewayplugintcplog_resource_sdk.go
@@ -213,8 +213,8 @@ func (r *GatewayPluginTCPLogResourceModel) ToSharedTCPLogPlugin(ctx context.Cont
 		var after *shared.TCPLogPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.TCPLogPluginAfter{
 				Access: access,
@@ -223,8 +223,8 @@ func (r *GatewayPluginTCPLogResourceModel) ToSharedTCPLogPlugin(ctx context.Cont
 		var before *shared.TCPLogPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.TCPLogPluginBefore{
 				Access: access1,
@@ -238,22 +238,22 @@ func (r *GatewayPluginTCPLogResourceModel) ToSharedTCPLogPlugin(ctx context.Cont
 	var partials []shared.TCPLogPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.TCPLogPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -267,8 +267,8 @@ func (r *GatewayPluginTCPLogResourceModel) ToSharedTCPLogPlugin(ctx context.Cont
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -280,9 +280,9 @@ func (r *GatewayPluginTCPLogResourceModel) ToSharedTCPLogPlugin(ctx context.Cont
 	var customFieldsByLua map[string]string
 	if r.Config.CustomFieldsByLua != nil {
 		customFieldsByLua = make(map[string]string)
-		for customFieldsByLuaKey, customFieldsByLuaValue := range r.Config.CustomFieldsByLua {
+		for customFieldsByLuaKey := range r.Config.CustomFieldsByLua {
 			var customFieldsByLuaInst string
-			customFieldsByLuaInst = customFieldsByLuaValue.ValueString()
+			customFieldsByLuaInst = r.Config.CustomFieldsByLua[customFieldsByLuaKey].ValueString()
 
 			customFieldsByLua[customFieldsByLuaKey] = customFieldsByLuaInst
 		}

--- a/internal/provider/gatewayplugintlshandshakemodifier_resource.go
+++ b/internal/provider/gatewayplugintlshandshakemodifier_resource.go
@@ -467,7 +467,10 @@ func (r *GatewayPluginTLSHandshakeModifierResource) Delete(ctx context.Context, 
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewayplugintlshandshakemodifier_resource_sdk.go
+++ b/internal/provider/gatewayplugintlshandshakemodifier_resource_sdk.go
@@ -205,8 +205,8 @@ func (r *GatewayPluginTLSHandshakeModifierResourceModel) ToSharedTLSHandshakeMod
 		var after *shared.TLSHandshakeModifierPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.TLSHandshakeModifierPluginAfter{
 				Access: access,
@@ -215,8 +215,8 @@ func (r *GatewayPluginTLSHandshakeModifierResourceModel) ToSharedTLSHandshakeMod
 		var before *shared.TLSHandshakeModifierPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.TLSHandshakeModifierPluginBefore{
 				Access: access1,
@@ -230,22 +230,22 @@ func (r *GatewayPluginTLSHandshakeModifierResourceModel) ToSharedTLSHandshakeMod
 	var partials []shared.TLSHandshakeModifierPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.TLSHandshakeModifierPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -259,8 +259,8 @@ func (r *GatewayPluginTLSHandshakeModifierResourceModel) ToSharedTLSHandshakeMod
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)

--- a/internal/provider/gatewayplugintlsmetadataheaders_resource.go
+++ b/internal/provider/gatewayplugintlsmetadataheaders_resource.go
@@ -499,7 +499,10 @@ func (r *GatewayPluginTLSMetadataHeadersResource) Delete(ctx context.Context, re
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewayplugintlsmetadataheaders_resource_sdk.go
+++ b/internal/provider/gatewayplugintlsmetadataheaders_resource_sdk.go
@@ -206,8 +206,8 @@ func (r *GatewayPluginTLSMetadataHeadersResourceModel) ToSharedTLSMetadataHeader
 		var after *shared.TLSMetadataHeadersPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.TLSMetadataHeadersPluginAfter{
 				Access: access,
@@ -216,8 +216,8 @@ func (r *GatewayPluginTLSMetadataHeadersResourceModel) ToSharedTLSMetadataHeader
 		var before *shared.TLSMetadataHeadersPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.TLSMetadataHeadersPluginBefore{
 				Access: access1,
@@ -231,22 +231,22 @@ func (r *GatewayPluginTLSMetadataHeadersResourceModel) ToSharedTLSMetadataHeader
 	var partials []shared.TLSMetadataHeadersPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.TLSMetadataHeadersPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -260,8 +260,8 @@ func (r *GatewayPluginTLSMetadataHeadersResourceModel) ToSharedTLSMetadataHeader
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)

--- a/internal/provider/gatewaypluginudplog_resource.go
+++ b/internal/provider/gatewaypluginudplog_resource.go
@@ -494,7 +494,10 @@ func (r *GatewayPluginUDPLogResource) Delete(ctx context.Context, req resource.D
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginudplog_resource_sdk.go
+++ b/internal/provider/gatewaypluginudplog_resource_sdk.go
@@ -210,8 +210,8 @@ func (r *GatewayPluginUDPLogResourceModel) ToSharedUDPLogPlugin(ctx context.Cont
 		var after *shared.UDPLogPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.UDPLogPluginAfter{
 				Access: access,
@@ -220,8 +220,8 @@ func (r *GatewayPluginUDPLogResourceModel) ToSharedUDPLogPlugin(ctx context.Cont
 		var before *shared.UDPLogPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.UDPLogPluginBefore{
 				Access: access1,
@@ -235,22 +235,22 @@ func (r *GatewayPluginUDPLogResourceModel) ToSharedUDPLogPlugin(ctx context.Cont
 	var partials []shared.UDPLogPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.UDPLogPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -264,8 +264,8 @@ func (r *GatewayPluginUDPLogResourceModel) ToSharedUDPLogPlugin(ctx context.Cont
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -277,9 +277,9 @@ func (r *GatewayPluginUDPLogResourceModel) ToSharedUDPLogPlugin(ctx context.Cont
 	var customFieldsByLua map[string]string
 	if r.Config.CustomFieldsByLua != nil {
 		customFieldsByLua = make(map[string]string)
-		for customFieldsByLuaKey, customFieldsByLuaValue := range r.Config.CustomFieldsByLua {
+		for customFieldsByLuaKey := range r.Config.CustomFieldsByLua {
 			var customFieldsByLuaInst string
-			customFieldsByLuaInst = customFieldsByLuaValue.ValueString()
+			customFieldsByLuaInst = r.Config.CustomFieldsByLua[customFieldsByLuaKey].ValueString()
 
 			customFieldsByLua[customFieldsByLuaKey] = customFieldsByLuaInst
 		}

--- a/internal/provider/gatewaypluginupstreamoauth_resource.go
+++ b/internal/provider/gatewaypluginupstreamoauth_resource.go
@@ -911,7 +911,10 @@ func (r *GatewayPluginUpstreamOauthResource) Delete(ctx context.Context, req res
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginupstreamoauth_resource_sdk.go
+++ b/internal/provider/gatewaypluginupstreamoauth_resource_sdk.go
@@ -347,8 +347,8 @@ func (r *GatewayPluginUpstreamOauthResourceModel) ToSharedUpstreamOauthPlugin(ct
 		var after *shared.UpstreamOauthPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.UpstreamOauthPluginAfter{
 				Access: access,
@@ -357,8 +357,8 @@ func (r *GatewayPluginUpstreamOauthResourceModel) ToSharedUpstreamOauthPlugin(ct
 		var before *shared.UpstreamOauthPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.UpstreamOauthPluginBefore{
 				Access: access1,
@@ -372,22 +372,22 @@ func (r *GatewayPluginUpstreamOauthResourceModel) ToSharedUpstreamOauthPlugin(ct
 	var partials []shared.UpstreamOauthPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.UpstreamOauthPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -401,8 +401,8 @@ func (r *GatewayPluginUpstreamOauthResourceModel) ToSharedUpstreamOauthPlugin(ct
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -438,8 +438,8 @@ func (r *GatewayPluginUpstreamOauthResourceModel) ToSharedUpstreamOauthPlugin(ct
 			idpErrorResponseStatusCode = nil
 		}
 		purgeTokenOnUpstreamStatusCodes := make([]int64, 0, len(r.Config.Behavior.PurgeTokenOnUpstreamStatusCodes))
-		for _, purgeTokenOnUpstreamStatusCodesItem := range r.Config.Behavior.PurgeTokenOnUpstreamStatusCodes {
-			purgeTokenOnUpstreamStatusCodes = append(purgeTokenOnUpstreamStatusCodes, purgeTokenOnUpstreamStatusCodesItem.ValueInt64())
+		for purgeTokenOnUpstreamStatusCodesIndex := range r.Config.Behavior.PurgeTokenOnUpstreamStatusCodes {
+			purgeTokenOnUpstreamStatusCodes = append(purgeTokenOnUpstreamStatusCodes, r.Config.Behavior.PurgeTokenOnUpstreamStatusCodes[purgeTokenOnUpstreamStatusCodesIndex].ValueInt64())
 		}
 		upstreamAccessTokenHeaderName := new(string)
 		if !r.Config.Behavior.UpstreamAccessTokenHeaderName.IsUnknown() && !r.Config.Behavior.UpstreamAccessTokenHeaderName.IsNull() {
@@ -493,16 +493,16 @@ func (r *GatewayPluginUpstreamOauthResourceModel) ToSharedUpstreamOauthPlugin(ct
 			var clusterNodes []shared.UpstreamOauthPluginClusterNodes
 			if r.Config.Cache.Redis.ClusterNodes != nil {
 				clusterNodes = make([]shared.UpstreamOauthPluginClusterNodes, 0, len(r.Config.Cache.Redis.ClusterNodes))
-				for _, clusterNodesItem := range r.Config.Cache.Redis.ClusterNodes {
+				for clusterNodesIndex := range r.Config.Cache.Redis.ClusterNodes {
 					ip := new(string)
-					if !clusterNodesItem.IP.IsUnknown() && !clusterNodesItem.IP.IsNull() {
-						*ip = clusterNodesItem.IP.ValueString()
+					if !r.Config.Cache.Redis.ClusterNodes[clusterNodesIndex].IP.IsUnknown() && !r.Config.Cache.Redis.ClusterNodes[clusterNodesIndex].IP.IsNull() {
+						*ip = r.Config.Cache.Redis.ClusterNodes[clusterNodesIndex].IP.ValueString()
 					} else {
 						ip = nil
 					}
 					port := new(int64)
-					if !clusterNodesItem.Port.IsUnknown() && !clusterNodesItem.Port.IsNull() {
-						*port = clusterNodesItem.Port.ValueInt64()
+					if !r.Config.Cache.Redis.ClusterNodes[clusterNodesIndex].Port.IsUnknown() && !r.Config.Cache.Redis.ClusterNodes[clusterNodesIndex].Port.IsNull() {
+						*port = r.Config.Cache.Redis.ClusterNodes[clusterNodesIndex].Port.ValueInt64()
 					} else {
 						port = nil
 					}
@@ -581,16 +581,16 @@ func (r *GatewayPluginUpstreamOauthResourceModel) ToSharedUpstreamOauthPlugin(ct
 			var sentinelNodes []shared.UpstreamOauthPluginSentinelNodes
 			if r.Config.Cache.Redis.SentinelNodes != nil {
 				sentinelNodes = make([]shared.UpstreamOauthPluginSentinelNodes, 0, len(r.Config.Cache.Redis.SentinelNodes))
-				for _, sentinelNodesItem := range r.Config.Cache.Redis.SentinelNodes {
+				for sentinelNodesIndex := range r.Config.Cache.Redis.SentinelNodes {
 					host1 := new(string)
-					if !sentinelNodesItem.Host.IsUnknown() && !sentinelNodesItem.Host.IsNull() {
-						*host1 = sentinelNodesItem.Host.ValueString()
+					if !r.Config.Cache.Redis.SentinelNodes[sentinelNodesIndex].Host.IsUnknown() && !r.Config.Cache.Redis.SentinelNodes[sentinelNodesIndex].Host.IsNull() {
+						*host1 = r.Config.Cache.Redis.SentinelNodes[sentinelNodesIndex].Host.ValueString()
 					} else {
 						host1 = nil
 					}
 					port2 := new(int64)
-					if !sentinelNodesItem.Port.IsUnknown() && !sentinelNodesItem.Port.IsNull() {
-						*port2 = sentinelNodesItem.Port.ValueInt64()
+					if !r.Config.Cache.Redis.SentinelNodes[sentinelNodesIndex].Port.IsUnknown() && !r.Config.Cache.Redis.SentinelNodes[sentinelNodesIndex].Port.IsNull() {
+						*port2 = r.Config.Cache.Redis.SentinelNodes[sentinelNodesIndex].Port.ValueInt64()
 					} else {
 						port2 = nil
 					}
@@ -763,8 +763,8 @@ func (r *GatewayPluginUpstreamOauthResourceModel) ToSharedUpstreamOauthPlugin(ct
 		}
 	}
 	audience := make([]string, 0, len(r.Config.Oauth.Audience))
-	for _, audienceItem := range r.Config.Oauth.Audience {
-		audience = append(audience, audienceItem.ValueString())
+	for audienceIndex := range r.Config.Oauth.Audience {
+		audience = append(audience, r.Config.Oauth.Audience[audienceIndex].ValueString())
 	}
 	clientID := new(string)
 	if !r.Config.Oauth.ClientID.IsUnknown() && !r.Config.Oauth.ClientID.IsNull() {
@@ -793,24 +793,24 @@ func (r *GatewayPluginUpstreamOauthResourceModel) ToSharedUpstreamOauthPlugin(ct
 	var scopes []string
 	if r.Config.Oauth.Scopes != nil {
 		scopes = make([]string, 0, len(r.Config.Oauth.Scopes))
-		for _, scopesItem := range r.Config.Oauth.Scopes {
-			scopes = append(scopes, scopesItem.ValueString())
+		for scopesIndex := range r.Config.Oauth.Scopes {
+			scopes = append(scopes, r.Config.Oauth.Scopes[scopesIndex].ValueString())
 		}
 	}
 	var tokenEndpoint string
 	tokenEndpoint = r.Config.Oauth.TokenEndpoint.ValueString()
 
 	tokenHeaders := make(map[string]string)
-	for tokenHeadersKey, tokenHeadersValue := range r.Config.Oauth.TokenHeaders {
+	for tokenHeadersKey := range r.Config.Oauth.TokenHeaders {
 		var tokenHeadersInst string
-		tokenHeadersInst = tokenHeadersValue.ValueString()
+		tokenHeadersInst = r.Config.Oauth.TokenHeaders[tokenHeadersKey].ValueString()
 
 		tokenHeaders[tokenHeadersKey] = tokenHeadersInst
 	}
 	tokenPostArgs := make(map[string]string)
-	for tokenPostArgsKey, tokenPostArgsValue := range r.Config.Oauth.TokenPostArgs {
+	for tokenPostArgsKey := range r.Config.Oauth.TokenPostArgs {
 		var tokenPostArgsInst string
-		tokenPostArgsInst = tokenPostArgsValue.ValueString()
+		tokenPostArgsInst = r.Config.Oauth.TokenPostArgs[tokenPostArgsKey].ValueString()
 
 		tokenPostArgs[tokenPostArgsKey] = tokenPostArgsInst
 	}

--- a/internal/provider/gatewaypluginupstreamtimeout_resource.go
+++ b/internal/provider/gatewaypluginupstreamtimeout_resource.go
@@ -498,7 +498,10 @@ func (r *GatewayPluginUpstreamTimeoutResource) Delete(ctx context.Context, req r
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginupstreamtimeout_resource_sdk.go
+++ b/internal/provider/gatewaypluginupstreamtimeout_resource_sdk.go
@@ -209,8 +209,8 @@ func (r *GatewayPluginUpstreamTimeoutResourceModel) ToSharedUpstreamTimeoutPlugi
 		var after *shared.UpstreamTimeoutPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.UpstreamTimeoutPluginAfter{
 				Access: access,
@@ -219,8 +219,8 @@ func (r *GatewayPluginUpstreamTimeoutResourceModel) ToSharedUpstreamTimeoutPlugi
 		var before *shared.UpstreamTimeoutPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.UpstreamTimeoutPluginBefore{
 				Access: access1,
@@ -234,22 +234,22 @@ func (r *GatewayPluginUpstreamTimeoutResourceModel) ToSharedUpstreamTimeoutPlugi
 	var partials []shared.UpstreamTimeoutPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.UpstreamTimeoutPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -263,8 +263,8 @@ func (r *GatewayPluginUpstreamTimeoutResourceModel) ToSharedUpstreamTimeoutPlugi
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)

--- a/internal/provider/gatewaypluginvaultauth_resource.go
+++ b/internal/provider/gatewaypluginvaultauth_resource.go
@@ -518,7 +518,10 @@ func (r *GatewayPluginVaultAuthResource) Delete(ctx context.Context, req resourc
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginvaultauth_resource_sdk.go
+++ b/internal/provider/gatewaypluginvaultauth_resource_sdk.go
@@ -212,8 +212,8 @@ func (r *GatewayPluginVaultAuthResourceModel) ToSharedVaultAuthPlugin(ctx contex
 		var after *shared.VaultAuthPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.VaultAuthPluginAfter{
 				Access: access,
@@ -222,8 +222,8 @@ func (r *GatewayPluginVaultAuthResourceModel) ToSharedVaultAuthPlugin(ctx contex
 		var before *shared.VaultAuthPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.VaultAuthPluginBefore{
 				Access: access1,
@@ -237,22 +237,22 @@ func (r *GatewayPluginVaultAuthResourceModel) ToSharedVaultAuthPlugin(ctx contex
 	var partials []shared.VaultAuthPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.VaultAuthPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -266,8 +266,8 @@ func (r *GatewayPluginVaultAuthResourceModel) ToSharedVaultAuthPlugin(ctx contex
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)

--- a/internal/provider/gatewaypluginwebsocketsizelimit_resource.go
+++ b/internal/provider/gatewaypluginwebsocketsizelimit_resource.go
@@ -486,7 +486,10 @@ func (r *GatewayPluginWebsocketSizeLimitResource) Delete(ctx context.Context, re
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginwebsocketsizelimit_resource_sdk.go
+++ b/internal/provider/gatewaypluginwebsocketsizelimit_resource_sdk.go
@@ -208,8 +208,8 @@ func (r *GatewayPluginWebsocketSizeLimitResourceModel) ToSharedWebsocketSizeLimi
 		var after *shared.WebsocketSizeLimitPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.WebsocketSizeLimitPluginAfter{
 				Access: access,
@@ -218,8 +218,8 @@ func (r *GatewayPluginWebsocketSizeLimitResourceModel) ToSharedWebsocketSizeLimi
 		var before *shared.WebsocketSizeLimitPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.WebsocketSizeLimitPluginBefore{
 				Access: access1,
@@ -233,22 +233,22 @@ func (r *GatewayPluginWebsocketSizeLimitResourceModel) ToSharedWebsocketSizeLimi
 	var partials []shared.WebsocketSizeLimitPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.WebsocketSizeLimitPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -262,8 +262,8 @@ func (r *GatewayPluginWebsocketSizeLimitResourceModel) ToSharedWebsocketSizeLimi
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)

--- a/internal/provider/gatewaypluginwebsocketvalidator_resource.go
+++ b/internal/provider/gatewaypluginwebsocketvalidator_resource.go
@@ -627,7 +627,10 @@ func (r *GatewayPluginWebsocketValidatorResource) Delete(ctx context.Context, re
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginwebsocketvalidator_resource_sdk.go
+++ b/internal/provider/gatewaypluginwebsocketvalidator_resource_sdk.go
@@ -244,8 +244,8 @@ func (r *GatewayPluginWebsocketValidatorResourceModel) ToSharedWebsocketValidato
 		var after *shared.WebsocketValidatorPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.WebsocketValidatorPluginAfter{
 				Access: access,
@@ -254,8 +254,8 @@ func (r *GatewayPluginWebsocketValidatorResourceModel) ToSharedWebsocketValidato
 		var before *shared.WebsocketValidatorPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.WebsocketValidatorPluginBefore{
 				Access: access1,
@@ -269,22 +269,22 @@ func (r *GatewayPluginWebsocketValidatorResourceModel) ToSharedWebsocketValidato
 	var partials []shared.WebsocketValidatorPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.WebsocketValidatorPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -298,8 +298,8 @@ func (r *GatewayPluginWebsocketValidatorResourceModel) ToSharedWebsocketValidato
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)

--- a/internal/provider/gatewaypluginxmlthreatprotection_resource.go
+++ b/internal/provider/gatewaypluginxmlthreatprotection_resource.go
@@ -651,7 +651,10 @@ func (r *GatewayPluginXMLThreatProtectionResource) Delete(ctx context.Context, r
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginxmlthreatprotection_resource_sdk.go
+++ b/internal/provider/gatewaypluginxmlthreatprotection_resource_sdk.go
@@ -235,8 +235,8 @@ func (r *GatewayPluginXMLThreatProtectionResourceModel) ToSharedXMLThreatProtect
 		var after *shared.XMLThreatProtectionPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.XMLThreatProtectionPluginAfter{
 				Access: access,
@@ -245,8 +245,8 @@ func (r *GatewayPluginXMLThreatProtectionResourceModel) ToSharedXMLThreatProtect
 		var before *shared.XMLThreatProtectionPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.XMLThreatProtectionPluginBefore{
 				Access: access1,
@@ -260,22 +260,22 @@ func (r *GatewayPluginXMLThreatProtectionResourceModel) ToSharedXMLThreatProtect
 	var partials []shared.XMLThreatProtectionPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.XMLThreatProtectionPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -289,8 +289,8 @@ func (r *GatewayPluginXMLThreatProtectionResourceModel) ToSharedXMLThreatProtect
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -308,8 +308,8 @@ func (r *GatewayPluginXMLThreatProtectionResourceModel) ToSharedXMLThreatProtect
 			allowDtd = nil
 		}
 		allowedContentTypes := make([]string, 0, len(r.Config.AllowedContentTypes))
-		for _, allowedContentTypesItem := range r.Config.AllowedContentTypes {
-			allowedContentTypes = append(allowedContentTypes, allowedContentTypesItem.ValueString())
+		for allowedContentTypesIndex := range r.Config.AllowedContentTypes {
+			allowedContentTypes = append(allowedContentTypes, r.Config.AllowedContentTypes[allowedContentTypesIndex].ValueString())
 		}
 		attribute := new(int64)
 		if !r.Config.Attribute.IsUnknown() && !r.Config.Attribute.IsNull() {
@@ -336,8 +336,8 @@ func (r *GatewayPluginXMLThreatProtectionResourceModel) ToSharedXMLThreatProtect
 			buffer = nil
 		}
 		checkedContentTypes := make([]string, 0, len(r.Config.CheckedContentTypes))
-		for _, checkedContentTypesItem := range r.Config.CheckedContentTypes {
-			checkedContentTypes = append(checkedContentTypes, checkedContentTypesItem.ValueString())
+		for checkedContentTypesIndex := range r.Config.CheckedContentTypes {
+			checkedContentTypes = append(checkedContentTypes, r.Config.CheckedContentTypes[checkedContentTypesIndex].ValueString())
 		}
 		comment := new(int64)
 		if !r.Config.Comment.IsUnknown() && !r.Config.Comment.IsNull() {

--- a/internal/provider/gatewaypluginzipkin_resource.go
+++ b/internal/provider/gatewaypluginzipkin_resource.go
@@ -811,7 +811,10 @@ func (r *GatewayPluginZipkinResource) Delete(ctx context.Context, req resource.D
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaypluginzipkin_resource_sdk.go
+++ b/internal/provider/gatewaypluginzipkin_resource_sdk.go
@@ -298,8 +298,8 @@ func (r *GatewayPluginZipkinResourceModel) ToSharedZipkinPlugin(ctx context.Cont
 		var after *shared.ZipkinPluginAfter
 		if r.Ordering.After != nil {
 			access := make([]string, 0, len(r.Ordering.After.Access))
-			for _, accessItem := range r.Ordering.After.Access {
-				access = append(access, accessItem.ValueString())
+			for accessIndex := range r.Ordering.After.Access {
+				access = append(access, r.Ordering.After.Access[accessIndex].ValueString())
 			}
 			after = &shared.ZipkinPluginAfter{
 				Access: access,
@@ -308,8 +308,8 @@ func (r *GatewayPluginZipkinResourceModel) ToSharedZipkinPlugin(ctx context.Cont
 		var before *shared.ZipkinPluginBefore
 		if r.Ordering.Before != nil {
 			access1 := make([]string, 0, len(r.Ordering.Before.Access))
-			for _, accessItem1 := range r.Ordering.Before.Access {
-				access1 = append(access1, accessItem1.ValueString())
+			for accessIndex1 := range r.Ordering.Before.Access {
+				access1 = append(access1, r.Ordering.Before.Access[accessIndex1].ValueString())
 			}
 			before = &shared.ZipkinPluginBefore{
 				Access: access1,
@@ -323,22 +323,22 @@ func (r *GatewayPluginZipkinResourceModel) ToSharedZipkinPlugin(ctx context.Cont
 	var partials []shared.ZipkinPluginPartials
 	if r.Partials != nil {
 		partials = make([]shared.ZipkinPluginPartials, 0, len(r.Partials))
-		for _, partialsItem := range r.Partials {
+		for partialsIndex := range r.Partials {
 			id1 := new(string)
-			if !partialsItem.ID.IsUnknown() && !partialsItem.ID.IsNull() {
-				*id1 = partialsItem.ID.ValueString()
+			if !r.Partials[partialsIndex].ID.IsUnknown() && !r.Partials[partialsIndex].ID.IsNull() {
+				*id1 = r.Partials[partialsIndex].ID.ValueString()
 			} else {
 				id1 = nil
 			}
 			name := new(string)
-			if !partialsItem.Name.IsUnknown() && !partialsItem.Name.IsNull() {
-				*name = partialsItem.Name.ValueString()
+			if !r.Partials[partialsIndex].Name.IsUnknown() && !r.Partials[partialsIndex].Name.IsNull() {
+				*name = r.Partials[partialsIndex].Name.ValueString()
 			} else {
 				name = nil
 			}
 			path := new(string)
-			if !partialsItem.Path.IsUnknown() && !partialsItem.Path.IsNull() {
-				*path = partialsItem.Path.ValueString()
+			if !r.Partials[partialsIndex].Path.IsUnknown() && !r.Partials[partialsIndex].Path.IsNull() {
+				*path = r.Partials[partialsIndex].Path.ValueString()
 			} else {
 				path = nil
 			}
@@ -352,8 +352,8 @@ func (r *GatewayPluginZipkinResourceModel) ToSharedZipkinPlugin(ctx context.Cont
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)
@@ -429,8 +429,8 @@ func (r *GatewayPluginZipkinResourceModel) ToSharedZipkinPlugin(ctx context.Cont
 			var clear []string
 			if r.Config.Propagation.Clear != nil {
 				clear = make([]string, 0, len(r.Config.Propagation.Clear))
-				for _, clearItem := range r.Config.Propagation.Clear {
-					clear = append(clear, clearItem.ValueString())
+				for clearIndex := range r.Config.Propagation.Clear {
+					clear = append(clear, r.Config.Propagation.Clear[clearIndex].ValueString())
 				}
 			}
 			defaultFormat := new(shared.ZipkinPluginDefaultFormat)
@@ -542,12 +542,12 @@ func (r *GatewayPluginZipkinResourceModel) ToSharedZipkinPlugin(ctx context.Cont
 		var staticTags []shared.StaticTags
 		if r.Config.StaticTags != nil {
 			staticTags = make([]shared.StaticTags, 0, len(r.Config.StaticTags))
-			for _, staticTagsItem := range r.Config.StaticTags {
+			for staticTagsIndex := range r.Config.StaticTags {
 				var name1 string
-				name1 = staticTagsItem.Name.ValueString()
+				name1 = r.Config.StaticTags[staticTagsIndex].Name.ValueString()
 
 				var value string
-				value = staticTagsItem.Value.ValueString()
+				value = r.Config.StaticTags[staticTagsIndex].Value.ValueString()
 
 				staticTags = append(staticTags, shared.StaticTags{
 					Name:  name1,

--- a/internal/provider/gatewayroute_resource.go
+++ b/internal/provider/gatewayroute_resource.go
@@ -490,7 +490,10 @@ func (r *GatewayRouteResource) Delete(ctx context.Context, req resource.DeleteRe
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewayroute_resource_sdk.go
+++ b/internal/provider/gatewayroute_resource_sdk.go
@@ -209,16 +209,16 @@ func (r *GatewayRouteResourceModel) ToSharedRouteJSON(ctx context.Context) (*sha
 	var destinations []shared.Destinations
 	if r.Destinations != nil {
 		destinations = make([]shared.Destinations, 0, len(r.Destinations))
-		for _, destinationsItem := range r.Destinations {
+		for destinationsIndex := range r.Destinations {
 			ip := new(string)
-			if !destinationsItem.IP.IsUnknown() && !destinationsItem.IP.IsNull() {
-				*ip = destinationsItem.IP.ValueString()
+			if !r.Destinations[destinationsIndex].IP.IsUnknown() && !r.Destinations[destinationsIndex].IP.IsNull() {
+				*ip = r.Destinations[destinationsIndex].IP.ValueString()
 			} else {
 				ip = nil
 			}
 			port := new(int64)
-			if !destinationsItem.Port.IsUnknown() && !destinationsItem.Port.IsNull() {
-				*port = destinationsItem.Port.ValueInt64()
+			if !r.Destinations[destinationsIndex].Port.IsUnknown() && !r.Destinations[destinationsIndex].Port.IsNull() {
+				*port = r.Destinations[destinationsIndex].Port.ValueInt64()
 			} else {
 				port = nil
 			}
@@ -231,10 +231,10 @@ func (r *GatewayRouteResourceModel) ToSharedRouteJSON(ctx context.Context) (*sha
 	var headers map[string][]string
 	if r.Headers != nil {
 		headers = make(map[string][]string)
-		for headersKey, headersValue := range r.Headers {
-			headersInst := make([]string, 0, len(headersValue))
-			for _, item := range headersValue {
-				headersInst = append(headersInst, item.ValueString())
+		for headersKey := range r.Headers {
+			headersInst := make([]string, 0, len(r.Headers[headersKey]))
+			for index := range r.Headers[headersKey] {
+				headersInst = append(headersInst, r.Headers[headersKey][index].ValueString())
 			}
 			headers[headersKey] = headersInst
 		}
@@ -242,8 +242,8 @@ func (r *GatewayRouteResourceModel) ToSharedRouteJSON(ctx context.Context) (*sha
 	var hosts []string
 	if r.Hosts != nil {
 		hosts = make([]string, 0, len(r.Hosts))
-		for _, hostsItem := range r.Hosts {
-			hosts = append(hosts, hostsItem.ValueString())
+		for hostsIndex := range r.Hosts {
+			hosts = append(hosts, r.Hosts[hostsIndex].ValueString())
 		}
 	}
 	httpsRedirectStatusCode := new(shared.HTTPSRedirectStatusCode)
@@ -261,8 +261,8 @@ func (r *GatewayRouteResourceModel) ToSharedRouteJSON(ctx context.Context) (*sha
 	var methods []string
 	if r.Methods != nil {
 		methods = make([]string, 0, len(r.Methods))
-		for _, methodsItem := range r.Methods {
-			methods = append(methods, methodsItem.ValueString())
+		for methodsIndex := range r.Methods {
+			methods = append(methods, r.Methods[methodsIndex].ValueString())
 		}
 	}
 	name := new(string)
@@ -280,8 +280,8 @@ func (r *GatewayRouteResourceModel) ToSharedRouteJSON(ctx context.Context) (*sha
 	var paths []string
 	if r.Paths != nil {
 		paths = make([]string, 0, len(r.Paths))
-		for _, pathsItem := range r.Paths {
-			paths = append(paths, pathsItem.ValueString())
+		for pathsIndex := range r.Paths {
+			paths = append(paths, r.Paths[pathsIndex].ValueString())
 		}
 	}
 	preserveHost := new(bool)
@@ -330,23 +330,23 @@ func (r *GatewayRouteResourceModel) ToSharedRouteJSON(ctx context.Context) (*sha
 	var snis []string
 	if r.Snis != nil {
 		snis = make([]string, 0, len(r.Snis))
-		for _, snisItem := range r.Snis {
-			snis = append(snis, snisItem.ValueString())
+		for snisIndex := range r.Snis {
+			snis = append(snis, r.Snis[snisIndex].ValueString())
 		}
 	}
 	var sources []shared.Sources
 	if r.Sources != nil {
 		sources = make([]shared.Sources, 0, len(r.Sources))
-		for _, sourcesItem := range r.Sources {
+		for sourcesIndex := range r.Sources {
 			ip1 := new(string)
-			if !sourcesItem.IP.IsUnknown() && !sourcesItem.IP.IsNull() {
-				*ip1 = sourcesItem.IP.ValueString()
+			if !r.Sources[sourcesIndex].IP.IsUnknown() && !r.Sources[sourcesIndex].IP.IsNull() {
+				*ip1 = r.Sources[sourcesIndex].IP.ValueString()
 			} else {
 				ip1 = nil
 			}
 			port1 := new(int64)
-			if !sourcesItem.Port.IsUnknown() && !sourcesItem.Port.IsNull() {
-				*port1 = sourcesItem.Port.ValueInt64()
+			if !r.Sources[sourcesIndex].Port.IsUnknown() && !r.Sources[sourcesIndex].Port.IsNull() {
+				*port1 = r.Sources[sourcesIndex].Port.ValueInt64()
 			} else {
 				port1 = nil
 			}
@@ -365,8 +365,8 @@ func (r *GatewayRouteResourceModel) ToSharedRouteJSON(ctx context.Context) (*sha
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)

--- a/internal/provider/gatewayrouteexpression_resource.go
+++ b/internal/provider/gatewayrouteexpression_resource.go
@@ -419,7 +419,10 @@ func (r *GatewayRouteExpressionResource) Delete(ctx context.Context, req resourc
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewayrouteexpression_resource_sdk.go
+++ b/internal/provider/gatewayrouteexpression_resource_sdk.go
@@ -229,8 +229,8 @@ func (r *GatewayRouteExpressionResourceModel) ToSharedRouteExpression(ctx contex
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)

--- a/internal/provider/gatewayservice_resource.go
+++ b/internal/provider/gatewayservice_resource.go
@@ -474,7 +474,10 @@ func (r *GatewayServiceResource) Delete(ctx context.Context, req resource.Delete
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewayservice_resource_sdk.go
+++ b/internal/provider/gatewayservice_resource_sdk.go
@@ -160,8 +160,8 @@ func (r *GatewayServiceResourceModel) ToSharedService(ctx context.Context) (*sha
 	var caCertificates []string
 	if r.CaCertificates != nil {
 		caCertificates = make([]string, 0, len(r.CaCertificates))
-		for _, caCertificatesItem := range r.CaCertificates {
-			caCertificates = append(caCertificates, caCertificatesItem.ValueString())
+		for caCertificatesIndex := range r.CaCertificates {
+			caCertificates = append(caCertificates, r.CaCertificates[caCertificatesIndex].ValueString())
 		}
 	}
 	var clientCertificate *shared.ClientCertificate
@@ -242,8 +242,8 @@ func (r *GatewayServiceResourceModel) ToSharedService(ctx context.Context) (*sha
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	var tlsSans *shared.TLSSans
@@ -251,15 +251,15 @@ func (r *GatewayServiceResourceModel) ToSharedService(ctx context.Context) (*sha
 		var dnsnames []string
 		if r.TLSSans.Dnsnames != nil {
 			dnsnames = make([]string, 0, len(r.TLSSans.Dnsnames))
-			for _, dnsnamesItem := range r.TLSSans.Dnsnames {
-				dnsnames = append(dnsnames, dnsnamesItem.ValueString())
+			for dnsnamesIndex := range r.TLSSans.Dnsnames {
+				dnsnames = append(dnsnames, r.TLSSans.Dnsnames[dnsnamesIndex].ValueString())
 			}
 		}
 		var uris []string
 		if r.TLSSans.Uris != nil {
 			uris = make([]string, 0, len(r.TLSSans.Uris))
-			for _, urisItem := range r.TLSSans.Uris {
-				uris = append(uris, urisItem.ValueString())
+			for urisIndex := range r.TLSSans.Uris {
+				uris = append(uris, r.TLSSans.Uris[urisIndex].ValueString())
 			}
 		}
 		tlsSans = &shared.TLSSans{

--- a/internal/provider/gatewaysni_resource.go
+++ b/internal/provider/gatewaysni_resource.go
@@ -326,7 +326,10 @@ func (r *GatewaySNIResource) Delete(ctx context.Context, req resource.DeleteRequ
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaysni_resource_sdk.go
+++ b/internal/provider/gatewaysni_resource_sdk.go
@@ -140,8 +140,8 @@ func (r *GatewaySNIResourceModel) ToSharedSni(ctx context.Context) (*shared.Sni,
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)

--- a/internal/provider/gatewaytarget_resource.go
+++ b/internal/provider/gatewaytarget_resource.go
@@ -369,7 +369,10 @@ func (r *GatewayTargetResource) Delete(ctx context.Context, req resource.DeleteR
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewaytarget_resource_sdk.go
+++ b/internal/provider/gatewaytarget_resource_sdk.go
@@ -129,8 +129,8 @@ func (r *GatewayTargetResourceModel) ToSharedTargetWithoutParents(ctx context.Co
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	var target string

--- a/internal/provider/gatewayupstream_resource.go
+++ b/internal/provider/gatewayupstream_resource.go
@@ -762,7 +762,10 @@ func (r *GatewayUpstreamResource) Delete(ctx context.Context, req resource.Delet
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewayupstream_resource_sdk.go
+++ b/internal/provider/gatewayupstream_resource_sdk.go
@@ -333,10 +333,10 @@ func (r *GatewayUpstreamResourceModel) ToSharedUpstream(ctx context.Context) (*s
 			var headers map[string][]string
 			if r.Healthchecks.Active.Headers != nil {
 				headers = make(map[string][]string)
-				for headersKey, headersValue := range r.Healthchecks.Active.Headers {
-					headersInst := make([]string, 0, len(headersValue))
-					for _, item := range headersValue {
-						headersInst = append(headersInst, item.ValueString())
+				for headersKey := range r.Healthchecks.Active.Headers {
+					headersInst := make([]string, 0, len(r.Healthchecks.Active.Headers[headersKey]))
+					for index := range r.Healthchecks.Active.Headers[headersKey] {
+						headersInst = append(headersInst, r.Healthchecks.Active.Headers[headersKey][index].ValueString())
 					}
 					headers[headersKey] = headersInst
 				}
@@ -344,8 +344,8 @@ func (r *GatewayUpstreamResourceModel) ToSharedUpstream(ctx context.Context) (*s
 			var healthy *shared.Healthy
 			if r.Healthchecks.Active.Healthy != nil {
 				httpStatuses := make([]int64, 0, len(r.Healthchecks.Active.Healthy.HTTPStatuses))
-				for _, httpStatusesItem := range r.Healthchecks.Active.Healthy.HTTPStatuses {
-					httpStatuses = append(httpStatuses, httpStatusesItem.ValueInt64())
+				for httpStatusesIndex := range r.Healthchecks.Active.Healthy.HTTPStatuses {
+					httpStatuses = append(httpStatuses, r.Healthchecks.Active.Healthy.HTTPStatuses[httpStatusesIndex].ValueInt64())
 				}
 				interval := new(float64)
 				if !r.Healthchecks.Active.Healthy.Interval.IsUnknown() && !r.Healthchecks.Active.Healthy.Interval.IsNull() {
@@ -404,8 +404,8 @@ func (r *GatewayUpstreamResourceModel) ToSharedUpstream(ctx context.Context) (*s
 					httpFailures = nil
 				}
 				httpStatuses1 := make([]int64, 0, len(r.Healthchecks.Active.Unhealthy.HTTPStatuses))
-				for _, httpStatusesItem1 := range r.Healthchecks.Active.Unhealthy.HTTPStatuses {
-					httpStatuses1 = append(httpStatuses1, httpStatusesItem1.ValueInt64())
+				for httpStatusesIndex1 := range r.Healthchecks.Active.Unhealthy.HTTPStatuses {
+					httpStatuses1 = append(httpStatuses1, r.Healthchecks.Active.Unhealthy.HTTPStatuses[httpStatusesIndex1].ValueInt64())
 				}
 				interval1 := new(float64)
 				if !r.Healthchecks.Active.Unhealthy.Interval.IsUnknown() && !r.Healthchecks.Active.Unhealthy.Interval.IsNull() {
@@ -450,8 +450,8 @@ func (r *GatewayUpstreamResourceModel) ToSharedUpstream(ctx context.Context) (*s
 			var healthy1 *shared.UpstreamHealthy
 			if r.Healthchecks.Passive.Healthy != nil {
 				httpStatuses2 := make([]int64, 0, len(r.Healthchecks.Passive.Healthy.HTTPStatuses))
-				for _, httpStatusesItem2 := range r.Healthchecks.Passive.Healthy.HTTPStatuses {
-					httpStatuses2 = append(httpStatuses2, httpStatusesItem2.ValueInt64())
+				for httpStatusesIndex2 := range r.Healthchecks.Passive.Healthy.HTTPStatuses {
+					httpStatuses2 = append(httpStatuses2, r.Healthchecks.Passive.Healthy.HTTPStatuses[httpStatusesIndex2].ValueInt64())
 				}
 				successes1 := new(int64)
 				if !r.Healthchecks.Passive.Healthy.Successes.IsUnknown() && !r.Healthchecks.Passive.Healthy.Successes.IsNull() {
@@ -479,8 +479,8 @@ func (r *GatewayUpstreamResourceModel) ToSharedUpstream(ctx context.Context) (*s
 					httpFailures1 = nil
 				}
 				httpStatuses3 := make([]int64, 0, len(r.Healthchecks.Passive.Unhealthy.HTTPStatuses))
-				for _, httpStatusesItem3 := range r.Healthchecks.Passive.Unhealthy.HTTPStatuses {
-					httpStatuses3 = append(httpStatuses3, httpStatusesItem3.ValueInt64())
+				for httpStatusesIndex3 := range r.Healthchecks.Passive.Unhealthy.HTTPStatuses {
+					httpStatuses3 = append(httpStatuses3, r.Healthchecks.Passive.Unhealthy.HTTPStatuses[httpStatusesIndex3].ValueInt64())
 				}
 				tcpFailures1 := new(int64)
 				if !r.Healthchecks.Passive.Unhealthy.TCPFailures.IsUnknown() && !r.Healthchecks.Passive.Unhealthy.TCPFailures.IsNull() {
@@ -555,8 +555,8 @@ func (r *GatewayUpstreamResourceModel) ToSharedUpstream(ctx context.Context) (*s
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)

--- a/internal/provider/gatewayvault_resource.go
+++ b/internal/provider/gatewayvault_resource.go
@@ -332,7 +332,10 @@ func (r *GatewayVaultResource) Delete(ctx context.Context, req resource.DeleteRe
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/gatewayvault_resource_sdk.go
+++ b/internal/provider/gatewayvault_resource_sdk.go
@@ -153,8 +153,8 @@ func (r *GatewayVaultResourceModel) ToSharedVault(ctx context.Context) (*shared.
 	var tags []string
 	if r.Tags != nil {
 		tags = make([]string, 0, len(r.Tags))
-		for _, tagsItem := range r.Tags {
-			tags = append(tags, tagsItem.ValueString())
+		for tagsIndex := range r.Tags {
+			tags = append(tags, r.Tags[tagsIndex].ValueString())
 		}
 	}
 	updatedAt := new(int64)

--- a/internal/provider/integrationinstance_resource.go
+++ b/internal/provider/integrationinstance_resource.go
@@ -19,7 +19,6 @@ import (
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect/v3/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect/v3/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect/v3/internal/sdk"
-	"github.com/kong/terraform-provider-konnect/v3/internal/validators"
 	"regexp"
 )
 
@@ -79,9 +78,6 @@ func (r *IntegrationInstanceResource) Schema(ctx context.Context, req resource.S
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity creation date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"description": schema.StringAttribute{
 				Optional:    true,
@@ -141,9 +137,6 @@ func (r *IntegrationInstanceResource) Schema(ctx context.Context, req resource.S
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity update date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 		},
 	}
@@ -416,7 +409,10 @@ func (r *IntegrationInstanceResource) Delete(ctx context.Context, req resource.D
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/integrationinstanceauthconfig_resource.go
+++ b/internal/provider/integrationinstanceauthconfig_resource.go
@@ -76,11 +76,6 @@ func (r *IntegrationInstanceAuthConfigResource) Schema(ctx context.Context, req 
 						Description: `The URL used to retrieve access tokens.`,
 					},
 				},
-				Validators: []validator.Object{
-					objectvalidator.ConflictsWith(path.Expressions{
-						path.MatchRelative().AtParent().AtName("oauth_config"),
-					}...),
-				},
 			},
 			"oauth_config": schema.SingleNestedAttribute{
 				Optional: true,
@@ -346,7 +341,10 @@ func (r *IntegrationInstanceAuthConfigResource) Delete(ctx context.Context, req 
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/integrationinstanceauthcredential_resource_sdk.go
+++ b/internal/provider/integrationinstanceauthcredential_resource_sdk.go
@@ -102,12 +102,12 @@ func (r *IntegrationInstanceAuthCredentialResourceModel) ToSharedCreateIntegrati
 	var multiKeyAuth *shared.MultiKeyAuth
 	if r.MultiKeyAuth != nil {
 		headers := make([]shared.Headers, 0, len(r.MultiKeyAuth.Config.Headers))
-		for _, headersItem := range r.MultiKeyAuth.Config.Headers {
+		for headersIndex := range r.MultiKeyAuth.Config.Headers {
 			var name string
-			name = headersItem.Name.ValueString()
+			name = r.MultiKeyAuth.Config.Headers[headersIndex].Name.ValueString()
 
 			var key string
-			key = headersItem.Key.ValueString()
+			key = r.MultiKeyAuth.Config.Headers[headersIndex].Key.ValueString()
 
 			headers = append(headers, shared.Headers{
 				Name: name,

--- a/internal/provider/meshcontrolplane_resource.go
+++ b/internal/provider/meshcontrolplane_resource.go
@@ -23,7 +23,6 @@ import (
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect/v3/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect/v3/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect/v3/internal/sdk"
-	"github.com/kong/terraform-provider-konnect/v3/internal/validators"
 	speakeasy_boolvalidators "github.com/kong/terraform-provider-konnect/v3/internal/validators/boolvalidators"
 	speakeasy_objectvalidators "github.com/kong/terraform-provider-konnect/v3/internal/validators/objectvalidators"
 	speakeasy_stringvalidators "github.com/kong/terraform-provider-konnect/v3/internal/validators/stringvalidators"
@@ -67,9 +66,6 @@ func (r *MeshControlPlaneResource) Schema(ctx context.Context, req resource.Sche
 				Computed: true,
 				PlanModifiers: []planmodifier.String{
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
-				},
-				Validators: []validator.String{
-					validators.IsRFC3339(),
 				},
 			},
 			"description": schema.StringAttribute{
@@ -186,9 +182,6 @@ func (r *MeshControlPlaneResource) Schema(ctx context.Context, req resource.Sche
 				Computed: true,
 				PlanModifiers: []planmodifier.String{
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
-				},
-				Validators: []validator.String{
-					validators.IsRFC3339(),
 				},
 			},
 		},
@@ -425,7 +418,10 @@ func (r *MeshControlPlaneResource) Delete(ctx context.Context, req resource.Dele
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/meshcontrolplane_resource_sdk.go
+++ b/internal/provider/meshcontrolplane_resource_sdk.go
@@ -113,21 +113,21 @@ func (r *MeshControlPlaneResourceModel) ToSharedCreateMeshControlPlaneRequest(ct
 		description = nil
 	}
 	features := make([]shared.MeshControlPlaneFeature, 0, len(r.Features))
-	for _, featuresItem := range r.Features {
-		typeVar := shared.Type(featuresItem.Type.ValueString())
+	for featuresIndex := range r.Features {
+		typeVar := shared.Type(r.Features[featuresIndex].Type.ValueString())
 		var hostnameGeneratorCreation *shared.MeshControlPlaneFeatureHostnameGenerationCreation
-		if featuresItem.HostnameGeneratorCreation != nil {
+		if r.Features[featuresIndex].HostnameGeneratorCreation != nil {
 			var enabled bool
-			enabled = featuresItem.HostnameGeneratorCreation.Enabled.ValueBool()
+			enabled = r.Features[featuresIndex].HostnameGeneratorCreation.Enabled.ValueBool()
 
 			hostnameGeneratorCreation = &shared.MeshControlPlaneFeatureHostnameGenerationCreation{
 				Enabled: enabled,
 			}
 		}
 		var meshCreation *shared.MeshControlPlaneFeatureMeshCreation
-		if featuresItem.MeshCreation != nil {
+		if r.Features[featuresIndex].MeshCreation != nil {
 			var enabled1 bool
-			enabled1 = featuresItem.MeshCreation.Enabled.ValueBool()
+			enabled1 = r.Features[featuresIndex].MeshCreation.Enabled.ValueBool()
 
 			meshCreation = &shared.MeshControlPlaneFeatureMeshCreation{
 				Enabled: enabled1,
@@ -142,10 +142,10 @@ func (r *MeshControlPlaneResourceModel) ToSharedCreateMeshControlPlaneRequest(ct
 	var labels map[string]*string
 	if r.Labels != nil {
 		labels = make(map[string]*string)
-		for labelsKey, labelsValue := range r.Labels {
+		for labelsKey := range r.Labels {
 			labelsInst := new(string)
-			if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-				*labelsInst = labelsValue.ValueString()
+			if !r.Labels[labelsKey].IsUnknown() && !r.Labels[labelsKey].IsNull() {
+				*labelsInst = r.Labels[labelsKey].ValueString()
 			} else {
 				labelsInst = nil
 			}
@@ -177,9 +177,9 @@ func (r *MeshControlPlaneResourceModel) ToSharedPutMeshControlPlaneRequest(ctx c
 	var labels map[string]string
 	if r.Labels != nil {
 		labels = make(map[string]string)
-		for labelsKey, labelsValue := range r.Labels {
+		for labelsKey := range r.Labels {
 			var labelsInst string
-			labelsInst = labelsValue.ValueString()
+			labelsInst = r.Labels[labelsKey].ValueString()
 
 			labels[labelsKey] = labelsInst
 		}

--- a/internal/provider/portal_resource.go
+++ b/internal/provider/portal_resource.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect/v3/internal/planmodifiers/stringplanmodifier"
 	"github.com/kong/terraform-provider-konnect/v3/internal/sdk"
-	"github.com/kong/terraform-provider-konnect/v3/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -94,9 +93,6 @@ func (r *PortalResource) Schema(ctx context.Context, req resource.SchemaRequest,
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity creation date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"default_api_visibility": schema.StringAttribute{
 				Computed:    true,
@@ -197,9 +193,6 @@ func (r *PortalResource) Schema(ctx context.Context, req resource.SchemaRequest,
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity update date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 		},
 	}
@@ -435,7 +428,10 @@ func (r *PortalResource) Delete(ctx context.Context, req resource.DeleteRequest,
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/portal_resource_sdk.go
+++ b/internal/provider/portal_resource_sdk.go
@@ -158,10 +158,10 @@ func (r *PortalResourceModel) ToSharedCreatePortal(ctx context.Context) (*shared
 	var labels map[string]*string
 	if r.Labels != nil {
 		labels = make(map[string]*string)
-		for labelsKey, labelsValue := range r.Labels {
+		for labelsKey := range r.Labels {
 			labelsInst := new(string)
-			if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-				*labelsInst = labelsValue.ValueString()
+			if !r.Labels[labelsKey].IsUnknown() && !r.Labels[labelsKey].IsNull() {
+				*labelsInst = r.Labels[labelsKey].ValueString()
 			} else {
 				labelsInst = nil
 			}
@@ -251,10 +251,10 @@ func (r *PortalResourceModel) ToSharedUpdatePortal(ctx context.Context) (*shared
 	var labels map[string]*string
 	if r.Labels != nil {
 		labels = make(map[string]*string)
-		for labelsKey, labelsValue := range r.Labels {
+		for labelsKey := range r.Labels {
 			labelsInst := new(string)
-			if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-				*labelsInst = labelsValue.ValueString()
+			if !r.Labels[labelsKey].IsUnknown() && !r.Labels[labelsKey].IsNull() {
+				*labelsInst = r.Labels[labelsKey].ValueString()
 			} else {
 				labelsInst = nil
 			}

--- a/internal/provider/portalauth_resource_sdk.go
+++ b/internal/provider/portalauth_resource_sdk.go
@@ -139,8 +139,8 @@ func (r *PortalAuthResourceModel) ToSharedPortalAuthenticationSettingsUpdateRequ
 	var oidcScopes []string
 	if r.OidcScopes != nil {
 		oidcScopes = make([]string, 0, len(r.OidcScopes))
-		for _, oidcScopesItem := range r.OidcScopes {
-			oidcScopes = append(oidcScopes, oidcScopesItem.ValueString())
+		for oidcScopesIndex := range r.OidcScopes {
+			oidcScopes = append(oidcScopes, r.OidcScopes[oidcScopesIndex].ValueString())
 		}
 	}
 	var oidcClaimMappings *shared.PortalAuthenticationSettingsUpdateRequestPortalClaimMappings

--- a/internal/provider/portalclassic_resource.go
+++ b/internal/provider/portalclassic_resource.go
@@ -16,7 +16,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect/v3/internal/planmodifiers/stringplanmodifier"
 	"github.com/kong/terraform-provider-konnect/v3/internal/sdk"
-	"github.com/kong/terraform-provider-konnect/v3/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -82,9 +81,6 @@ func (r *PortalClassicResource) Schema(ctx context.Context, req resource.SchemaR
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity creation date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"custom_client_domain": schema.StringAttribute{
 				Optional:    true,
@@ -183,9 +179,6 @@ func (r *PortalClassicResource) Schema(ctx context.Context, req resource.SchemaR
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity update date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 		},
 	}
@@ -421,7 +414,10 @@ func (r *PortalClassicResource) Delete(ctx context.Context, req resource.DeleteR
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/portalclassic_resource_sdk.go
+++ b/internal/provider/portalclassic_resource_sdk.go
@@ -158,10 +158,10 @@ func (r *PortalClassicResourceModel) ToSharedV2CreatePortalRequest(ctx context.C
 		defaultApplicationAuthStrategyID = nil
 	}
 	labels := make(map[string]*string)
-	for labelsKey, labelsValue := range r.Labels {
+	for labelsKey := range r.Labels {
 		labelsInst := new(string)
-		if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-			*labelsInst = labelsValue.ValueString()
+		if !r.Labels[labelsKey].IsUnknown() && !r.Labels[labelsKey].IsNull() {
+			*labelsInst = r.Labels[labelsKey].ValueString()
 		} else {
 			labelsInst = nil
 		}
@@ -250,10 +250,10 @@ func (r *PortalClassicResourceModel) ToSharedV2UpdatePortalRequest(ctx context.C
 	var labels map[string]*string
 	if r.Labels != nil {
 		labels = make(map[string]*string)
-		for labelsKey, labelsValue := range r.Labels {
+		for labelsKey := range r.Labels {
 			labelsInst := new(string)
-			if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-				*labelsInst = labelsValue.ValueString()
+			if !r.Labels[labelsKey].IsUnknown() && !r.Labels[labelsKey].IsNull() {
+				*labelsInst = r.Labels[labelsKey].ValueString()
 			} else {
 				labelsInst = nil
 			}

--- a/internal/provider/portalcustomdomain_resource.go
+++ b/internal/provider/portalcustomdomain_resource.go
@@ -22,7 +22,6 @@ import (
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect/v3/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect/v3/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect/v3/internal/sdk"
-	"github.com/kong/terraform-provider-konnect/v3/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -63,13 +62,6 @@ func (r *PortalCustomDomainResource) Schema(ctx context.Context, req resource.Sc
 				PlanModifiers: []planmodifier.String{
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
-				Description: `must be one of ["verified", "pending"]`,
-				Validators: []validator.String{
-					stringvalidator.OneOf(
-						"verified",
-						"pending",
-					),
-				},
 			},
 			"created_at": schema.StringAttribute{
 				Computed: true,
@@ -77,9 +69,6 @@ func (r *PortalCustomDomainResource) Schema(ctx context.Context, req resource.Sc
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity creation date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"enabled": schema.BoolAttribute{
 				Required: true,
@@ -138,9 +127,6 @@ func (r *PortalCustomDomainResource) Schema(ctx context.Context, req resource.Sc
 							speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 						},
 						Description: `An ISO-8601 timestamp representation of the ssl certificate expiration date.`,
-						Validators: []validator.String{
-							validators.IsRFC3339(),
-						},
 					},
 					"skip_ca_check": schema.BoolAttribute{
 						Computed: true,
@@ -157,9 +143,6 @@ func (r *PortalCustomDomainResource) Schema(ctx context.Context, req resource.Sc
 							speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 						},
 						Description: `An ISO-8601 timestamp representation of the ssl certificate upload date.`,
-						Validators: []validator.String{
-							validators.IsRFC3339(),
-						},
 					},
 					"validation_errors": schema.ListAttribute{
 						Computed: true,
@@ -173,14 +156,6 @@ func (r *PortalCustomDomainResource) Schema(ctx context.Context, req resource.Sc
 						PlanModifiers: []planmodifier.String{
 							speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 						},
-						Description: `must be one of ["verified", "pending", "error"]`,
-						Validators: []validator.String{
-							stringvalidator.OneOf(
-								"verified",
-								"pending",
-								"error",
-							),
-						},
 					},
 				},
 				Description: `Requires replacement if changed.`,
@@ -191,9 +166,6 @@ func (r *PortalCustomDomainResource) Schema(ctx context.Context, req resource.Sc
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity update date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 		},
 	}
@@ -466,7 +438,10 @@ func (r *PortalCustomDomainResource) Delete(ctx context.Context, req resource.De
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/portalcustomization_resource_sdk.go
+++ b/internal/provider/portalcustomization_resource_sdk.go
@@ -194,16 +194,16 @@ func (r *PortalCustomizationResourceModel) ToSharedPortalCustomization(ctx conte
 		var main []shared.PortalMenuItem
 		if r.Menu.Main != nil {
 			main = make([]shared.PortalMenuItem, 0, len(r.Menu.Main))
-			for _, mainItem := range r.Menu.Main {
+			for mainIndex := range r.Menu.Main {
 				var path string
-				path = mainItem.Path.ValueString()
+				path = r.Menu.Main[mainIndex].Path.ValueString()
 
 				var title string
-				title = mainItem.Title.ValueString()
+				title = r.Menu.Main[mainIndex].Title.ValueString()
 
-				visibility := shared.Visibility(mainItem.Visibility.ValueString())
+				visibility := shared.Visibility(r.Menu.Main[mainIndex].Visibility.ValueString())
 				var external bool
-				external = mainItem.External.ValueBool()
+				external = r.Menu.Main[mainIndex].External.ValueBool()
 
 				main = append(main, shared.PortalMenuItem{
 					Path:       path,
@@ -216,21 +216,21 @@ func (r *PortalCustomizationResourceModel) ToSharedPortalCustomization(ctx conte
 		var footerSections []shared.PortalFooterMenuSection
 		if r.Menu.FooterSections != nil {
 			footerSections = make([]shared.PortalFooterMenuSection, 0, len(r.Menu.FooterSections))
-			for _, footerSectionsItem := range r.Menu.FooterSections {
+			for footerSectionsIndex := range r.Menu.FooterSections {
 				var title1 string
-				title1 = footerSectionsItem.Title.ValueString()
+				title1 = r.Menu.FooterSections[footerSectionsIndex].Title.ValueString()
 
-				items := make([]shared.PortalMenuItem, 0, len(footerSectionsItem.Items))
-				for _, itemsItem := range footerSectionsItem.Items {
+				items := make([]shared.PortalMenuItem, 0, len(r.Menu.FooterSections[footerSectionsIndex].Items))
+				for itemsIndex := range r.Menu.FooterSections[footerSectionsIndex].Items {
 					var path1 string
-					path1 = itemsItem.Path.ValueString()
+					path1 = r.Menu.FooterSections[footerSectionsIndex].Items[itemsIndex].Path.ValueString()
 
 					var title2 string
-					title2 = itemsItem.Title.ValueString()
+					title2 = r.Menu.FooterSections[footerSectionsIndex].Items[itemsIndex].Title.ValueString()
 
-					visibility1 := shared.Visibility(itemsItem.Visibility.ValueString())
+					visibility1 := shared.Visibility(r.Menu.FooterSections[footerSectionsIndex].Items[itemsIndex].Visibility.ValueString())
 					var external1 bool
-					external1 = itemsItem.External.ValueBool()
+					external1 = r.Menu.FooterSections[footerSectionsIndex].Items[itemsIndex].External.ValueBool()
 
 					items = append(items, shared.PortalMenuItem{
 						Path:       path1,
@@ -248,16 +248,16 @@ func (r *PortalCustomizationResourceModel) ToSharedPortalCustomization(ctx conte
 		var footerBottom []shared.PortalMenuItem
 		if r.Menu.FooterBottom != nil {
 			footerBottom = make([]shared.PortalMenuItem, 0, len(r.Menu.FooterBottom))
-			for _, footerBottomItem := range r.Menu.FooterBottom {
+			for footerBottomIndex := range r.Menu.FooterBottom {
 				var path2 string
-				path2 = footerBottomItem.Path.ValueString()
+				path2 = r.Menu.FooterBottom[footerBottomIndex].Path.ValueString()
 
 				var title3 string
-				title3 = footerBottomItem.Title.ValueString()
+				title3 = r.Menu.FooterBottom[footerBottomIndex].Title.ValueString()
 
-				visibility2 := shared.Visibility(footerBottomItem.Visibility.ValueString())
+				visibility2 := shared.Visibility(r.Menu.FooterBottom[footerBottomIndex].Visibility.ValueString())
 				var external2 bool
-				external2 = footerBottomItem.External.ValueBool()
+				external2 = r.Menu.FooterBottom[footerBottomIndex].External.ValueBool()
 
 				footerBottom = append(footerBottom, shared.PortalMenuItem{
 					Path:       path2,

--- a/internal/provider/portalpage_resource.go
+++ b/internal/provider/portalpage_resource.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect/v3/internal/planmodifiers/stringplanmodifier"
 	"github.com/kong/terraform-provider-konnect/v3/internal/sdk"
-	"github.com/kong/terraform-provider-konnect/v3/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -70,9 +69,6 @@ func (r *PortalPageResource) Schema(ctx context.Context, req resource.SchemaRequ
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity creation date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"description": schema.StringAttribute{
 				Computed: true,
@@ -133,9 +129,6 @@ func (r *PortalPageResource) Schema(ctx context.Context, req resource.SchemaRequ
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity update date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"visibility": schema.StringAttribute{
 				Computed: true,
@@ -384,7 +377,10 @@ func (r *PortalPageResource) Delete(ctx context.Context, req resource.DeleteRequ
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/portalproductversion_resource_sdk.go
+++ b/internal/provider/portalproductversion_resource_sdk.go
@@ -125,8 +125,8 @@ func (r *PortalProductVersionResourceModel) ToSharedV2ReplacePortalProductVersio
 
 	publishStatus := shared.V2PortalProductVersionPublishStatus(r.PublishStatus.ValueString())
 	authStrategyIds := make([]string, 0, len(r.AuthStrategyIds))
-	for _, authStrategyIdsItem := range r.AuthStrategyIds {
-		authStrategyIds = append(authStrategyIds, authStrategyIdsItem.ValueString())
+	for authStrategyIdsIndex := range r.AuthStrategyIds {
+		authStrategyIds = append(authStrategyIds, r.AuthStrategyIds[authStrategyIdsIndex].ValueString())
 	}
 	var applicationRegistrationEnabled bool
 	applicationRegistrationEnabled = r.ApplicationRegistrationEnabled.ValueBool()

--- a/internal/provider/portalsnippet_resource.go
+++ b/internal/provider/portalsnippet_resource.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect/v3/internal/planmodifiers/stringplanmodifier"
 	"github.com/kong/terraform-provider-konnect/v3/internal/sdk"
-	"github.com/kong/terraform-provider-konnect/v3/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -69,9 +68,6 @@ func (r *PortalSnippetResource) Schema(ctx context.Context, req resource.SchemaR
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity creation date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"description": schema.StringAttribute{
 				Computed: true,
@@ -123,9 +119,6 @@ func (r *PortalSnippetResource) Schema(ctx context.Context, req resource.SchemaR
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity update date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"visibility": schema.StringAttribute{
 				Computed: true,
@@ -374,7 +367,10 @@ func (r *PortalSnippetResource) Delete(ctx context.Context, req resource.DeleteR
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/portalteam_resource.go
+++ b/internal/provider/portalteam_resource.go
@@ -17,7 +17,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect/v3/internal/planmodifiers/stringplanmodifier"
 	"github.com/kong/terraform-provider-konnect/v3/internal/sdk"
-	"github.com/kong/terraform-provider-konnect/v3/internal/validators"
 	"regexp"
 )
 
@@ -58,9 +57,6 @@ func (r *PortalTeamResource) Schema(ctx context.Context, req resource.SchemaRequ
 				PlanModifiers: []planmodifier.String{
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"description": schema.StringAttribute{
 				Optional: true,
@@ -89,9 +85,6 @@ func (r *PortalTeamResource) Schema(ctx context.Context, req resource.SchemaRequ
 				Computed: true,
 				PlanModifiers: []planmodifier.String{
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
-				},
-				Validators: []validator.String{
-					validators.IsRFC3339(),
 				},
 			},
 		},
@@ -328,7 +321,10 @@ func (r *PortalTeamResource) Delete(ctx context.Context, req resource.DeleteRequ
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/realm_resource.go
+++ b/internal/provider/realm_resource.go
@@ -20,7 +20,6 @@ import (
 	speakeasy_setplanmodifier "github.com/kong/terraform-provider-konnect/v3/internal/planmodifiers/setplanmodifier"
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect/v3/internal/planmodifiers/stringplanmodifier"
 	"github.com/kong/terraform-provider-konnect/v3/internal/sdk"
-	"github.com/kong/terraform-provider-konnect/v3/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -90,9 +89,6 @@ func (r *RealmResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity creation date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"force_destroy": schema.StringAttribute{
 				Computed: true,
@@ -149,9 +145,6 @@ func (r *RealmResource) Schema(ctx context.Context, req resource.SchemaRequest, 
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `An ISO-8601 timestamp representation of entity update date.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 		},
 	}
@@ -387,7 +380,10 @@ func (r *RealmResource) Delete(ctx context.Context, req resource.DeleteRequest, 
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/realm_resource_sdk.go
+++ b/internal/provider/realm_resource_sdk.go
@@ -96,8 +96,8 @@ func (r *RealmResourceModel) ToSharedConsumerRealmCreateRequest(ctx context.Cont
 	name = r.Name.ValueString()
 
 	allowedControlPlanes := make([]string, 0, len(r.AllowedControlPlanes))
-	for _, allowedControlPlanesItem := range r.AllowedControlPlanes {
-		allowedControlPlanes = append(allowedControlPlanes, allowedControlPlanesItem.ValueString())
+	for allowedControlPlanesIndex := range r.AllowedControlPlanes {
+		allowedControlPlanes = append(allowedControlPlanes, r.AllowedControlPlanes[allowedControlPlanesIndex].ValueString())
 	}
 	allowAllControlPlanes := new(bool)
 	if !r.AllowAllControlPlanes.IsUnknown() && !r.AllowAllControlPlanes.IsNull() {
@@ -118,8 +118,8 @@ func (r *RealmResourceModel) ToSharedConsumerRealmCreateRequest(ctx context.Cont
 		negativeTTL = nil
 	}
 	consumerGroups := make([]string, 0, len(r.ConsumerGroups))
-	for _, consumerGroupsItem := range r.ConsumerGroups {
-		consumerGroups = append(consumerGroups, consumerGroupsItem.ValueString())
+	for consumerGroupsIndex := range r.ConsumerGroups {
+		consumerGroups = append(consumerGroups, r.ConsumerGroups[consumerGroupsIndex].ValueString())
 	}
 	out := shared.ConsumerRealmCreateRequest{
 		Name:                  name,
@@ -143,8 +143,8 @@ func (r *RealmResourceModel) ToSharedConsumerRealmUpdateRequest(ctx context.Cont
 		name = nil
 	}
 	allowedControlPlanes := make([]string, 0, len(r.AllowedControlPlanes))
-	for _, allowedControlPlanesItem := range r.AllowedControlPlanes {
-		allowedControlPlanes = append(allowedControlPlanes, allowedControlPlanesItem.ValueString())
+	for allowedControlPlanesIndex := range r.AllowedControlPlanes {
+		allowedControlPlanes = append(allowedControlPlanes, r.AllowedControlPlanes[allowedControlPlanesIndex].ValueString())
 	}
 	allowAllControlPlanes := new(bool)
 	if !r.AllowAllControlPlanes.IsUnknown() && !r.AllowAllControlPlanes.IsNull() {
@@ -153,8 +153,8 @@ func (r *RealmResourceModel) ToSharedConsumerRealmUpdateRequest(ctx context.Cont
 		allowAllControlPlanes = nil
 	}
 	consumerGroups := make([]string, 0, len(r.ConsumerGroups))
-	for _, consumerGroupsItem := range r.ConsumerGroups {
-		consumerGroups = append(consumerGroups, consumerGroupsItem.ValueString())
+	for consumerGroupsIndex := range r.ConsumerGroups {
+		consumerGroups = append(consumerGroups, r.ConsumerGroups[consumerGroupsIndex].ValueString())
 	}
 	ttl := new(int64)
 	if !r.TTL.IsUnknown() && !r.TTL.IsNull() {

--- a/internal/provider/serverlesscloudgateway_resource.go
+++ b/internal/provider/serverlesscloudgateway_resource.go
@@ -21,7 +21,6 @@ import (
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect/v3/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect/v3/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect/v3/internal/sdk"
-	"github.com/kong/terraform-provider-konnect/v3/internal/validators"
 )
 
 // Ensure provider defined types fully satisfy framework interfaces.
@@ -118,9 +117,6 @@ func (r *ServerlessCloudGatewayResource) Schema(ctx context.Context, req resourc
 				PlanModifiers: []planmodifier.String{
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"gateway_endpoint": schema.StringAttribute{
 				Computed: true,
@@ -143,9 +139,6 @@ func (r *ServerlessCloudGatewayResource) Schema(ctx context.Context, req resourc
 				Computed: true,
 				PlanModifiers: []planmodifier.String{
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
-				},
-				Validators: []validator.String{
-					validators.IsRFC3339(),
 				},
 			},
 		},
@@ -383,7 +376,10 @@ func (r *ServerlessCloudGatewayResource) Delete(ctx context.Context, req resourc
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/serverlesscloudgateway_resource_sdk.go
+++ b/internal/provider/serverlesscloudgateway_resource_sdk.go
@@ -80,9 +80,9 @@ func (r *ServerlessCloudGatewayResourceModel) ToSharedCreateServerlessCloudGatew
 	clusterCertKey = r.ClusterCertKey.ValueString()
 
 	labels := make(map[string]string)
-	for labelsKey, labelsValue := range r.Labels {
+	for labelsKey := range r.Labels {
 		var labelsInst string
-		labelsInst = labelsValue.ValueString()
+		labelsInst = r.Labels[labelsKey].ValueString()
 
 		labels[labelsKey] = labelsInst
 	}

--- a/internal/provider/systemaccountrole_resource.go
+++ b/internal/provider/systemaccountrole_resource.go
@@ -215,6 +215,13 @@ func (r *SystemAccountRoleResource) Create(ctx context.Context, req resource.Cre
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
+	if res.StatusCode == 409 {
+		resp.Diagnostics.AddError(
+			"Resource Already Exists",
+			"When creating this resource, the API indicated that this resource already exists. You can bring the existing resource under management using Terraform import functionality or retry with a unique configuration.",
+		)
+		return
+	}
 	if res.StatusCode != 201 {
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
@@ -319,7 +326,10 @@ func (r *SystemAccountRoleResource) Delete(ctx context.Context, req resource.Del
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/systemaccountteam_resource.go
+++ b/internal/provider/systemaccountteam_resource.go
@@ -116,6 +116,13 @@ func (r *SystemAccountTeamResource) Create(ctx context.Context, req resource.Cre
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
+	if res.StatusCode == 409 {
+		resp.Diagnostics.AddError(
+			"Resource Already Exists",
+			"When creating this resource, the API indicated that this resource already exists. You can bring the existing resource under management using Terraform import functionality or retry with a unique configuration.",
+		)
+		return
+	}
 	if res.StatusCode != 201 {
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
@@ -211,7 +218,10 @@ func (r *SystemAccountTeamResource) Delete(ctx context.Context, req resource.Del
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/team_resource.go
+++ b/internal/provider/team_resource.go
@@ -17,7 +17,6 @@ import (
 	speakeasy_boolplanmodifier "github.com/kong/terraform-provider-konnect/v3/internal/planmodifiers/boolplanmodifier"
 	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect/v3/internal/planmodifiers/stringplanmodifier"
 	"github.com/kong/terraform-provider-konnect/v3/internal/sdk"
-	"github.com/kong/terraform-provider-konnect/v3/internal/validators"
 	"regexp"
 )
 
@@ -60,9 +59,6 @@ func (r *TeamResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `A Unix timestamp representation of team creation.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 			"description": schema.StringAttribute{
 				Optional:    true,
@@ -108,9 +104,6 @@ func (r *TeamResource) Schema(ctx context.Context, req resource.SchemaRequest, r
 					speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
 				},
 				Description: `A Unix timestamp representation of the most recent change to the team object in Konnect.`,
-				Validators: []validator.String{
-					validators.IsRFC3339(),
-				},
 			},
 		},
 	}
@@ -346,7 +339,10 @@ func (r *TeamResource) Delete(ctx context.Context, req resource.DeleteRequest, r
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/team_resource_sdk.go
+++ b/internal/provider/team_resource_sdk.go
@@ -92,10 +92,10 @@ func (r *TeamResourceModel) ToSharedCreateTeam(ctx context.Context) (*shared.Cre
 		description = nil
 	}
 	labels := make(map[string]*string)
-	for labelsKey, labelsValue := range r.Labels {
+	for labelsKey := range r.Labels {
 		labelsInst := new(string)
-		if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-			*labelsInst = labelsValue.ValueString()
+		if !r.Labels[labelsKey].IsUnknown() && !r.Labels[labelsKey].IsNull() {
+			*labelsInst = r.Labels[labelsKey].ValueString()
 		} else {
 			labelsInst = nil
 		}
@@ -128,10 +128,10 @@ func (r *TeamResourceModel) ToSharedUpdateTeam(ctx context.Context) (*shared.Upd
 	var labels map[string]*string
 	if r.Labels != nil {
 		labels = make(map[string]*string)
-		for labelsKey, labelsValue := range r.Labels {
+		for labelsKey := range r.Labels {
 			labelsInst := new(string)
-			if !labelsValue.IsUnknown() && !labelsValue.IsNull() {
-				*labelsInst = labelsValue.ValueString()
+			if !r.Labels[labelsKey].IsUnknown() && !r.Labels[labelsKey].IsNull() {
+				*labelsInst = r.Labels[labelsKey].ValueString()
 			} else {
 				labelsInst = nil
 			}

--- a/internal/provider/teamrole_resource.go
+++ b/internal/provider/teamrole_resource.go
@@ -215,6 +215,13 @@ func (r *TeamRoleResource) Create(ctx context.Context, req resource.CreateReques
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
+	if res.StatusCode == 409 {
+		resp.Diagnostics.AddError(
+			"Resource Already Exists",
+			"When creating this resource, the API indicated that this resource already exists. You can bring the existing resource under management using Terraform import functionality or retry with a unique configuration.",
+		)
+		return
+	}
 	if res.StatusCode != 201 {
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
@@ -319,7 +326,10 @@ func (r *TeamRoleResource) Delete(ctx context.Context, req resource.DeleteReques
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/provider/teamuser_resource.go
+++ b/internal/provider/teamuser_resource.go
@@ -116,6 +116,13 @@ func (r *TeamUserResource) Create(ctx context.Context, req resource.CreateReques
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
+	if res.StatusCode == 409 {
+		resp.Diagnostics.AddError(
+			"Resource Already Exists",
+			"When creating this resource, the API indicated that this resource already exists. You can bring the existing resource under management using Terraform import functionality or retry with a unique configuration.",
+		)
+		return
+	}
 	if res.StatusCode != 201 {
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
@@ -211,7 +218,10 @@ func (r *TeamUserResource) Delete(ctx context.Context, req resource.DeleteReques
 		resp.Diagnostics.AddError("unexpected response from API", fmt.Sprintf("%v", res))
 		return
 	}
-	if res.StatusCode != 204 {
+	switch res.StatusCode {
+	case 204, 404:
+		break
+	default:
 		resp.Diagnostics.AddError(fmt.Sprintf("unexpected response from API. Got an unexpected response code %v", res.StatusCode), debugResponse(res.RawResponse))
 		return
 	}

--- a/internal/sdk/acls.go
+++ b/internal/sdk/acls.go
@@ -264,6 +264,7 @@ func (s *ACLs) DeleteACLWithConsumer(ctx context.Context, request operations.Del
 
 	switch {
 	case httpRes.StatusCode == 204:
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/apikeys.go
+++ b/internal/sdk/apikeys.go
@@ -264,6 +264,7 @@ func (s *APIKeys) DeleteKeyAuthWithConsumer(ctx context.Context, request operati
 
 	switch {
 	case httpRes.StatusCode == 204:
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/assets.go
+++ b/internal/sdk/assets.go
@@ -196,6 +196,7 @@ func (s *Assets) GetPortalAssetFavicon(ctx context.Context, request operations.G
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -580,6 +581,7 @@ func (s *Assets) GetPortalAssetLogo(ctx context.Context, request operations.GetP
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/auditlogs.go
+++ b/internal/sdk/auditlogs.go
@@ -1228,6 +1228,7 @@ func (s *AuditLogs) GetAuditLogWebhook(ctx context.Context, opts ...operations.O
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -1434,6 +1435,7 @@ func (s *AuditLogs) DeleteAuditLogWebhook(ctx context.Context, request *operatio
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/basicauthcredentials.go
+++ b/internal/sdk/basicauthcredentials.go
@@ -264,6 +264,7 @@ func (s *BasicAuthCredentials) DeleteBasicAuthWithConsumer(ctx context.Context, 
 
 	switch {
 	case httpRes.StatusCode == 204:
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/cacertificates.go
+++ b/internal/sdk/cacertificates.go
@@ -308,6 +308,7 @@ func (s *CACertificates) DeleteCaCertificate(ctx context.Context, request operat
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/certificates.go
+++ b/internal/sdk/certificates.go
@@ -311,6 +311,7 @@ func (s *Certificates) DeleteCertificate(ctx context.Context, request operations
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/cloudgateways.go
+++ b/internal/sdk/cloudgateways.go
@@ -3732,7 +3732,7 @@ func (s *CloudGateways) ListProviderAccounts(ctx context.Context, request operat
 
 	req.Header.Set("User-Agent", s.sdkConfiguration.UserAgent)
 
-	if err := utils.PopulateQueryParams(ctx, req, request, nil); err != nil {
+	if err := utils.PopulateQueryParams(ctx, req, request, nil, nil); err != nil {
 		return nil, fmt.Errorf("error populating query params: %w", err)
 	}
 
@@ -3864,6 +3864,7 @@ func (s *CloudGateways) ListProviderAccounts(ctx context.Context, request operat
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/configstores.go
+++ b/internal/sdk/configstores.go
@@ -423,6 +423,7 @@ func (s *ConfigStores) GetConfigStore(ctx context.Context, request operations.Ge
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -736,7 +737,7 @@ func (s *ConfigStores) DeleteConfigStore(ctx context.Context, request operations
 	req.Header.Set("Accept", "application/problem+json")
 	req.Header.Set("User-Agent", s.sdkConfiguration.UserAgent)
 
-	if err := utils.PopulateQueryParams(ctx, req, request, nil); err != nil {
+	if err := utils.PopulateQueryParams(ctx, req, request, nil, nil); err != nil {
 		return nil, fmt.Errorf("error populating query params: %w", err)
 	}
 
@@ -848,6 +849,7 @@ func (s *ConfigStores) DeleteConfigStore(ctx context.Context, request operations
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/consumergroups.go
+++ b/internal/sdk/consumergroups.go
@@ -308,6 +308,7 @@ func (s *ConsumerGroups) DeleteConsumerGroup(ctx context.Context, request operat
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -845,6 +846,7 @@ func (s *ConsumerGroups) RemoveConsumerFromGroup(ctx context.Context, request op
 
 	switch {
 	case httpRes.StatusCode == 204:
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/consumers.go
+++ b/internal/sdk/consumers.go
@@ -308,6 +308,7 @@ func (s *Consumers) DeleteConsumer(ctx context.Context, request operations.Delet
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/controlplanes.go
+++ b/internal/sdk/controlplanes.go
@@ -90,7 +90,7 @@ func (s *ControlPlanes) ListControlPlanes(ctx context.Context, request operation
 
 	req.Header.Set("User-Agent", s.sdkConfiguration.UserAgent)
 
-	if err := utils.PopulateQueryParams(ctx, req, request, nil); err != nil {
+	if err := utils.PopulateQueryParams(ctx, req, request, nil, nil); err != nil {
 		return nil, fmt.Errorf("error populating query params: %w", err)
 	}
 
@@ -1427,7 +1427,7 @@ func (s *ControlPlanes) ListControlPlanesSingleResource(ctx context.Context, req
 
 	req.Header.Set("User-Agent", s.sdkConfiguration.UserAgent)
 
-	if err := utils.PopulateQueryParams(ctx, req, request, nil); err != nil {
+	if err := utils.PopulateQueryParams(ctx, req, request, nil, nil); err != nil {
 		return nil, fmt.Errorf("error populating query params: %w", err)
 	}
 

--- a/internal/sdk/customplugins.go
+++ b/internal/sdk/customplugins.go
@@ -312,6 +312,7 @@ func (s *CustomPlugins) DeleteCustomPlugin(ctx context.Context, request operatio
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/hmacauthcredentials.go
+++ b/internal/sdk/hmacauthcredentials.go
@@ -264,6 +264,7 @@ func (s *HMACAuthCredentials) DeleteHmacAuthWithConsumer(ctx context.Context, re
 
 	switch {
 	case httpRes.StatusCode == 204:
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/internal/utils/requestbody.go
+++ b/internal/sdk/internal/utils/requestbody.go
@@ -176,7 +176,7 @@ func encodeMultipartFormData(w io.Writer, data interface{}) (string, error) {
 				for i := 0; i < valType.Len(); i++ {
 					arrayVal := valType.Index(i)
 
-					if err := encodeMultipartFormDataFile(writer, tag.Name+"[]", arrayVal.Type(), arrayVal); err != nil {
+					if err := encodeMultipartFormDataFile(writer, tag.Name, arrayVal.Type(), arrayVal); err != nil {
 						writer.Close()
 						return "", err
 					}
@@ -207,7 +207,7 @@ func encodeMultipartFormData(w io.Writer, data interface{}) (string, error) {
 			case reflect.Slice, reflect.Array:
 				values := parseDelimitedArray(true, valType, ",")
 				for _, v := range values {
-					if err := writer.WriteField(tag.Name+"[]", v); err != nil {
+					if err := writer.WriteField(tag.Name, v); err != nil {
 						writer.Close()
 						return "", err
 					}
@@ -325,7 +325,7 @@ func encodeFormData(fieldName string, w io.Writer, data interface{}) error {
 				switch tag.Style {
 				// TODO: support other styles
 				case "form":
-					values := populateForm(tag.Name, tag.Explode, fieldType, valType, ",", nil, func(sf reflect.StructField) string {
+					values := populateForm(tag.Name, tag.Explode, fieldType, valType, ",", nil, nil, func(sf reflect.StructField) string {
 						tag := parseFormTag(field)
 						if tag == nil {
 							return ""

--- a/internal/sdk/jwts.go
+++ b/internal/sdk/jwts.go
@@ -264,6 +264,7 @@ func (s *JWTs) DeleteJwtWithConsumer(ctx context.Context, request operations.Del
 
 	switch {
 	case httpRes.StatusCode == 204:
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/keys.go
+++ b/internal/sdk/keys.go
@@ -307,6 +307,7 @@ func (s *Keys) DeleteKey(ctx context.Context, request operations.DeleteKeyReques
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/keysets.go
+++ b/internal/sdk/keysets.go
@@ -307,6 +307,7 @@ func (s *KeySets) DeleteKeySet(ctx context.Context, request operations.DeleteKey
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/konnect.go
+++ b/internal/sdk/konnect.go
@@ -2,7 +2,7 @@
 
 package sdk
 
-// Generated from OpenAPI doc version 2.0.0 and generator version 2.748.0
+// Generated from OpenAPI doc version 2.0.0 and generator version 2.767.2
 
 import (
 	"context"
@@ -344,7 +344,7 @@ func New(opts ...SDKOption) *Konnect {
 	sdk := &Konnect{
 		SDKVersion: "3.4.2",
 		sdkConfiguration: config.SDKConfiguration{
-			UserAgent:  "speakeasy-sdk/terraform 3.4.2 2.748.0 2.0.0 github.com/kong/terraform-provider-konnect/v3/internal/sdk",
+			UserAgent:  "speakeasy-sdk/terraform 3.4.2 2.767.2 2.0.0 github.com/kong/terraform-provider-konnect/v3/internal/sdk",
 			ServerList: ServerList,
 		},
 		hooks: hooks.New(),

--- a/internal/sdk/mesh.go
+++ b/internal/sdk/mesh.go
@@ -90,7 +90,7 @@ func (s *Mesh) ListMeshControlPlanes(ctx context.Context, request operations.Lis
 
 	req.Header.Set("User-Agent", s.sdkConfiguration.UserAgent)
 
-	if err := utils.PopulateQueryParams(ctx, req, request, nil); err != nil {
+	if err := utils.PopulateQueryParams(ctx, req, request, nil, nil); err != nil {
 		return nil, fmt.Errorf("error populating query params: %w", err)
 	}
 
@@ -201,6 +201,7 @@ func (s *Mesh) ListMeshControlPlanes(ctx context.Context, request operations.Lis
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/mtlsauthcredentials.go
+++ b/internal/sdk/mtlsauthcredentials.go
@@ -264,6 +264,7 @@ func (s *MTLSAuthCredentials) DeleteMtlsAuthWithConsumer(ctx context.Context, re
 
 	switch {
 	case httpRes.StatusCode == 204:
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/partials.go
+++ b/internal/sdk/partials.go
@@ -307,6 +307,7 @@ func (s *Partials) DeletePartial(ctx context.Context, request operations.DeleteP
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/plugins.go
+++ b/internal/sdk/plugins.go
@@ -375,7 +375,7 @@ func (s *Plugins) GetPlugin(ctx context.Context, request operations.GetPluginReq
 	req.Header.Set("Accept", "application/json")
 	req.Header.Set("User-Agent", s.sdkConfiguration.UserAgent)
 
-	if err := utils.PopulateQueryParams(ctx, req, request, nil); err != nil {
+	if err := utils.PopulateQueryParams(ctx, req, request, nil, nil); err != nil {
 		return nil, fmt.Errorf("error populating query params: %w", err)
 	}
 
@@ -755,6 +755,7 @@ func (s *Plugins) DeleteAcePlugin(ctx context.Context, request operations.Delete
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -1196,6 +1197,7 @@ func (s *Plugins) DeleteACLPlugin(ctx context.Context, request operations.Delete
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -1637,6 +1639,7 @@ func (s *Plugins) DeleteAcmePlugin(ctx context.Context, request operations.Delet
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -2078,6 +2081,7 @@ func (s *Plugins) DeleteAiawsguardrailsPlugin(ctx context.Context, request opera
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -2519,6 +2523,7 @@ func (s *Plugins) DeleteAiazurecontentsafetyPlugin(ctx context.Context, request 
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -2960,6 +2965,7 @@ func (s *Plugins) DeleteAigcpmodelarmorPlugin(ctx context.Context, request opera
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -3401,6 +3407,7 @@ func (s *Plugins) DeleteAillmasjudgePlugin(ctx context.Context, request operatio
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -3842,6 +3849,7 @@ func (s *Plugins) DeleteAimcpoauth2Plugin(ctx context.Context, request operation
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -4283,6 +4291,7 @@ func (s *Plugins) DeleteAimcpproxyPlugin(ctx context.Context, request operations
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -4724,6 +4733,7 @@ func (s *Plugins) DeleteAipromptcompressorPlugin(ctx context.Context, request op
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -5165,6 +5175,7 @@ func (s *Plugins) DeleteAipromptdecoratorPlugin(ctx context.Context, request ope
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -5606,6 +5617,7 @@ func (s *Plugins) DeleteAipromptguardPlugin(ctx context.Context, request operati
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -6047,6 +6059,7 @@ func (s *Plugins) DeleteAiprompttemplatePlugin(ctx context.Context, request oper
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -6488,6 +6501,7 @@ func (s *Plugins) DeleteAiproxyPlugin(ctx context.Context, request operations.De
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -6929,6 +6943,7 @@ func (s *Plugins) DeleteAiproxyadvancedPlugin(ctx context.Context, request opera
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -7370,6 +7385,7 @@ func (s *Plugins) DeleteAiraginjectorPlugin(ctx context.Context, request operati
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -7811,6 +7827,7 @@ func (s *Plugins) DeleteAiratelimitingadvancedPlugin(ctx context.Context, reques
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -8252,6 +8269,7 @@ func (s *Plugins) DeleteAirequesttransformerPlugin(ctx context.Context, request 
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -8693,6 +8711,7 @@ func (s *Plugins) DeleteAiresponsetransformerPlugin(ctx context.Context, request
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -9134,6 +9153,7 @@ func (s *Plugins) DeleteAisanitizerPlugin(ctx context.Context, request operation
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -9575,6 +9595,7 @@ func (s *Plugins) DeleteAisemanticcachePlugin(ctx context.Context, request opera
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -10016,6 +10037,7 @@ func (s *Plugins) DeleteAisemanticpromptguardPlugin(ctx context.Context, request
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -10457,6 +10479,7 @@ func (s *Plugins) DeleteAisemanticresponseguardPlugin(ctx context.Context, reque
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -10898,6 +10921,7 @@ func (s *Plugins) DeleteAppdynamicsPlugin(ctx context.Context, request operation
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -11339,6 +11363,7 @@ func (s *Plugins) DeleteAwslambdaPlugin(ctx context.Context, request operations.
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -11780,6 +11805,7 @@ func (s *Plugins) DeleteAzurefunctionsPlugin(ctx context.Context, request operat
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -12221,6 +12247,7 @@ func (s *Plugins) DeleteBasicauthPlugin(ctx context.Context, request operations.
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -12662,6 +12689,7 @@ func (s *Plugins) DeleteBotdetectionPlugin(ctx context.Context, request operatio
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -13103,6 +13131,7 @@ func (s *Plugins) DeleteCanaryPlugin(ctx context.Context, request operations.Del
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -13544,6 +13573,7 @@ func (s *Plugins) DeleteConfluentPlugin(ctx context.Context, request operations.
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -13985,6 +14015,7 @@ func (s *Plugins) DeleteConfluentconsumePlugin(ctx context.Context, request oper
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -14426,6 +14457,7 @@ func (s *Plugins) DeleteCorrelationidPlugin(ctx context.Context, request operati
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -14867,6 +14899,7 @@ func (s *Plugins) DeleteCorsPlugin(ctx context.Context, request operations.Delet
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -15308,6 +15341,7 @@ func (s *Plugins) DeleteDatadogPlugin(ctx context.Context, request operations.De
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -15749,6 +15783,7 @@ func (s *Plugins) DeleteDatakitPlugin(ctx context.Context, request operations.De
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -16190,6 +16225,7 @@ func (s *Plugins) DeleteDegraphqlPlugin(ctx context.Context, request operations.
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -16631,6 +16667,7 @@ func (s *Plugins) DeleteExittransformerPlugin(ctx context.Context, request opera
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -17072,6 +17109,7 @@ func (s *Plugins) DeleteFilelogPlugin(ctx context.Context, request operations.De
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -17513,6 +17551,7 @@ func (s *Plugins) DeleteForwardproxyPlugin(ctx context.Context, request operatio
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -17954,6 +17993,7 @@ func (s *Plugins) DeleteGraphqlproxycacheadvancedPlugin(ctx context.Context, req
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -18395,6 +18435,7 @@ func (s *Plugins) DeleteGraphqlratelimitingadvancedPlugin(ctx context.Context, r
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -18836,6 +18877,7 @@ func (s *Plugins) DeleteGrpcgatewayPlugin(ctx context.Context, request operation
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -19277,6 +19319,7 @@ func (s *Plugins) DeleteGrpcwebPlugin(ctx context.Context, request operations.De
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -19718,6 +19761,7 @@ func (s *Plugins) DeleteHeadercertauthPlugin(ctx context.Context, request operat
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -20159,6 +20203,7 @@ func (s *Plugins) DeleteHmacauthPlugin(ctx context.Context, request operations.D
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -20600,6 +20645,7 @@ func (s *Plugins) DeleteHttplogPlugin(ctx context.Context, request operations.De
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -21041,6 +21087,7 @@ func (s *Plugins) DeleteInjectionprotectionPlugin(ctx context.Context, request o
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -21482,6 +21529,7 @@ func (s *Plugins) DeleteIprestrictionPlugin(ctx context.Context, request operati
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -21923,6 +21971,7 @@ func (s *Plugins) DeleteJqPlugin(ctx context.Context, request operations.DeleteJ
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -22364,6 +22413,7 @@ func (s *Plugins) DeleteJsonthreatprotectionPlugin(ctx context.Context, request 
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -22805,6 +22855,7 @@ func (s *Plugins) DeleteJwedecryptPlugin(ctx context.Context, request operations
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -23246,6 +23297,7 @@ func (s *Plugins) DeleteJwtPlugin(ctx context.Context, request operations.Delete
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -23687,6 +23739,7 @@ func (s *Plugins) DeleteJwtsignerPlugin(ctx context.Context, request operations.
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -24128,6 +24181,7 @@ func (s *Plugins) DeleteKafkaconsumePlugin(ctx context.Context, request operatio
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -24569,6 +24623,7 @@ func (s *Plugins) DeleteKafkalogPlugin(ctx context.Context, request operations.D
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -25010,6 +25065,7 @@ func (s *Plugins) DeleteKafkaupstreamPlugin(ctx context.Context, request operati
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -25451,6 +25507,7 @@ func (s *Plugins) DeleteKeyauthPlugin(ctx context.Context, request operations.De
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -25892,6 +25949,7 @@ func (s *Plugins) DeleteLdapauthPlugin(ctx context.Context, request operations.D
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -26333,6 +26391,7 @@ func (s *Plugins) DeleteLdapauthadvancedPlugin(ctx context.Context, request oper
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -26774,6 +26833,7 @@ func (s *Plugins) DeleteLogglyPlugin(ctx context.Context, request operations.Del
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -27215,6 +27275,7 @@ func (s *Plugins) DeleteMockingPlugin(ctx context.Context, request operations.De
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -27656,6 +27717,7 @@ func (s *Plugins) DeleteMtlsauthPlugin(ctx context.Context, request operations.D
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -28097,6 +28159,7 @@ func (s *Plugins) DeleteOasvalidationPlugin(ctx context.Context, request operati
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -28538,6 +28601,7 @@ func (s *Plugins) DeleteOauth2introspectionPlugin(ctx context.Context, request o
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -28979,6 +29043,7 @@ func (s *Plugins) DeleteOpaPlugin(ctx context.Context, request operations.Delete
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -29420,6 +29485,7 @@ func (s *Plugins) DeleteOpenidconnectPlugin(ctx context.Context, request operati
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -29861,6 +29927,7 @@ func (s *Plugins) DeleteOpentelemetryPlugin(ctx context.Context, request operati
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -30302,6 +30369,7 @@ func (s *Plugins) DeletePostfunctionPlugin(ctx context.Context, request operatio
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -30743,6 +30811,7 @@ func (s *Plugins) DeletePrefunctionPlugin(ctx context.Context, request operation
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -31184,6 +31253,7 @@ func (s *Plugins) DeletePrometheusPlugin(ctx context.Context, request operations
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -31625,6 +31695,7 @@ func (s *Plugins) DeleteProxycachePlugin(ctx context.Context, request operations
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -32066,6 +32137,7 @@ func (s *Plugins) DeleteProxycacheadvancedPlugin(ctx context.Context, request op
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -32507,6 +32579,7 @@ func (s *Plugins) DeleteRatelimitingPlugin(ctx context.Context, request operatio
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -32948,6 +33021,7 @@ func (s *Plugins) DeleteRatelimitingadvancedPlugin(ctx context.Context, request 
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -33389,6 +33463,7 @@ func (s *Plugins) DeleteRedirectPlugin(ctx context.Context, request operations.D
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -33830,6 +33905,7 @@ func (s *Plugins) DeleteRequestcalloutPlugin(ctx context.Context, request operat
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -34271,6 +34347,7 @@ func (s *Plugins) DeleteRequestsizelimitingPlugin(ctx context.Context, request o
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -34712,6 +34789,7 @@ func (s *Plugins) DeleteRequestterminationPlugin(ctx context.Context, request op
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -35153,6 +35231,7 @@ func (s *Plugins) DeleteRequesttransformerPlugin(ctx context.Context, request op
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -35594,6 +35673,7 @@ func (s *Plugins) DeleteRequesttransformeradvancedPlugin(ctx context.Context, re
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -36035,6 +36115,7 @@ func (s *Plugins) DeleteRequestvalidatorPlugin(ctx context.Context, request oper
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -36476,6 +36557,7 @@ func (s *Plugins) DeleteResponseratelimitingPlugin(ctx context.Context, request 
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -36917,6 +36999,7 @@ func (s *Plugins) DeleteResponsetransformerPlugin(ctx context.Context, request o
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -37358,6 +37441,7 @@ func (s *Plugins) DeleteResponsetransformeradvancedPlugin(ctx context.Context, r
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -37799,6 +37883,7 @@ func (s *Plugins) DeleteRoutebyheaderPlugin(ctx context.Context, request operati
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -38240,6 +38325,7 @@ func (s *Plugins) DeleteRoutetransformeradvancedPlugin(ctx context.Context, requ
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -38681,6 +38767,7 @@ func (s *Plugins) DeleteSamlPlugin(ctx context.Context, request operations.Delet
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -39122,6 +39209,7 @@ func (s *Plugins) DeleteServiceprotectionPlugin(ctx context.Context, request ope
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -39563,6 +39651,7 @@ func (s *Plugins) DeleteSessionPlugin(ctx context.Context, request operations.De
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -40004,6 +40093,7 @@ func (s *Plugins) DeleteSolaceconsumePlugin(ctx context.Context, request operati
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -40445,6 +40535,7 @@ func (s *Plugins) DeleteSolacelogPlugin(ctx context.Context, request operations.
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -40886,6 +40977,7 @@ func (s *Plugins) DeleteSolaceupstreamPlugin(ctx context.Context, request operat
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -41327,6 +41419,7 @@ func (s *Plugins) DeleteStandardwebhooksPlugin(ctx context.Context, request oper
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -41768,6 +41861,7 @@ func (s *Plugins) DeleteStatsdPlugin(ctx context.Context, request operations.Del
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -42209,6 +42303,7 @@ func (s *Plugins) DeleteStatsdadvancedPlugin(ctx context.Context, request operat
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -42650,6 +42745,7 @@ func (s *Plugins) DeleteSyslogPlugin(ctx context.Context, request operations.Del
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -43091,6 +43187,7 @@ func (s *Plugins) DeleteTcplogPlugin(ctx context.Context, request operations.Del
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -43532,6 +43629,7 @@ func (s *Plugins) DeleteTlshandshakemodifierPlugin(ctx context.Context, request 
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -43973,6 +44071,7 @@ func (s *Plugins) DeleteTlsmetadataheadersPlugin(ctx context.Context, request op
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -44414,6 +44513,7 @@ func (s *Plugins) DeleteUdplogPlugin(ctx context.Context, request operations.Del
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -44855,6 +44955,7 @@ func (s *Plugins) DeleteUpstreamoauthPlugin(ctx context.Context, request operati
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -45296,6 +45397,7 @@ func (s *Plugins) DeleteUpstreamtimeoutPlugin(ctx context.Context, request opera
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -45737,6 +45839,7 @@ func (s *Plugins) DeleteVaultauthPlugin(ctx context.Context, request operations.
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -46178,6 +46281,7 @@ func (s *Plugins) DeleteWebsocketsizelimitPlugin(ctx context.Context, request op
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -46619,6 +46723,7 @@ func (s *Plugins) DeleteWebsocketvalidatorPlugin(ctx context.Context, request op
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -47060,6 +47165,7 @@ func (s *Plugins) DeleteXmlthreatprotectionPlugin(ctx context.Context, request o
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -47501,6 +47607,7 @@ func (s *Plugins) DeleteZipkinPlugin(ctx context.Context, request operations.Del
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/portalauthsettings.go
+++ b/internal/sdk/portalauthsettings.go
@@ -178,6 +178,7 @@ func (s *PortalAuthSettings) GetPortalAuthenticationSettings(ctx context.Context
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/portals.go
+++ b/internal/sdk/portals.go
@@ -531,7 +531,7 @@ func (s *Portals) DeletePortalClassic(ctx context.Context, request operations.De
 	req.Header.Set("Accept", "application/problem+json")
 	req.Header.Set("User-Agent", s.sdkConfiguration.UserAgent)
 
-	if err := utils.PopulateQueryParams(ctx, req, request, nil); err != nil {
+	if err := utils.PopulateQueryParams(ctx, req, request, nil, nil); err != nil {
 		return nil, fmt.Errorf("error populating query params: %w", err)
 	}
 
@@ -735,7 +735,7 @@ func (s *Portals) ListPortalsClassic(ctx context.Context, request operations.Lis
 
 	req.Header.Set("User-Agent", s.sdkConfiguration.UserAgent)
 
-	if err := utils.PopulateQueryParams(ctx, req, request, nil); err != nil {
+	if err := utils.PopulateQueryParams(ctx, req, request, nil, nil); err != nil {
 		return nil, fmt.Errorf("error populating query params: %w", err)
 	}
 
@@ -867,6 +867,7 @@ func (s *Portals) ListPortalsClassic(ctx context.Context, request operations.Lis
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -1144,7 +1145,7 @@ func (s *Portals) ListPortals(ctx context.Context, request operations.ListPortal
 
 	req.Header.Set("User-Agent", s.sdkConfiguration.UserAgent)
 
-	if err := utils.PopulateQueryParams(ctx, req, request, nil); err != nil {
+	if err := utils.PopulateQueryParams(ctx, req, request, nil, nil); err != nil {
 		return nil, fmt.Errorf("error populating query params: %w", err)
 	}
 
@@ -1994,7 +1995,7 @@ func (s *Portals) DeletePortal(ctx context.Context, request operations.DeletePor
 	req.Header.Set("Accept", "application/problem+json")
 	req.Header.Set("User-Agent", s.sdkConfiguration.UserAgent)
 
-	if err := utils.PopulateQueryParams(ctx, req, request, nil); err != nil {
+	if err := utils.PopulateQueryParams(ctx, req, request, nil, nil); err != nil {
 		return nil, fmt.Errorf("error populating query params: %w", err)
 	}
 

--- a/internal/sdk/realms.go
+++ b/internal/sdk/realms.go
@@ -319,6 +319,7 @@ func (s *Realms) GetRealm(ctx context.Context, request operations.GetRealmReques
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -551,7 +552,7 @@ func (s *Realms) DeleteRealm(ctx context.Context, request operations.DeleteRealm
 	req.Header.Set("Accept", "application/problem+json")
 	req.Header.Set("User-Agent", s.sdkConfiguration.UserAgent)
 
-	if err := utils.PopulateQueryParams(ctx, req, request, nil); err != nil {
+	if err := utils.PopulateQueryParams(ctx, req, request, nil, nil); err != nil {
 		return nil, fmt.Errorf("error populating query params: %w", err)
 	}
 

--- a/internal/sdk/routes.go
+++ b/internal/sdk/routes.go
@@ -329,6 +329,7 @@ func (s *Routes) DeleteRoute(ctx context.Context, request operations.DeleteRoute
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {
@@ -770,6 +771,7 @@ func (s *Routes) DeleteRouteRouteExpression(ctx context.Context, request operati
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/services.go
+++ b/internal/sdk/services.go
@@ -313,6 +313,7 @@ func (s *Services) DeleteService(ctx context.Context, request operations.DeleteS
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/snis.go
+++ b/internal/sdk/snis.go
@@ -309,6 +309,7 @@ func (s *SNIs) DeleteSni(ctx context.Context, request operations.DeleteSniReques
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/targets.go
+++ b/internal/sdk/targets.go
@@ -267,6 +267,7 @@ func (s *Targets) DeleteTargetWithUpstream(ctx context.Context, request operatio
 
 	switch {
 	case httpRes.StatusCode == 204:
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/upstreams.go
+++ b/internal/sdk/upstreams.go
@@ -310,6 +310,7 @@ func (s *Upstreams) DeleteUpstream(ctx context.Context, request operations.Delet
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {

--- a/internal/sdk/vaults.go
+++ b/internal/sdk/vaults.go
@@ -313,6 +313,7 @@ func (s *Vaults) DeleteVault(ctx context.Context, request operations.DeleteVault
 			}
 			return nil, errors.NewSDKError(fmt.Sprintf("unknown content-type received: %s", httpRes.Header.Get("Content-Type")), httpRes.StatusCode, string(rawBody), httpRes)
 		}
+	case httpRes.StatusCode == 404:
 	default:
 		rawBody, err := utils.ConsumeRawBody(httpRes)
 		if err != nil {


### PR DESCRIPTION
### Summary
This PR bumps speakeasy to v1.665.0
Changes: Enum values are removed from docs for read-only properties.
Ref https://kongstrong.slack.com/archives/C05MLAA216D/p1763350306812849
  
### Issues resolved
-

### Related PRs on platform-api (if any)
-

### Checklist ✅ 
- [x] Clean commit history (reset to the current release (`release/x.y.z`) and `git cherry-pick` if necessary)
- [ ] Added/updated examples (if applicable)  
- [ ] Added acceptance tests (if applicable)  
- [ ] Updated `CHANGELOG.md`  
