### PR TITLE
fix: improve partial hook to skip reading body if request does not match plugin endpoint

### DIFF
--- a/internal/sdk/internal/hooks/plugin_with_partial_hook.go
+++ b/internal/sdk/internal/hooks/plugin_with_partial_hook.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io"
 	"net/http"
+	"regexp"
 	"strings"
 )
 
@@ -14,14 +15,27 @@ import (
 // those fields are not overwritten — they are owned by the referenced partial.
 type PluginWithPartialHook struct{}
 
+var konnectMatchPlugin = func(req *http.Request) bool {
+	if req == nil || req.URL == nil {
+		return false
+	}
+
+	match, err := regexp.MatchString(`^/v2/control-planes/[^/]+/core-entities/plugins`, req.URL.Path)
+	if err != nil {
+		return false
+	}
+
+	return match && (req.Method == http.MethodPost || req.Method == http.MethodPut)
+}
+
 // BeforeRequest removes any fields from the request body that are covered by
 // a partial's path.
 func (h PluginWithPartialHook) BeforeRequest(hookCtx BeforeRequestContext, req *http.Request) (*http.Request, error) {
-	if req.Body == nil {
+	if !konnectMatchPlugin(req) {
 		return req, nil
 	}
 
-	if req.Method != http.MethodPost && req.Method != http.MethodPut {
+	if req.Body == nil {
 		return req, nil
 	}
 

--- a/internal/sdk/internal/hooks/plugin_with_partial_hook_test.go
+++ b/internal/sdk/internal/hooks/plugin_with_partial_hook_test.go
@@ -143,6 +143,19 @@ func TestPluginWithPartialHook_BeforeRequest(t *testing.T) {
 		assert.Equal(t, "", readBody(t, result))
 	})
 
+	t.Run("skips body read for POST to non-matching path", func(t *testing.T) {
+		body := `{"config":{"redis":{"host":"localhost"}},"partials":[{"id":"x","path":"config.redis"}]}`
+		req := &http.Request{
+			Method: http.MethodPost,
+			URL:    &url.URL{Path: "/v1/control-planes/cp-1/core-entities/plugins"},
+			Body:   io.NopCloser(bytes.NewBufferString(body)),
+		}
+		result, err := hook.BeforeRequest(ctx, req)
+		require.NoError(t, err)
+		// Body must be untouched — config.redis should still be present.
+		assert.JSONEq(t, body, readBody(t, result))
+	})
+
 	t.Run("content length is updated after body modification", func(t *testing.T) {
 		req := makeReq(http.MethodPost, `{
 			"config": {"redis": {"host": "localhost"}, "limit": [10]},


### PR DESCRIPTION
fix: improve partial hook to skip reading body if request does not match plugin endpoint

### Summary
  
### Issues resolved
-

### Related PRs on platform-api (if any)
-

### Checklist ✅ 
- [x] Clean commit history (reset to the current release (`release/x.y.z`) and `git cherry-pick` if necessary)
- [ ] Added/updated examples (if applicable)  
- [ ] Added acceptance tests (if applicable)  
- [ ] Updated `CHANGELOG.md`  
