### PR TITLE
Fix/otel plugin drift

### DIFF
--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,16 +1,16 @@
 lockVersion: 2.0.0
 id: 9d20c53e-7836-4ea8-88b8-a75fb7dce3a2
 management:
-  docChecksum: 8e37a3d007773f93ab31b076d6472ac6
+  docChecksum: 33f6acaca94ce77cbf44abd80775388f
   docVersion: 2.0.0
   speakeasyVersion: 1.773.1
   generationVersion: 2.897.1
   releaseVersion: 3.18.1
   configChecksum: 7a82bd8e5bc99fa8bc9beaf575d80c0d
 persistentEdits:
-  generation_id: 18a67133-87e6-4433-8590-27f8dc63dbce
-  pristine_commit_hash: 2b2b9788c84f240b690e15f81ab5a86b10a793d9
-  pristine_tree_hash: 7cea8dc65c3e81a68a1bcffbda11d6b60ec2859d
+  generation_id: e45ea23a-8d94-4949-b82c-c58768052e9f
+  pristine_commit_hash: e780b067ee89eaeb0760b070fc963ff49c6c7fea
+  pristine_tree_hash: 3ef6ab75691cdcec0a9d79fbcc9ebc582129ffff
 features:
   terraform:
     additionalDependencies: 0.1.0
@@ -3857,8 +3857,8 @@ trackedFiles:
     pristine_git_object: dfc7bb40f9bb5a27da2991a8b7158f120cab28c8
   internal/provider/gatewaypluginopentelemetry_resource.go:
     id: e7b731a65f7f
-    last_write_checksum: sha1:731507e2d47e5d86c80449d58df675c6abb1fb5f
-    pristine_git_object: 84d0ca48e2a358d82d8e449a2ea0807210d19807
+    last_write_checksum: sha1:0726b87b75eab6d708ecaf4e00e40c8241652582
+    pristine_git_object: a155c335e25a6aaa04dc82a6e069f1db1d184dd8
   internal/provider/gatewaypluginopentelemetry_resource_sdk.go:
     id: 0f863580197c
     last_write_checksum: sha1:150f2a1070324caf0c01142ccde0a91719d65ab2
@@ -11797,8 +11797,8 @@ trackedFiles:
     pristine_git_object: fece7e9163230c4e07c09e08f04d672d51f7126c
   internal/sdk/models/shared/opentelemetryplugin.go:
     id: 6e2a002108e9
-    last_write_checksum: sha1:b8a540b9be455805623778764e40c42f26679692
-    pristine_git_object: 0ee0737b805180c0cdeb4d186c68bdb2e74f650b
+    last_write_checksum: sha1:a0a59d18480b93ab541054b4679fbd71ab386b47
+    pristine_git_object: bc22879c8e57e0e823206d427569c91acdec50cd
   internal/sdk/models/shared/pagemeta.go:
     id: 27a382a7831b
     last_write_checksum: sha1:5f0bca68ca3c65f3492c2feb508ec6c93834b078

--- a/.speakeasy/gen.lock
+++ b/.speakeasy/gen.lock
@@ -1,16 +1,16 @@
 lockVersion: 2.0.0
 id: 9d20c53e-7836-4ea8-88b8-a75fb7dce3a2
 management:
-  docChecksum: 97c8b54f7df6cd060f78933ea5068641
+  docChecksum: 8e37a3d007773f93ab31b076d6472ac6
   docVersion: 2.0.0
   speakeasyVersion: 1.773.1
   generationVersion: 2.897.1
   releaseVersion: 3.18.1
   configChecksum: 7a82bd8e5bc99fa8bc9beaf575d80c0d
 persistentEdits:
-  generation_id: 961d8106-ed44-43d0-85e0-12e956e2f1fe
-  pristine_commit_hash: df5ddaffcb5537e9bad73face06af51a92f2a23c
-  pristine_tree_hash: b92f46095e4ee8d3b671f8d435b783be00b061ce
+  generation_id: 18a67133-87e6-4433-8590-27f8dc63dbce
+  pristine_commit_hash: 2b2b9788c84f240b690e15f81ab5a86b10a793d9
+  pristine_tree_hash: 7cea8dc65c3e81a68a1bcffbda11d6b60ec2859d
 features:
   terraform:
     additionalDependencies: 0.1.0
@@ -3857,8 +3857,8 @@ trackedFiles:
     pristine_git_object: dfc7bb40f9bb5a27da2991a8b7158f120cab28c8
   internal/provider/gatewaypluginopentelemetry_resource.go:
     id: e7b731a65f7f
-    last_write_checksum: sha1:426dc33e515cd33e7be8d6914e64cccf577ea2ee
-    pristine_git_object: 4bfcc75b11b0fc0a147c08de861a2871985c239b
+    last_write_checksum: sha1:731507e2d47e5d86c80449d58df675c6abb1fb5f
+    pristine_git_object: 84d0ca48e2a358d82d8e449a2ea0807210d19807
   internal/provider/gatewaypluginopentelemetry_resource_sdk.go:
     id: 0f863580197c
     last_write_checksum: sha1:150f2a1070324caf0c01142ccde0a91719d65ab2
@@ -11797,8 +11797,8 @@ trackedFiles:
     pristine_git_object: fece7e9163230c4e07c09e08f04d672d51f7126c
   internal/sdk/models/shared/opentelemetryplugin.go:
     id: 6e2a002108e9
-    last_write_checksum: sha1:a703114ae91ac3a4a3165be007ab2ac3a1390a9a
-    pristine_git_object: ad65251675a9115f8d47a3cba24dd552f54008d7
+    last_write_checksum: sha1:b8a540b9be455805623778764e40c42f26679692
+    pristine_git_object: 0ee0737b805180c0cdeb4d186c68bdb2e74f650b
   internal/sdk/models/shared/pagemeta.go:
     id: 27a382a7831b
     last_write_checksum: sha1:5f0bca68ca3c65f3492c2feb508ec6c93834b078

--- a/docs/resources/gateway_plugin_opentelemetry.md
+++ b/docs/resources/gateway_plugin_opentelemetry.md
@@ -146,7 +146,7 @@ resource "konnect_gateway_plugin_opentelemetry" "my_gatewaypluginopentelemetry" 
 Optional:
 
 - `access_logs` (Attributes) (see [below for nested schema](#nestedatt--config--access_logs))
-- `access_logs_endpoint` (String, Deprecated) Deprecated: Use `access_logs.endpoint` instead. An HTTP URL endpoint where access logs (e.g. request/response, route/service, latency, etc.) are exported.
+- `access_logs_endpoint` (String, Deprecated) An HTTP URL endpoint where access logs (e.g. request/response, route/service, latency, etc.) are exported.
 - `batch_flush_delay` (Number) The delay, in seconds, between two consecutive batches.
 - `batch_span_count` (Number) The number of spans to be sent in a single batch.
 - `connect_timeout` (Number) An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2. Default: 1000

--- a/docs/resources/gateway_plugin_opentelemetry.md
+++ b/docs/resources/gateway_plugin_opentelemetry.md
@@ -146,7 +146,7 @@ resource "konnect_gateway_plugin_opentelemetry" "my_gatewaypluginopentelemetry" 
 Optional:
 
 - `access_logs` (Attributes) (see [below for nested schema](#nestedatt--config--access_logs))
-- `access_logs_endpoint` (String) An HTTP URL endpoint where access logs (e.g. request/response, route/service, latency, etc.) are exported.
+- `access_logs_endpoint` (String, Deprecated) Deprecated: Use `access_logs.endpoint` instead. An HTTP URL endpoint where access logs (e.g. request/response, route/service, latency, etc.) are exported.
 - `batch_flush_delay` (Number) The delay, in seconds, between two consecutive batches.
 - `batch_span_count` (Number) The number of spans to be sent in a single batch.
 - `connect_timeout` (Number) An integer representing a timeout in milliseconds. Must be between 0 and 2^31-2. Default: 1000

--- a/internal/provider/gatewaypluginopentelemetry_resource.go
+++ b/internal/provider/gatewaypluginopentelemetry_resource.go
@@ -25,6 +25,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
+	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect/v3/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect/v3/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect/v3/internal/sdk"
 	speakeasy_objectvalidators "github.com/kong/terraform-provider-konnect/v3/internal/validators/objectvalidators"
@@ -99,8 +100,13 @@ func (r *GatewayPluginOpentelemetryResource) Schema(ctx context.Context, req res
 						},
 					},
 					"access_logs_endpoint": schema.StringAttribute{
-						Optional:    true,
-						Description: `An HTTP URL endpoint where access logs (e.g. request/response, route/service, latency, etc.) are exported.`,
+						Computed: true,
+						Optional: true,
+						PlanModifiers: []planmodifier.String{
+							speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
+						},
+						DeprecationMessage: `This will be removed in a future release, please migrate away from it as soon as possible`,
+						Description:        `Deprecated: Use ` + "`" + `access_logs.endpoint` + "`" + ` instead. An HTTP URL endpoint where access logs (e.g. request/response, route/service, latency, etc.) are exported.`,
 					},
 					"batch_flush_delay": schema.Int64Attribute{
 						Optional:    true,

--- a/internal/provider/gatewaypluginopentelemetry_resource.go
+++ b/internal/provider/gatewaypluginopentelemetry_resource.go
@@ -25,7 +25,6 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/hashicorp/terraform-plugin-framework/types/basetypes"
-	speakeasy_stringplanmodifier "github.com/kong/terraform-provider-konnect/v3/internal/planmodifiers/stringplanmodifier"
 	tfTypes "github.com/kong/terraform-provider-konnect/v3/internal/provider/types"
 	"github.com/kong/terraform-provider-konnect/v3/internal/sdk"
 	speakeasy_objectvalidators "github.com/kong/terraform-provider-konnect/v3/internal/validators/objectvalidators"
@@ -100,13 +99,10 @@ func (r *GatewayPluginOpentelemetryResource) Schema(ctx context.Context, req res
 						},
 					},
 					"access_logs_endpoint": schema.StringAttribute{
-						Computed: true,
-						Optional: true,
-						PlanModifiers: []planmodifier.String{
-							speakeasy_stringplanmodifier.SuppressDiff(speakeasy_stringplanmodifier.ExplicitSuppress),
-						},
+						Computed:           true,
+						Optional:           true,
 						DeprecationMessage: `This will be removed in a future release, please migrate away from it as soon as possible`,
-						Description:        `Deprecated: Use ` + "`" + `access_logs.endpoint` + "`" + ` instead. An HTTP URL endpoint where access logs (e.g. request/response, route/service, latency, etc.) are exported.`,
+						Description:        `An HTTP URL endpoint where access logs (e.g. request/response, route/service, latency, etc.) are exported.`,
 					},
 					"batch_flush_delay": schema.Int64Attribute{
 						Optional:    true,

--- a/internal/sdk/models/shared/opentelemetryplugin.go
+++ b/internal/sdk/models/shared/opentelemetryplugin.go
@@ -567,7 +567,7 @@ type OpentelemetryPluginConfig struct {
 	SendTimeout *int64 `default:"5000" json:"send_timeout"`
 	// A string representing a URL, such as https://example.com/path/to/resource?q=search.
 	TracesEndpoint *string `default:"null" json:"traces_endpoint"`
-	// Deprecated: Use `access_logs.endpoint` instead. An HTTP URL endpoint where access logs (e.g. request/response, route/service, latency, etc.) are exported.
+	// An HTTP URL endpoint where access logs (e.g. request/response, route/service, latency, etc.) are exported.
 	//
 	// Deprecated: This will be removed in a future release, please migrate away from it as soon as possible.
 	AccessLogsEndpoint *string `json:"access_logs_endpoint,omitempty"`

--- a/internal/sdk/models/shared/opentelemetryplugin.go
+++ b/internal/sdk/models/shared/opentelemetryplugin.go
@@ -567,8 +567,10 @@ type OpentelemetryPluginConfig struct {
 	SendTimeout *int64 `default:"5000" json:"send_timeout"`
 	// A string representing a URL, such as https://example.com/path/to/resource?q=search.
 	TracesEndpoint *string `default:"null" json:"traces_endpoint"`
-	// An HTTP URL endpoint where access logs (e.g. request/response, route/service, latency, etc.) are exported.
-	AccessLogsEndpoint *string `default:"null" json:"access_logs_endpoint"`
+	// Deprecated: Use `access_logs.endpoint` instead. An HTTP URL endpoint where access logs (e.g. request/response, route/service, latency, etc.) are exported.
+	//
+	// Deprecated: This will be removed in a future release, please migrate away from it as soon as possible.
+	AccessLogsEndpoint *string `json:"access_logs_endpoint,omitempty"`
 }
 
 func (o OpentelemetryPluginConfig) MarshalJSON() ([]byte, error) {

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -29702,6 +29702,7 @@ components:
 
             **Requires a minimum runtime version of `1.2`**.
           type: array
+          nullable: true
           x-min-runtime-version: '1.2'
           x-speakeasy-param-computed: false
           x-speakeasy-terraform-ignore: true
@@ -58453,10 +58454,8 @@ components:
             access_logs_endpoint:
               description: 'An HTTP URL endpoint where access logs (e.g. request/response, route/service, latency, etc.) are exported.'
               type: string
-              default: null
-              nullable: true
               x-referenceable: true
-              x-speakeasy-param-computed: false
+              x-speakeasy-param-computed: true
           x-speakeasy-param-computed: true
         consumer:
           description: 'If set, the plugin will activate only for requests where the specified has been authenticated. (Note that some plugins can not be restricted to consumers this way.). Leave unset for the plugin to activate regardless of the authenticated Consumer.'
@@ -72092,6 +72091,7 @@ components:
 
                   **Requires a minimum runtime version of `1.2`**.
                 type: array
+                nullable: true
                 x-min-runtime-version: '1.2'
                 x-speakeasy-param-computed: false
                 x-speakeasy-terraform-ignore: true
@@ -72137,6 +72137,7 @@ components:
 
                   **Requires a minimum runtime version of `1.2`**.
                 type: array
+                nullable: true
                 x-min-runtime-version: '1.2'
                 x-speakeasy-param-computed: false
                 x-speakeasy-terraform-ignore: true

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -58454,6 +58454,7 @@ components:
             access_logs_endpoint:
               description: 'An HTTP URL endpoint where access logs (e.g. request/response, route/service, latency, etc.) are exported.'
               type: string
+              deprecated: true
               x-referenceable: true
               x-speakeasy-param-computed: true
           x-speakeasy-param-computed: true

--- a/tests/resources/gateway_plugin_opentelemetry_test.go
+++ b/tests/resources/gateway_plugin_opentelemetry_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/hashicorp/terraform-plugin-testing/config"
 	"github.com/hashicorp/terraform-plugin-testing/helper/resource"
+	"github.com/hashicorp/terraform-plugin-testing/plancheck"
 )
 
 func TestGatewayPluginOpenTelemetry(t *testing.T) {
@@ -28,6 +29,31 @@ func TestGatewayPluginOpenTelemetry(t *testing.T) {
 					Check: resource.ComposeTestCheckFunc(
 						resource.TestCheckNoResourceAttr("konnect_gateway_plugin_opentelemetry.my_opentelemetry", "config.logs_endpoint"),
 					),
+				},
+			},
+		})
+	})
+
+	t.Run("access-logs-endpoint-no-drift", func(t *testing.T) {
+		resource.Test(t, resource.TestCase{
+			ProtoV6ProviderFactories: providerFactory,
+			Steps: []resource.TestStep{
+				{
+					Config:          providerConfigUs,
+					ConfigDirectory: config.TestNameDirectory(),
+					Check: resource.ComposeAggregateTestCheckFunc(
+						resource.TestCheckResourceAttr("konnect_gateway_plugin_opentelemetry.my_opentelemetry", "enabled", "true"),
+						resource.TestCheckResourceAttrSet("konnect_gateway_plugin_opentelemetry.my_opentelemetry", "config.access_logs.endpoint"),
+					),
+				},
+				{
+					Config:          providerConfigUs,
+					ConfigDirectory: config.TestNameDirectory(),
+					ConfigPlanChecks: resource.ConfigPlanChecks{
+						PreApply: []plancheck.PlanCheck{
+							plancheck.ExpectEmptyPlan(),
+						},
+					},
 				},
 			},
 		})

--- a/tests/resources/testdata/TestCentralizedConsumers/plan-diff/main.tf
+++ b/tests/resources/testdata/TestCentralizedConsumers/plan-diff/main.tf
@@ -5,7 +5,7 @@ resource "konnect_gateway_control_plane" "tfdemo" {
 }
 
 resource "konnect_realm" "my_realm" {
-  name                     = "tf-test-centralized-consumers"
+  name                     = "Production"
   ttl                      = 60
   negative_ttl             = 10
   allow_all_control_planes = false

--- a/tests/resources/testdata/TestCentralizedConsumers/plan-diff/main.tf
+++ b/tests/resources/testdata/TestCentralizedConsumers/plan-diff/main.tf
@@ -5,7 +5,7 @@ resource "konnect_gateway_control_plane" "tfdemo" {
 }
 
 resource "konnect_realm" "my_realm" {
-  name                     = "Production"
+  name                     = "tf-test-centralized-consumers"
   ttl                      = 60
   negative_ttl             = 10
   allow_all_control_planes = false

--- a/tests/resources/testdata/TestGatewayPluginOpenTelemetry/access-logs-endpoint-no-drift/main.tf
+++ b/tests/resources/testdata/TestGatewayPluginOpenTelemetry/access-logs-endpoint-no-drift/main.tf
@@ -1,0 +1,21 @@
+resource "konnect_gateway_control_plane" "pluginopentelemetrycp" {
+  name         = "Terraform Control Plane For OpenTelemetry Plugin Access Logs"
+  description  = "Test control plane for access_logs_endpoint drift fix"
+  cluster_type = "CLUSTER_TYPE_CONTROL_PLANE"
+}
+
+resource "konnect_gateway_plugin_opentelemetry" "my_opentelemetry" {
+  enabled = true
+  config = {
+    traces_endpoint = "http://localhost:4318/v1/traces"
+
+    # Using access_logs.endpoint (not access_logs_endpoint)
+    # The API will auto-populate access_logs_endpoint from this value
+    # This test verifies there's no drift on subsequent plans
+    access_logs = {
+      endpoint = "http://localhost:4318/v1/logs"
+    }
+  }
+  control_plane_id = konnect_gateway_control_plane.pluginopentelemetrycp.id
+}
+


### PR DESCRIPTION
### Summary
`konnect_gateway_plugin_opentelemetry` has drift with `access_logs_endpoint`. Everytime API was trying to compute it so we added an annotation to mark this as computed true.

`TestCentralizedConsumers` was failing in CI because consumer `alice` hit the 10,000 key limit. Fixed by renaming the realm to use fresh resources.

### Issues resolved
- https://github.com/Kong/terraform-provider-konnect/issues/417

### Related PRs on platform-api (if any)
- https://github.com/Kong/platform-api/pull/2839

### Checklist ✅ 
- [ ] Clean commit history (reset to the current release (`release/x.y.z`) and `git cherry-pick` if necessary)
- [ ] Added/updated examples (if applicable)  
- [ ] Added acceptance tests (if applicable)  
- [ ] Updated `CHANGELOG.md`  
