### PR TITLE
tests: updated images for portal-favicon and portal-logo tests.

### DIFF
--- a/examples/scenarios/portal_v3.tf
+++ b/examples/scenarios/portal_v3.tf
@@ -23,12 +23,12 @@ resource "konnect_portal_page" "my_portalpage" {
 }
 
 resource "konnect_portal_logo" "my_portal_logo" {
-  data      = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg=="
+  data      = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAIAAAD8GO2jAAAAMUlEQVR4nOzNMREAIAwEQYbB7fuviYl8tyfg9v3kNLvVOwAAAAAAAAAAAFhsAgAA///pYwIYmsB+qQAAAABJRU5ErkJggg=="
   portal_id = konnect_portal.my_portal.id
 }
 
 resource "konnect_portal_favicon" "my_portal_favicon" {
-  data      = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg=="
+  data      = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAIAAAD8GO2jAAAAMUlEQVR4nOzNMREAIAwEQYbB7fuviYl8tyfg9v3kNLvVOwAAAAAAAAAAAFhsAgAA///pYwIYmsB+qQAAAABJRU5ErkJggg=="
   portal_id = konnect_portal.my_portal.id
 }
 

--- a/tests/resources/portal_favicon_test.go
+++ b/tests/resources/portal_favicon_test.go
@@ -17,7 +17,7 @@ func TestPortalFavicon(t *testing.T) {
 					Config:          providerConfigUs,
 					ConfigDirectory: config.TestNameDirectory(),
 					Check: resource.ComposeAggregateTestCheckFunc(
-						resource.TestCheckResourceAttr("konnect_portal_favicon.my_portal_favicon", "data", "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg=="),
+						resource.TestCheckResourceAttr("konnect_portal_favicon.my_portal_favicon", "data", "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAEElEQVR4nGL6n50NCAAA//8ESgHYqxSkJQAAAABJRU5ErkJggg=="),
 					),
 				},
 				{

--- a/tests/resources/portal_logo_test.go
+++ b/tests/resources/portal_logo_test.go
@@ -17,7 +17,7 @@ func TestPortalLogo(t *testing.T) {
 					Config:          providerConfigUs,
 					ConfigDirectory: config.TestNameDirectory(),
 					Check: resource.ComposeAggregateTestCheckFunc(
-						resource.TestCheckResourceAttr("konnect_portal_logo.my_portal_logo", "data", "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg=="),
+						resource.TestCheckResourceAttr("konnect_portal_logo.my_portal_logo", "data", "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAEElEQVR4nGL6n50NCAAA//8ESgHYqxSkJQAAAABJRU5ErkJggg=="),
 					),
 				},
 				{

--- a/tests/resources/testdata/TestPortalFavicon/plan-diff/main.tf
+++ b/tests/resources/testdata/TestPortalFavicon/plan-diff/main.tf
@@ -4,6 +4,6 @@ resource "konnect_portal" "my_portal_for_favicon" {
 }
 
 resource "konnect_portal_favicon" "my_portal_favicon" {
-  data      = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg=="
+  data      = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAEElEQVR4nGL6n50NCAAA//8ESgHYqxSkJQAAAABJRU5ErkJggg=="
   portal_id = konnect_portal.my_portal_for_favicon.id
 }

--- a/tests/resources/testdata/TestPortalLogo/plan-diff/main.tf
+++ b/tests/resources/testdata/TestPortalLogo/plan-diff/main.tf
@@ -4,6 +4,6 @@ resource "konnect_portal" "my_portal_for_logo" {
 }
 
 resource "konnect_portal_logo" "my_portal_logo" {
-  data      = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR4nGMAAQAABQABDQottAAAAABJRU5ErkJggg=="
+  data      = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAEElEQVR4nGL6n50NCAAA//8ESgHYqxSkJQAAAABJRU5ErkJggg=="
   portal_id = konnect_portal.my_portal_for_logo.id
 }


### PR DESCRIPTION
### Summary
We have noticed that test for `konnect_portal_favicon` and `konnect_portal_logo` resource were failing with `image_not_lodable` error. We have updated the correct image.
  
### Issues resolved
-  https://github.com/Kong/terraform-provider-konnect/actions/runs/32059220432/job/95988987711

### Related PRs on platform-api (if any)
-

### Checklist ✅ 
- [x] Clean commit history (reset to the current release (`release/x.y.z`) and `git cherry-pick` if necessary)
- [x] Added/updated examples (if applicable)  
- [ ] Added acceptance tests (if applicable)  
- [ ] Updated `CHANGELOG.md`  
