### PR TITLE
fix: custom plugin config when dynamic

### DIFF
--- a/src/custom_plugin_model.go
+++ b/src/custom_plugin_model.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
 	tfTypes "github.com/kong/terraform-provider-konnect/v3/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect/v3/internal/sdk"
 	"github.com/kong/terraform-provider-konnect/v3/internal/sdk/models/shared"
@@ -37,7 +38,17 @@ func (r *CustomPluginResourceModel) ToSharedPluginInput() (shared.Plugin, error)
 	// Use .String() to convert the dynamic value to a string,
 	// then unmarshal the JSON string into a map[string]any
 	var configJson map[string]any
-	err := json.Unmarshal([]byte(config.String()), &configJson)
+	var confstr string
+	switch v := config.(type) {
+	case basetypes.StringValue:
+		confstr = v.ValueString()
+	case types.Object:
+		confstr = config.String()
+	default:
+		confstr = config.String()
+	}
+
+	err := json.Unmarshal([]byte(confstr), &configJson)
 	if err != nil {
 		return shared.Plugin{}, err
 	}

--- a/tests/resources/gateway_custom_plugin_test.go
+++ b/tests/resources/gateway_custom_plugin_test.go
@@ -21,7 +21,9 @@ func TestGatewayCustomPlugin(t *testing.T) {
 					ConfigDirectory: config.TestNameDirectory(),
 					Check: resource.ComposeAggregateTestCheckFunc(
 						resource.TestCheckResourceAttr("konnect_gateway_custom_plugin.custom_basic_auth", "instance_name", "custom-plugin-test"),
+						resource.TestCheckResourceAttr("konnect_gateway_custom_plugin.custom_basic_auth", "config", "{\"anonymous\":\"capybara\"}"),
 						resource.TestCheckResourceAttr("konnect_gateway_custom_plugin.custom_basic_auth_nested", "instance_name", "custom-nested-plugin-test"),
+						resource.TestCheckResourceAttr("konnect_gateway_custom_plugin.custom_basic_auth_nested", "config.anonymous", "capybara"),
 						resource.TestCheckNoResourceAttr("konnect_gateway_custom_plugin.custom_no_instance_name", "instance_name"),
 						resource.TestCheckResourceAttr("konnect_gateway_custom_plugin.custom_basic_auth_with_ordering", "ordering.before.access.0", "acl"),
 						resource.TestCheckResourceAttr("konnect_gateway_custom_plugin.custom_basic_auth_with_ordering", "ordering.after.access.0", "request-transformer"),

--- a/tests/resources/testdata/TestGatewayCustomPlugin/CRUD/2/main-step-2.tf
+++ b/tests/resources/testdata/TestGatewayCustomPlugin/CRUD/2/main-step-2.tf
@@ -49,14 +49,18 @@ resource "konnect_gateway_plugin_request_transformer" "my_request_transformer" {
 resource "konnect_gateway_custom_plugin" "custom_basic_auth" {
   name             = "basic-auth"
   instance_name    = "custom-plugin-test"
-  config           = {}
+  config           = jsonencode({
+    "anonymous": "capybara"
+  })
   control_plane_id = konnect_gateway_control_plane.tfdemo.id
 }
 
 resource "konnect_gateway_custom_plugin" "custom_basic_auth_nested" {
   name             = "basic-auth"
   instance_name    = "custom-nested-plugin-test"
-  config           = {}
+  config           = {
+    anonymous = "capybara"
+  }
   control_plane_id = konnect_gateway_control_plane.tfdemo.id
   service = {
     id = konnect_gateway_service.httpbin.id

--- a/tests/resources/testdata/TestGatewayCustomPlugin/CRUD/main.tf
+++ b/tests/resources/testdata/TestGatewayCustomPlugin/CRUD/main.tf
@@ -50,14 +50,18 @@ resource "konnect_gateway_plugin_request_transformer" "my_request_transformer" {
 resource "konnect_gateway_custom_plugin" "custom_basic_auth" {
   name             = "basic-auth"
   instance_name    = "custom-plugin-test"
-  config           = {}
+  config           = jsonencode({
+    "anonymous": "capybara"
+  })
   control_plane_id = konnect_gateway_control_plane.tfdemo.id
 }
 
 resource "konnect_gateway_custom_plugin" "custom_basic_auth_nested" {
   name             = "basic-auth"
   instance_name    = "custom-nested-plugin-test"
-  config           = {}
+  config           = {
+    anonymous = "capybara"
+  }
   control_plane_id = konnect_gateway_control_plane.tfdemo.id
   service = {
     id = konnect_gateway_service.httpbin.id


### PR DESCRIPTION
### Summary
When `config` field in custom plugin is passed as a json encoded string, our current implementation fails in unmarshalling into the terraform type.  We use `attr.String()`, which is usually only meant for debugging - not for business logic, wraps the content in invalid characters - which leads to the failure.

Fix: type check, if string, use `ValueString()`, if not, continue as we were.

Discovered in https://github.com/Kong/deck/pull/1979#discussion_r3083809678

### Related PRs on platform-api (if any)
-

### Checklist ✅ 
- [x] Clean commit history (reset to the current release (`release/x.y.z`) and `git cherry-pick` if necessary)
- [ ] Added/updated examples (if applicable)  
- [x] Added acceptance tests (if applicable)  
- [ ] Updated `CHANGELOG.md`  
