### PR TITLE
chore: bump speakeasy to v1.773.1

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -3,20 +3,20 @@ id: 9d20c53e-7836-4ea8-88b8-a75fb7dce3a2
 management:
   docChecksum: 99ce6e1852255659e5560ffd9ee08682
   docVersion: 2.0.0
-  speakeasyVersion: 1.763.1
-  generationVersion: 2.884.4
+  speakeasyVersion: 1.773.1
+  generationVersion: 2.897.1
   releaseVersion: 3.18.0
   configChecksum: 2bbde14328d18c723ef109de8453d67a
 persistentEdits:
-  generation_id: 6f3ad0b8-f0cd-4f84-8a2d-7847a7b0dcf6
-  pristine_commit_hash: 486c287320aace6c77a4fd7e5d0db735ddb213da
-  pristine_tree_hash: dccd92d9b1a51df173c94c97530bd0a1025f52fc
+  generation_id: dd366e95-91d4-46cc-a761-b900de6fb47f
+  pristine_commit_hash: 86da3c418a77ba25e8416a2bcac178be50f2e9a1
+  pristine_tree_hash: 24dbd281c73f2749d7b06022d45026cff837cd87
 features:
   terraform:
     additionalDependencies: 0.1.0
     additionalProperties: 0.1.4
     constsAndDefaults: 0.3.2
-    core: 3.47.4
+    core: 3.47.9
     deepObjectParams: 0.1.0
     deprecations: 2.82.0
     globalSecurity: 2.82.3
@@ -28,7 +28,7 @@ features:
     nameOverrides: 2.81.7
     nullables: 0.0.0
     openEnums: 0.1.0
-    pagination: 2.83.5
+    pagination: 2.83.6
     retries: 2.81.4
     sets: 0.1.2
     transformJq: 0.0.1
@@ -2617,8 +2617,8 @@ trackedFiles:
     pristine_git_object: dd602efe5cbf920a707e5acc9aa819c3292dc027
   go.mod:
     id: c47645c391ad
-    last_write_checksum: sha1:a59720063aa9678a061b55e5a2ca1e4ae2c8e962
-    pristine_git_object: 122ab24916457e111fd6a31143b74efb561f40f0
+    last_write_checksum: sha1:491073d682f4b9dc9f6046c415c6e6c6f747aa63
+    pristine_git_object: 34fe443bafb4a19a8800692aa4a33c80640813cc
   internal/planmodifiers/boolplanmodifier/suppress_diff.go:
     id: 3cf85b98963e
     last_write_checksum: sha1:fd6984577c6c57e42da4c7aa4c45813eeded8092
@@ -2945,8 +2945,8 @@ trackedFiles:
     pristine_git_object: d8dbde86e8de396645d18e78b35e100b4dac6d3f
   internal/provider/cloudgatewayprovideraccountlist_data_source.go:
     id: 7dc866fdfc1d
-    last_write_checksum: sha1:b00d2be22d89c83c0f739e9e21b54a6ea4ea3950
-    pristine_git_object: 02c5ffa5017ea93b080a4f0bf3ae223bf7c5dd26
+    last_write_checksum: sha1:76c625cd06ef69603f57a73fdddddbb54d80d6a4
+    pristine_git_object: 5cae9027f26cc0e942e67a3a9d45ead075a54852
   internal/provider/cloudgatewayprovideraccountlist_data_source_sdk.go:
     id: e488b970d877
     last_write_checksum: sha1:02945e3a9d4f2b3f907170b8909437503ab99857
@@ -3201,8 +3201,8 @@ trackedFiles:
     pristine_git_object: 14135e554e98b20813df5246d76a0f039eeb20c3
   internal/provider/gatewaycontrolplanelist_data_source.go:
     id: 9b79eabaa7ab
-    last_write_checksum: sha1:8aa83c57b8d58f06624a603fe2097cb9745139f8
-    pristine_git_object: 976067121e133951fdbfbeca7f26dd8dd3102280
+    last_write_checksum: sha1:6a203c655010738b85cf2f2efa7ad4d393430089
+    pristine_git_object: 4c9b353658e155641479cb3f18fab59f718e3a8e
   internal/provider/gatewaycontrolplanelist_data_source_sdk.go:
     id: c5b3e8291612
     last_write_checksum: sha1:c08e7099b109a5ba641d6ac35677372e4ed6f271
@@ -4321,8 +4321,8 @@ trackedFiles:
     pristine_git_object: 1d17c3c769687f177961acb2e66ce7ee0c6ca226
   internal/provider/meshcontrolplanes_data_source.go:
     id: "787364299751"
-    last_write_checksum: sha1:f36687ab810b590b498143879d2768eb1963cab2
-    pristine_git_object: 29875ab7dbc69cf8c8180b7de278a1d1cd1eb47f
+    last_write_checksum: sha1:c8788e983e6f38057d5f55d81f904ad986b48407
+    pristine_git_object: 27ee42edd4bcfadd4c6f185e37677a54f75cee96
   internal/provider/meshcontrolplanes_data_source_sdk.go:
     id: 48cd696e6882
     last_write_checksum: sha1:a403ca590c49cb2fed3c67a2c49950583109ab85
@@ -4385,8 +4385,8 @@ trackedFiles:
     pristine_git_object: d5c011a2f1524e08dffe339c7f44947ddd770802
   internal/provider/portalclassiclist_data_source.go:
     id: de8f9edb825d
-    last_write_checksum: sha1:da7237e4581cbd3f8a6dfaca92dbd333aa99351d
-    pristine_git_object: 99779c4a392422c332862026d82847e976bb5f6f
+    last_write_checksum: sha1:594e6dda501aa7edd1cf91f086610192c3ee9f1c
+    pristine_git_object: 49d85457bd646e4a8675678d9c581911fb4b5b34
   internal/provider/portalclassiclist_data_source_sdk.go:
     id: 44bdf03e233b
     last_write_checksum: sha1:87c4c2c1348d0c75efbb370e741d32ae3932b5bf
@@ -4565,8 +4565,8 @@ trackedFiles:
     pristine_git_object: 2be6f7d9a94055fd6ed023298b077506a0d01595
   internal/provider/systemaccountlist_data_source.go:
     id: 957305b3af87
-    last_write_checksum: sha1:28c6838ff32abbbb8b98d1f62435b8e1aa3241df
-    pristine_git_object: 76645d64106d0ebed7e8c7ba0d691404de77ea17
+    last_write_checksum: sha1:2934ba4a2fda7934a65afd1ab0c6724069e84368
+    pristine_git_object: c5b077ffedbc50b0ddb3eb8655550774bb0c8fdb
   internal/provider/systemaccountlist_data_source_sdk.go:
     id: 0863cc44f7c2
     last_write_checksum: sha1:5ddbccba968b3d4f209ee1d18a07d6b9574ec659
@@ -4605,8 +4605,8 @@ trackedFiles:
     pristine_git_object: da029e3629274e687488e67c971f294cfd11e9c6
   internal/provider/teamlist_data_source.go:
     id: 5e3b889bdf83
-    last_write_checksum: sha1:43b0a1c1c27a37f93ae64001144ef8d0212cb36e
-    pristine_git_object: 38d3e7c0baf2b42d90d94e3dce1b3487490b74f1
+    last_write_checksum: sha1:23f9d58d4145cebc03288727deebea2d71cbb637
+    pristine_git_object: 5e242cc1140b052673fdcfad777df59f24cfe4b4
   internal/provider/teamlist_data_source_sdk.go:
     id: fd26a36b84cc
     last_write_checksum: sha1:19c861fe7476509d55efc823ecbe975b45599b23
@@ -6865,8 +6865,8 @@ trackedFiles:
     pristine_git_object: 24827e92d9ceb6d7a3eea097902ed1b309bc5e14
   internal/sdk/internal/utils/json.go:
     id: 2231afac3add
-    last_write_checksum: sha1:f76398e20d6ad5da38879b3cb318b702fe90c05b
-    pristine_git_object: cad66dc8ad05c54348ba0dec8e15ec2e0dd0bc7f
+    last_write_checksum: sha1:7fc5b2c6ffb25429cdbca64843c0f208026f7e5a
+    pristine_git_object: 7645b27300f78c48e8ca9f25fe9c4fa773cfb8ef
   internal/sdk/internal/utils/pathparams.go:
     id: e7fec2afe4a6
     last_write_checksum: sha1:9ee6300befaf17f62c090deea5a9c229544820c4
@@ -6913,8 +6913,8 @@ trackedFiles:
     pristine_git_object: de6e80ba00b21ebe196bef40b3442ceab1158baf
   internal/sdk/konnect.go:
     id: defee4f1aaf8
-    last_write_checksum: sha1:2c3d2b1479a731b254d56397c36da5849d45c252
-    pristine_git_object: 357cbe6ac4d5637c164ac6cd451caf0476748cf4
+    last_write_checksum: sha1:3a3872bff73cf5ac29b4853f4da016141e0e1632
+    pristine_git_object: 4b0bfde7a16781008d73ff3d9da4672be09209a6
   internal/sdk/mesh.go:
     id: c3f36614baba
     last_write_checksum: sha1:efd743a519129a43ecc2856b3edc75a855d87c0a

--- a/.speakeasy/workflow.lock
+++ b/.speakeasy/workflow.lock
@@ -1,4 +1,4 @@
-speakeasyVersion: 1.763.1
+speakeasyVersion: 1.773.1
 sources:
     kong:
         sourceNamespace: kong
@@ -15,7 +15,7 @@ targets:
         sourceBlobDigest: sha256:fe7d9348a81627bd7708751e55cd5c4ef15b7c2b748c058ce7dd03298e8a92fa
 workflow:
     workflowVersion: 1.0.0
-    speakeasyVersion: 1.763.1
+    speakeasyVersion: 1.773.1
     sources:
         kong:
             inputs:

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -1,5 +1,5 @@
 workflowVersion: 1.0.0
-speakeasyVersion: 1.763.1
+speakeasyVersion: 1.773.1
 sources:
   kong:
     inputs:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kong/terraform-provider-konnect/v3
 
-go 1.25.8
+go 1.25.10
 
 require (
 	github.com/Kong/shared-speakeasy/customtypes v0.3.0

--- a/internal/provider/cloudgatewayprovideraccountlist_data_source.go
+++ b/internal/provider/cloudgatewayprovideraccountlist_data_source.go
@@ -149,7 +149,10 @@ func (r *CloudGatewayProviderAccountListDataSource) Read(ctx context.Context, re
 		res, err = res.Next()
 
 		if err != nil {
-			resp.Diagnostics.AddError(fmt.Sprintf("failed to retrieve next page of results: %v", err), debugResponse(res.RawResponse))
+			resp.Diagnostics.AddError("failed to retrieve next page of results", err.Error())
+			if res != nil && res.RawResponse != nil {
+				resp.Diagnostics.AddError("unexpected http request/response", debugResponse(res.RawResponse))
+			}
 			return
 		}
 

--- a/internal/provider/gatewaycontrolplanelist_data_source.go
+++ b/internal/provider/gatewaycontrolplanelist_data_source.go
@@ -267,7 +267,10 @@ func (r *GatewayControlPlaneListDataSource) Read(ctx context.Context, req dataso
 		res, err = res.Next()
 
 		if err != nil {
-			resp.Diagnostics.AddError(fmt.Sprintf("failed to retrieve next page of results: %v", err), debugResponse(res.RawResponse))
+			resp.Diagnostics.AddError("failed to retrieve next page of results", err.Error())
+			if res != nil && res.RawResponse != nil {
+				resp.Diagnostics.AddError("unexpected http request/response", debugResponse(res.RawResponse))
+			}
 			return
 		}
 

--- a/internal/provider/meshcontrolplanes_data_source.go
+++ b/internal/provider/meshcontrolplanes_data_source.go
@@ -178,7 +178,10 @@ func (r *MeshControlPlanesDataSource) Read(ctx context.Context, req datasource.R
 		res, err = res.Next()
 
 		if err != nil {
-			resp.Diagnostics.AddError(fmt.Sprintf("failed to retrieve next page of results: %v", err), debugResponse(res.RawResponse))
+			resp.Diagnostics.AddError("failed to retrieve next page of results", err.Error())
+			if res != nil && res.RawResponse != nil {
+				resp.Diagnostics.AddError("unexpected http request/response", debugResponse(res.RawResponse))
+			}
 			return
 		}
 

--- a/internal/provider/portalclassiclist_data_source.go
+++ b/internal/provider/portalclassiclist_data_source.go
@@ -221,7 +221,10 @@ func (r *PortalClassicListDataSource) Read(ctx context.Context, req datasource.R
 		res, err = res.Next()
 
 		if err != nil {
-			resp.Diagnostics.AddError(fmt.Sprintf("failed to retrieve next page of results: %v", err), debugResponse(res.RawResponse))
+			resp.Diagnostics.AddError("failed to retrieve next page of results", err.Error())
+			if res != nil && res.RawResponse != nil {
+				resp.Diagnostics.AddError("unexpected http request/response", debugResponse(res.RawResponse))
+			}
 			return
 		}
 

--- a/internal/provider/systemaccountlist_data_source.go
+++ b/internal/provider/systemaccountlist_data_source.go
@@ -193,7 +193,10 @@ func (r *SystemAccountListDataSource) Read(ctx context.Context, req datasource.R
 		res, err = res.Next()
 
 		if err != nil {
-			resp.Diagnostics.AddError(fmt.Sprintf("failed to retrieve next page of results: %v", err), debugResponse(res.RawResponse))
+			resp.Diagnostics.AddError("failed to retrieve next page of results", err.Error())
+			if res != nil && res.RawResponse != nil {
+				resp.Diagnostics.AddError("unexpected http request/response", debugResponse(res.RawResponse))
+			}
 			return
 		}
 

--- a/internal/provider/teamlist_data_source.go
+++ b/internal/provider/teamlist_data_source.go
@@ -182,7 +182,10 @@ func (r *TeamListDataSource) Read(ctx context.Context, req datasource.ReadReques
 		res, err = res.Next()
 
 		if err != nil {
-			resp.Diagnostics.AddError(fmt.Sprintf("failed to retrieve next page of results: %v", err), debugResponse(res.RawResponse))
+			resp.Diagnostics.AddError("failed to retrieve next page of results", err.Error())
+			if res != nil && res.RawResponse != nil {
+				resp.Diagnostics.AddError("unexpected http request/response", debugResponse(res.RawResponse))
+			}
 			return
 		}
 

--- a/internal/sdk/internal/utils/json.go
+++ b/internal/sdk/internal/utils/json.go
@@ -512,6 +512,13 @@ func unmarshalValue(value json.RawMessage, v reflect.Value, tag reflect.StructTa
 			return nil
 		}
 	case reflect.Map:
+		if implementsJSONUnmarshaler(v.Type()) {
+			if v.CanAddr() {
+				return json.Unmarshal(value, v.Addr().Interface())
+			}
+			return json.Unmarshal(value, v.Interface())
+		}
+
 		if bytes.Equal(value, []byte("null")) || !isComplexValueType(dereferenceTypePointer(typ.Elem())) {
 			if v.CanAddr() {
 				return json.Unmarshal(value, v.Addr().Interface())

--- a/internal/sdk/konnect.go
+++ b/internal/sdk/konnect.go
@@ -2,7 +2,7 @@
 
 package sdk
 
-// Generated from OpenAPI doc version 2.0.0 and generator version 2.884.4
+// Generated from OpenAPI doc version 2.0.0 and generator version 2.897.1
 
 import (
 	"bytes"
@@ -408,7 +408,7 @@ func New(opts ...SDKOption) *Konnect {
 	sdk := &Konnect{
 		SDKVersion: "3.18.0",
 		sdkConfiguration: config.SDKConfiguration{
-			UserAgent:  "speakeasy-sdk/terraform 3.18.0 2.884.4 2.0.0 github.com/kong/terraform-provider-konnect/v3/internal/sdk",
+			UserAgent:  "speakeasy-sdk/terraform 3.18.0 2.897.1 2.0.0 github.com/kong/terraform-provider-konnect/v3/internal/sdk",
 			ServerList: ServerList,
 		},
 		hooks: hooks.New(),


### PR DESCRIPTION
### Summary
Bumping speakeasy version to v1.773.1
  
### Issues resolved
-

### Related PRs on platform-api (if any)
-

### Checklist ✅ 
- [x] Clean commit history (reset to the current release (`release/x.y.z`) and `git cherry-pick` if necessary)
- [ ] Added/updated examples (if applicable)  
- [ ] Added acceptance tests (if applicable)  
- [ ] Updated `CHANGELOG.md`  
