### PR TITLE
chore: set up renovate and update terraform version in CI

### DIFF
--- a/.github/workflows/provider-tests.yaml
+++ b/.github/workflows/provider-tests.yaml
@@ -19,7 +19,7 @@ jobs:
         # Only test against one version for now as these tests are not
         # namespaced and will conflict
         terraform-version:
-          - "1.13.*"
+          - "1.16.*"
     steps:
       - name: Harden Runner
         uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "enabled": true,
+  "extends": [
+    "Kong/public-shared-renovate"
+  ],
+  "packageRules": [
+    {
+      "description": "Keep all dependencies disabled except Terraform",
+      "enabled": false,
+      "matchPackageNames": ["*"]
+    },
+    {
+      "description": "Enable only Terraform version updates in CI",
+      "enabled": true,
+      "matchDatasources": ["terraform-version"],
+      "ignoreUnstable": true,
+      "extends": ["schedule:monthly"]
+    }
+  ]
+}


### PR DESCRIPTION
### Summary
We usually forget to update the terraform version in our CI - so setting up renovate to send a PR to update it monthly.

Weekly is overkill - terraform usually does not get released that often.
  
### Issues resolved
-

### Related PRs on platform-api (if any)
-

### Checklist ✅ 
- [ ] Clean commit history (reset to the current release (`release/x.y.z`) and `git cherry-pick` if necessary)
- [ ] Added/updated examples (if applicable)  
- [ ] Added acceptance tests (if applicable)  
- [ ] Updated `CHANGELOG.md`  
